### PR TITLE
feat(code_execution): make MCP and host tools callable from python

### DIFF
--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -21,7 +21,7 @@ use maki_agent::headless::{self, InteractiveHandle, InteractiveParams};
 use maki_agent::mcp::config::{RawHttpFields, RawStdioFields, RawTransport};
 use maki_agent::mcp::{self, McpHandle};
 use maki_agent::permissions::PermissionAnswer;
-use maki_agent::tools::{LocalToolFn, LocalTools, QUESTION_TOOL_NAME, local_tool};
+use maki_agent::tools::{LocalTool, LocalTools, QUESTION_TOOL_NAME, ToolAudience, local_tool};
 use maki_agent::types::AgentEvent;
 use maki_agent::{AgentInput, AgentMode, Envelope, ImageMediaType, ImageSource};
 use maki_config::{MAX_SERVER_NAME_LEN, ModelPolicy};
@@ -383,8 +383,10 @@ fn ask_client(
 /// Shadows the Lua `question` tool: sends `elicitation/create` to the client
 /// and blocks the tool call until the form comes back. Serializes on the same
 /// answer channel as permissions, so at most one ask is in flight.
-fn question_tool(out_tx: Sender<Value>, pending: PendingState) -> LocalToolFn {
-    local_tool(move |input, ctx| {
+fn question_tool(out_tx: Sender<Value>, pending: PendingState) -> LocalTool {
+    // The audience the Lua `question` tool carries: shadowing a tool must not
+    // widen who may call it.
+    local_tool(ToolAudience::MAIN, move |input, ctx| {
         let out_tx = out_tx.clone();
         let pending = Arc::clone(&pending);
         Box::pin(async move {

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -474,7 +474,6 @@ impl<'h> Agent<'h> {
         tool_dispatch::process_tool_calls(
             response,
             &mut self.recent_calls,
-            self.mcp.as_ref(),
             self.history,
             &self.event_tx,
             &ctx,
@@ -972,7 +971,7 @@ mod tests {
             let captured = Arc::clone(&provider.captured_tools);
             let mut history = History::new(Vec::new());
             let (agent, _event_rx) = make_agent(provider, &mut history);
-            let mut agent = agent.with_mcp(Some(crate::mcp::stub_session(&[(
+            let mut agent = agent.with_mcp(Some(crate::mcp::test_support::stub_session(&[(
                 "srv.fetch_issue",
                 "Fetch a GitHub issue",
             )])));

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
-use std::collections::VecDeque;
 use std::collections::hash_map::DefaultHasher;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -10,16 +10,12 @@ use tracing::{debug, error, warn};
 
 use crate::mcp::{McpSession, TOOL_SEARCH_TOOL_NAME, UNKNOWN_MCP};
 use crate::task_set::TaskSet;
-use crate::tools::registry::{ToolInvocation, ToolRegistry};
-use crate::tools::{LocalToolFn, ToolContext, truncate_bytes};
+use crate::tools::registry::{RegisteredTool, ToolInvocation};
+use crate::tools::{
+    CallOrigin, LocalTool, LocalToolFn, ToolAudience, ToolContext, ToolFilter, truncate_bytes,
+};
 use crate::{AgentError, AgentEvent, ToolDoneEvent, ToolOutput, ToolStartEvent};
 use maki_config::ToolKey;
-
-#[derive(Clone, Copy)]
-pub enum Emit {
-    Notify,
-    Silent,
-}
 
 const DOOM_LOOP_THRESHOLD: usize = 3;
 const DOOM_LOOP_MESSAGE: &str = "You have called this tool with identical input 3 times in a row. You are stuck in a loop. Break out and try a different approach.";
@@ -29,9 +25,8 @@ const MCP_PERM_SCOPE_MAX_BYTES: usize = 200;
 
 const SOURCE_NATIVE: &str = "native";
 const SOURCE_LOCAL: &str = "local";
+const SOURCE_MCP: &str = "mcp";
 const SOURCE_UNKNOWN: &str = "unknown";
-/// A name that still carries one means the MCP server behind it is gone.
-const MCP_NAME_SEPARATOR: &str = "__";
 const BASH_TOOL: &str = "bash";
 const BASH_COMMAND_FIELD: &str = "command";
 const GIT_COMMIT: &str = "git commit";
@@ -83,58 +78,237 @@ impl RecentCalls {
 /// Every tool call in maki lands here (native, Lua, MCP, subagents, batch
 /// children), which makes it the one place telemetry has to wrap.
 pub async fn run(
-    registry: &ToolRegistry,
-    mcp: Option<&McpSession>,
     id: String,
     name: &str,
     input: &Value,
     ctx: &ToolContext,
-    emit: Emit,
+    origin: CallOrigin,
 ) -> ToolDoneEvent {
+    let resolved = resolve(ctx, name);
     if !maki_otel::enabled() {
-        return run_inner(registry, mcp, id, name, input, ctx, emit).await;
+        return run_inner(resolved, id, input, ctx, origin).await;
     }
-    let canonical = super::streaming::canonical_tool_name(name);
-    let source = tool_source(registry, ctx, canonical);
+    let name = resolved.name;
+    let source = resolved.route.source();
     let started = Instant::now();
-    let done = run_inner(registry, mcp, id, name, input, ctx, emit).await;
-    report(&done, canonical, &source, input, started.elapsed());
+    let done = run_inner(resolved, id, input, ctx, origin).await;
+    report(&done, name, &source, input, started.elapsed());
     done
 }
 
-/// Parse errors and unknown tools skip the start event so the UI never
-/// shows a phantom spinner.
+/// Where a name goes for one context. Dispatch and telemetry read this one
+/// answer, so a name can never be reported as one thing and run as another.
+enum Route<'a> {
+    Local(&'a LocalTool),
+    Native(RegisteredTool),
+    ToolSearch(&'a McpSession),
+    Mcp(&'a McpSession, Arc<str>),
+    Unknown,
+}
+
+impl Route<'_> {
+    /// Registry tools report the plugin behind them, because "native" alone
+    /// tells whoever reads the metric nothing.
+    fn source(&self) -> Cow<'static, str> {
+        match self {
+            Self::Native(entry) => entry.source.as_log_field(),
+            Self::Local(_) => Cow::Borrowed(SOURCE_LOCAL),
+            Self::Mcp(..) => Cow::Borrowed(SOURCE_MCP),
+            Self::ToolSearch(_) => Cow::Borrowed(TOOL_SEARCH_TOOL_NAME),
+            Self::Unknown => Cow::Borrowed(SOURCE_UNKNOWN),
+        }
+    }
+}
+
+/// A canonical name paired with where it goes. Only [`resolve`] builds one, so
+/// no caller can act on a name it forgot to canonicalize.
+struct Resolved<'a> {
+    name: &'a str,
+    route: Route<'a>,
+}
+
+/// Precedence, highest first: client (ACP) tools, the registry, then MCP.
+/// The context is the only input, because resolving against one session and
+/// executing against another is how a tool escapes its audience.
+fn resolve<'a>(ctx: &'a ToolContext, name: &'a str) -> Resolved<'a> {
+    // Names coming back from model JSON (batch children, `call_tool`, the
+    // interpreter bridge) never passed through streaming.rs, so clean up here.
+    let name = super::streaming::canonical_tool_name(name);
+    let route = if let Some(local) = ctx.local_tools.get(name) {
+        Route::Local(local)
+    } else if let Some(entry) = ctx.registry.get(name) {
+        Route::Native(entry)
+    } else if let Some(mcp) = ctx.mcp.as_ref() {
+        match mcp.resolve(name) {
+            Some(qualified) => Route::Mcp(mcp, qualified),
+            None if name == TOOL_SEARCH_TOOL_NAME => Route::ToolSearch(mcp),
+            None => Route::Unknown,
+        }
+    } else {
+        Route::Unknown
+    };
+    Resolved { name, route }
+}
+
+/// One callable name, as [`resolve`] would route it.
+pub struct Callable {
+    /// The name to dispatch. Always what `resolve` was asked, never an alias.
+    pub name: String,
+    /// A name a host that binds tools as identifiers can use, set only when
+    /// `name` is not one already (MCP servers publish `srv__get-docs`). Call
+    /// `name`, bind `alias`.
+    pub alias: Option<String>,
+    pub source: &'static str,
+    /// The audience of whatever will run, not of whatever shares its name.
+    pub audience: ToolAudience,
+    /// Registry tools only. MCP and host tools publish their schema to the
+    /// model in the request's tool array, so repeating it here would buy an
+    /// allocation per call and nothing else.
+    pub schema: Option<Value>,
+}
+
+/// Every name this context can dispatch, deduplicated in [`resolve`]'s
+/// precedence, so an entry always describes the tool that a call to that name
+/// would actually reach. It lives beside `resolve` so the two cannot drift into
+/// answering differently.
+///
+/// Filtered like the request's tool array is: this context's audience, the
+/// config's `disabled_tools`, and the model's capabilities. What is left is the
+/// caller's own policy, read off `audience` (a sandbox wants `INTERPRETER`).
+///
+/// Recompute per call: MCP republishes its index whenever a server comes or goes.
+pub fn callable(ctx: &ToolContext) -> Vec<Callable> {
+    let filter = ToolFilter::from_config(&ctx.config, &ctx.model, &[]);
+    let mut out: Vec<Callable> = Vec::new();
+    let mut claimed: HashSet<String> = HashSet::new();
+    // A name belongs to the first source dispatch would reach, claimed before
+    // any filter runs: a registry tool this audience may not call still owns its
+    // name, or MCP would publish a way around it.
+    let mut claim = |name: &str, audience: ToolAudience| {
+        let first = claimed.insert(name.to_owned());
+        first && audience.contains(ctx.audience)
+    };
+    let entry_of = |name: &str, source, audience, schema| Callable {
+        name: name.to_owned(),
+        alias: None,
+        source,
+        audience,
+        schema,
+    };
+
+    let mut local: Vec<(&String, &LocalTool)> = ctx.local_tools.iter().collect();
+    local.sort_by(|a, b| a.0.cmp(b.0));
+    for (name, tool) in local {
+        if claim(name, tool.audience) {
+            out.push(entry_of(name, SOURCE_LOCAL, tool.audience, None));
+        }
+    }
+    for entry in ctx.registry.iter().iter() {
+        let audience = entry.tool.audience();
+        if !claim(entry.name(), audience) || !filter.matches(entry.name()) {
+            continue;
+        }
+        out.push(entry_of(
+            entry.name(),
+            SOURCE_NATIVE,
+            audience,
+            Some(entry.tool.schema()),
+        ));
+    }
+    if let Some(mcp) = ctx.mcp.as_ref() {
+        let mut names = mcp.wire_names();
+        names.push(TOOL_SEARCH_TOOL_NAME.to_owned());
+        names.sort();
+        for name in names {
+            // MCP has no audience system: a server is reachable or it is not,
+            // and a session holding one already offers its tools to the model.
+            if claim(&name, ToolAudience::all()) {
+                out.push(entry_of(&name, SOURCE_MCP, ToolAudience::all(), None));
+            }
+        }
+    }
+    assign_aliases(&mut out);
+    out
+}
+
+/// Fills in `alias` for names an identifier cannot hold. A collision (a server
+/// publishing both `get-docs` and `get_docs`) leaves both aliases unset rather
+/// than pointing one name at the other's tool.
+fn assign_aliases(tools: &mut [Callable]) {
+    let aliases: Vec<Option<String>> = tools.iter().map(|t| identifier_alias(&t.name)).collect();
+    let mut claims: HashMap<String, usize> = HashMap::new();
+    for claimant in tools
+        .iter()
+        .map(|t| t.name.clone())
+        .chain(aliases.iter().flatten().cloned())
+    {
+        *claims.entry(claimant).or_default() += 1;
+    }
+    // An alias always claims itself once, and never its own name, or
+    // `identifier_alias` would have declined it. A second claim is therefore
+    // another tool's name or alias, and then neither of them may have it.
+    for (tool, alias) in tools.iter_mut().zip(aliases) {
+        if alias.as_deref().is_some_and(|a| claims[a] == 1) {
+            tool.alias = alias;
+        }
+    }
+}
+
+fn identifier_alias(name: &str) -> Option<String> {
+    let is_body = |c: char| c.is_ascii_alphanumeric() || c == '_';
+    // A leading digit is not something substitution can fix without inventing a
+    // character the model never saw.
+    if name.is_empty() || name.starts_with(|c: char| c.is_ascii_digit()) {
+        return None;
+    }
+    name.chars().any(|c| !is_body(c)).then(|| {
+        name.chars()
+            .map(|c| if is_body(c) { c } else { '_' })
+            .collect()
+    })
+}
+
+/// Pure router: every arm owns its own start event, permission gate and
+/// telemetry, so adding a source never means editing another one's path.
 async fn run_inner(
-    registry: &ToolRegistry,
-    mcp: Option<&McpSession>,
+    resolved: Resolved<'_>,
+    id: String,
+    input: &Value,
+    ctx: &ToolContext,
+    origin: CallOrigin,
+) -> ToolDoneEvent {
+    let name = resolved.name;
+    match resolved.route {
+        Route::Local(local) => run_local_tool(&local.handler, id, name, input, ctx, origin).await,
+        Route::Native(entry) => run_native_tool(entry, id, name, input, ctx, origin).await,
+        Route::ToolSearch(mcp) => run_tool_search(mcp, id, input, ctx, origin),
+        Route::Mcp(mcp, qualified) => {
+            execute_mcp_tool(ctx, mcp, &id, qualified, input, origin).await
+        }
+        Route::Unknown => {
+            warn!(tool = %name, "unknown tool");
+            ToolDoneEvent {
+                id,
+                tool: Arc::from(UNKNOWN_MCP),
+                output: ToolOutput::Plain(format!("{UNKNOWN_TOOL_PREFIX}: {name}").into()),
+                is_error: true,
+                annotation: None,
+                written_path: None,
+            }
+        }
+    }
+}
+
+/// Parse errors skip the start event so the UI never shows a phantom spinner.
+async fn run_native_tool(
+    entry: RegisteredTool,
     id: String,
     name: &str,
     input: &Value,
     ctx: &ToolContext,
-    emit: Emit,
+    origin: CallOrigin,
 ) -> ToolDoneEvent {
-    // Covers names re-entering from model JSON (batch children, `call_tool`,
-    // the interpreter bridge); streamed names are canonicalized in streaming.rs.
-    let name = super::streaming::canonical_tool_name(name);
-    if let Some(local) = ctx.local_tools.get(name) {
-        return run_local_tool(local, id, name, input, ctx, emit).await;
-    }
-    let entry = registry.get(name);
-    // LLM providers send tool names in wire format (server__tool) but our
-    // internal index uses server.tool. Only convert if the name isn't a
-    // native tool — avoids mangling native names that happen to contain __.
-    let mcp_name;
-    let mcp_lookup = if entry.is_none() && name.contains("__") && mcp.is_some() {
-        mcp_name = crate::mcp::internal_tool_name(name);
-        mcp_name.as_str()
-    } else {
-        name
-    };
-    let tool_id: Arc<str> = entry
-        .as_ref()
-        .map(|e| Arc::from(e.tool.name()))
-        .or_else(|| mcp.map(|m| m.interned_name(mcp_lookup)))
-        .unwrap_or_else(|| Arc::from(UNKNOWN_MCP));
+    let tool_id: Arc<str> = Arc::from(entry.tool.name());
     let started = Instant::now();
 
     let done_error = |msg: String| ToolDoneEvent {
@@ -146,106 +320,88 @@ async fn run_inner(
         written_path: None,
     };
 
-    if let Some(entry) = entry {
-        let invocation = match entry.tool.parse(input) {
-            Ok(inv) => inv,
-            Err(e) => {
+    let invocation = match entry.tool.parse(input) {
+        Ok(inv) => inv,
+        Err(e) => {
+            warn!(
+                tool = %name,
+                source = %entry.source.as_log_field(),
+                input_preview = %crate::tools::schema::preview(&input.to_string()),
+                error = %e,
+                "tool input parse failed"
+            );
+            return done_error(e.to_string());
+        }
+    };
+
+    if let Some(target) = invocation.mutable_path() {
+        let is_plan_target = ctx.mode.plan_path().is_some_and(|pp| target == pp);
+        if !is_plan_target {
+            if ctx.mode.plan_path().is_some() {
                 warn!(
                     tool = %name,
-                    source = %entry.source.as_log_field(),
-                    input_preview = %crate::tools::schema::preview(&input.to_string()),
-                    error = %e,
-                    "tool input parse failed"
+                    target = %target.display(),
+                    "blocked write in plan mode"
                 );
-                return done_error(e.to_string());
+                return done_error(crate::tools::PLAN_WRITE_RESTRICTED.into());
             }
-        };
-
-        if let Some(target) = invocation.mutable_path() {
-            let is_plan_target = ctx.mode.plan_path().is_some_and(|pp| target == pp);
-            if !is_plan_target {
-                if ctx.mode.plan_path().is_some() {
-                    warn!(
-                        tool = %name,
-                        target = %target.display(),
-                        "blocked write in plan mode"
-                    );
-                    return done_error(crate::tools::PLAN_WRITE_RESTRICTED.into());
-                }
-                if let Some(reason) = ctx.permissions.boundary_block_reason(target) {
-                    return done_error(reason);
-                }
+            if let Some(reason) = ctx.permissions.boundary_block_reason(target) {
+                return done_error(reason);
             }
         }
+    }
 
-        let header_result = invocation.start_header().await;
-        let start = ToolStartEvent {
-            id: id.clone(),
-            tool: Arc::clone(&tool_id),
-            summary: header_result.text(),
-            render_header: header_result.snapshot(),
-            annotation: invocation.start_annotation(),
-            input: None,
-            raw_input: Some(input.clone()),
-            output: invocation.start_output(ctx),
-        };
-        if matches!(emit, Emit::Notify) {
-            let _ = ctx.event_tx.send(AgentEvent::ToolStart(Box::new(start)));
-        }
+    let header_result = invocation.start_header().await;
+    let start = ToolStartEvent {
+        id: id.clone(),
+        tool: Arc::clone(&tool_id),
+        summary: header_result.text(),
+        render_header: header_result.snapshot(),
+        annotation: invocation.start_annotation(),
+        input: None,
+        raw_input: Some(input.clone()),
+        output: invocation.start_output(ctx),
+    };
+    if origin.is_model() {
+        let _ = ctx.event_tx.send(AgentEvent::ToolStart(Box::new(start)));
+    }
 
-        invocation.start(ctx).await;
+    invocation.start(ctx).await;
 
-        if let Err(e) = enforce_permission(invocation.as_ref(), name, ctx, &id).await {
-            return done_error(e);
-        }
+    if let Err(e) = enforce_permission(invocation.as_ref(), name, ctx, &id).await {
+        return done_error(e);
+    }
 
-        let result = invocation.execute(ctx).await;
+    let result = invocation.execute(ctx).await;
 
-        let elapsed = started.elapsed();
-        match result.output {
-            Ok(output) => {
-                debug!(
-                    tool = %name,
-                    source = %entry.source.as_log_field(),
-                    elapsed_ms = elapsed.as_millis() as u64,
-                    "tool ok"
-                );
-                ToolDoneEvent {
-                    id,
-                    tool: tool_id,
-                    output,
-                    is_error: false,
-                    annotation: result.annotation,
-                    written_path: result.written_path,
-                }
-            }
-            Err(message) => {
-                warn!(
-                    tool = %name,
-                    source = %entry.source.as_log_field(),
-                    elapsed_ms = elapsed.as_millis() as u64,
-                    error = %message,
-                    "tool failed"
-                );
-                done_error(message)
+    let elapsed = started.elapsed();
+    match result.output {
+        Ok(output) => {
+            debug!(
+                tool = %name,
+                source = %entry.source.as_log_field(),
+                elapsed_ms = elapsed.as_millis() as u64,
+                "tool ok"
+            );
+            ToolDoneEvent {
+                id,
+                tool: tool_id,
+                output,
+                is_error: false,
+                annotation: result.annotation,
+                written_path: result.written_path,
             }
         }
-    } else if let Some(mcp) = mcp.filter(|_| name == TOOL_SEARCH_TOOL_NAME) {
-        run_tool_search(mcp, id, input, ctx, emit)
-    } else if mcp.is_some_and(|m| m.has_tool(mcp_lookup)) {
-        emit_raw_start(
-            ctx,
-            emit,
-            &id,
-            &tool_id,
-            format!("mcp: {mcp_lookup}"),
-            input,
-        );
-        execute_mcp_tool(ctx, &id, tool_id, mcp_lookup, input).await
-    } else {
-        let msg = format!("{UNKNOWN_TOOL_PREFIX}: {mcp_lookup}");
-        warn!(tool = %mcp_lookup, "unknown tool");
-        done_error(msg)
+        Err(message) => {
+            warn!(
+                tool = %name,
+                source = %entry.source.as_log_field(),
+                elapsed_ms = elapsed.as_millis() as u64,
+                error = %message,
+                "tool failed"
+            );
+            done_error(message)
+        }
     }
 }
 
@@ -253,13 +409,13 @@ async fn run_inner(
 /// so there is no parsed input to show; the UI gets the raw JSON instead.
 fn emit_raw_start(
     ctx: &ToolContext,
-    emit: Emit,
+    origin: CallOrigin,
     id: &str,
     tool: &Arc<str>,
     summary: String,
     input: &Value,
 ) {
-    if !matches!(emit, Emit::Notify) {
+    if !origin.is_model() {
         return;
     }
     let start = ToolStartEvent {
@@ -282,12 +438,12 @@ fn run_tool_search(
     id: String,
     input: &Value,
     ctx: &ToolContext,
-    emit: Emit,
+    origin: CallOrigin,
 ) -> ToolDoneEvent {
     let tool_id: Arc<str> = Arc::from(TOOL_SEARCH_TOOL_NAME);
     let query = input["query"].as_str().unwrap_or_default();
-    emit_raw_start(ctx, emit, &id, &tool_id, query.to_owned(), input);
-    let (output, is_error) = match mcp.search_tools(query) {
+    emit_raw_start(ctx, origin, &id, &tool_id, query.to_owned(), input);
+    let (output, is_error) = match mcp.search_tools(query, origin) {
         Ok(out) => (out, false),
         Err(e) => (e, true),
     };
@@ -307,10 +463,10 @@ async fn run_local_tool(
     name: &str,
     input: &Value,
     ctx: &ToolContext,
-    emit: Emit,
+    origin: CallOrigin,
 ) -> ToolDoneEvent {
     let tool_id: Arc<str> = Arc::from(name);
-    emit_raw_start(ctx, emit, &id, &tool_id, name.to_owned(), input);
+    emit_raw_start(ctx, origin, &id, &tool_id, name.to_owned(), input);
     let tool_ctx = ToolContext {
         tool_use_id: Some(id.clone()),
         ..ctx.clone()
@@ -367,14 +523,16 @@ async fn enforce_permission(
 
 async fn execute_mcp_tool(
     ctx: &ToolContext,
+    mcp: &McpSession,
     id: &str,
-    tool_id: Arc<str>,
-    tool_name: &str,
+    tool: Arc<str>,
     input: &Value,
+    origin: CallOrigin,
 ) -> ToolDoneEvent {
+    emit_raw_start(ctx, origin, id, &tool, format!("mcp: {tool}"), input);
     let done = |output: String, is_error: bool| ToolDoneEvent {
         id: id.to_owned(),
-        tool: Arc::clone(&tool_id),
+        tool: Arc::clone(&tool),
         output: ToolOutput::Plain(output.into()),
         is_error,
         annotation: None,
@@ -385,10 +543,10 @@ async fn execute_mcp_tool(
         return done(MCP_BLOCKED_IN_PLAN.into(), true);
     }
 
-    let perm_tool = match ToolKey::parse(tool_name) {
+    let perm_tool = match ToolKey::parse(&tool) {
         Ok(k) => k,
         Err(e) => {
-            return done(format!("invalid MCP tool key '{tool_name}': {e}"), true);
+            return done(format!("invalid MCP tool key '{tool}': {e}"), true);
         }
     };
     let perm_scope = truncate_bytes(&input.to_string(), MCP_PERM_SCOPE_MAX_BYTES);
@@ -410,14 +568,10 @@ async fn execute_mcp_tool(
         return done(e.to_string(), true);
     }
 
-    let Some(mcp) = &ctx.mcp else {
-        return done(format!("MCP manager not available for {tool_name}"), true);
-    };
-
-    // A permitted call to a deferred tool counts as loading it, so its full
-    // definition joins the next request; a denied call must not load anything.
-    mcp.mark_loaded(tool_name);
-    match mcp.call_tool(tool_name, input).await {
+    // A permitted call counts as loading the tool, so its definition joins the
+    // next request; a denied one must not load anything.
+    mcp.mark_loaded(&tool, origin);
+    match mcp.call_tool(&tool, input).await {
         Ok(text) => done(text, false),
         Err(e) => done(e.to_string(), true),
     }
@@ -427,7 +581,6 @@ async fn execute_mcp_tool(
 pub(super) async fn process_tool_calls(
     response: maki_providers::StreamResponse,
     recent_calls: &mut RecentCalls,
-    mcp: Option<&McpSession>,
     history: &mut super::history::History,
     event_tx: &crate::EventSender,
     ctx: &ToolContext,
@@ -472,18 +625,8 @@ pub(super) async fn process_tool_calls(
             tool_use_id: Some(id.clone()),
             ..ctx.clone()
         };
-        let mcp_owned = mcp.cloned();
         set.spawn(async move {
-            let done = run(
-                &tool_ctx.registry,
-                mcp_owned.as_ref(),
-                id,
-                &name,
-                &input,
-                &tool_ctx,
-                Emit::Notify,
-            )
-            .await;
+            let done = run(id, &name, &input, &tool_ctx, CallOrigin::Model).await;
             event_tx_clone.try_send(AgentEvent::ToolDone(Box::new(done.clone())));
             done
         });
@@ -511,17 +654,6 @@ pub(super) async fn process_tool_calls(
     })?;
     history.push(tool_msg);
     Ok(())
-}
-
-fn tool_source(registry: &ToolRegistry, ctx: &ToolContext, name: &str) -> Cow<'static, str> {
-    if ctx.local_tools.contains_key(name) {
-        return Cow::Borrowed(SOURCE_LOCAL);
-    }
-    match registry.get(name) {
-        Some(entry) => entry.source.as_log_field(),
-        None if name.contains(MCP_NAME_SEPARATOR) => Cow::Borrowed(SOURCE_UNKNOWN),
-        None => Cow::Borrowed(SOURCE_NATIVE),
-    }
 }
 
 /// Low-cardinality buckets, because a raw error message would give the
@@ -596,37 +728,42 @@ fn report(done: &ToolDoneEvent, name: &str, source: &str, input: &Value, took: D
     }
 }
 
-/// Test-only entry that skips native lookup, letting plan-mode and MCP tests
-/// exercise the dispatch path without registering a fake native tool.
-#[cfg(test)]
-async fn dispatch_mcp(
-    ctx: &ToolContext,
-    id: &str,
-    tool_name: &str,
-    input: &Value,
-) -> ToolDoneEvent {
-    let tool_id = ctx
-        .mcp
-        .as_ref()
-        .map(|m| m.interned_name(tool_name))
-        .unwrap_or_else(|| Arc::from(UNKNOWN_MCP));
-    execute_mcp_tool(ctx, id, tool_id, tool_name, input).await
-}
-
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     use maki_config::{Effect, PermissionRule, PermissionsConfig, ToolKey};
-    use tempfile::TempDir;
     use test_case::test_case;
 
     use super::*;
     use crate::AgentMode;
+    use crate::mcp::test_support::stub_session;
+    use crate::mcp::tool_names;
     use crate::permissions::{PERMISSION_DENIED_PREFIX, PermissionManager};
-    use crate::tools::registry::ToolSource;
-    use crate::tools::test_support::{GUARDED_TOOL_NAME, GuardedMock};
+    use crate::tools::registry::{ToolRegistry, ToolSource};
+    use crate::tools::test_support::{
+        GUARDED_TOOL_NAME, GuardedMock, mock_tool, stub_ctx, stub_ctx_with_permissions,
+    };
+    use crate::tools::{
+        BoxFuture, DescriptionContext, ExecFuture, HeaderFuture, HeaderResult, ParseError,
+        PermissionScopes, Tool, ToolAudience, ToolExecResult, local_tool,
+    };
+
+    const TEST_ID: &str = "t1";
+    const PROBE_WIRE: &str = "srv__probe";
+    const PROBE_QUALIFIED: &str = "srv.probe";
+    const OTHER_WIRE: &str = "srv__other";
+    const OTHER_QUALIFIED: &str = "srv.other";
+    const SHADOWED_NAME: &str = "batch";
+    const CLIENT_NAME: &str = "client_probe";
+    const TEST_PLUGIN: &str = "test";
+    const TEST_PLUGIN_SOURCE: &str = "lua:test";
+    const START_PROBE_NAME: &str = "start_probe";
+    /// Allowed by the shared stub permissions; nothing is ever written here.
+    const TEST_ROOT: &str = "/tmp";
+    const PLAN_PATH: &str = "/tmp/plan.md";
 
     fn recent_calls(entries: &[(&str, Value)]) -> RecentCalls {
         let mut rc = RecentCalls::new();
@@ -654,47 +791,95 @@ mod tests {
         name: &str,
         f: impl Fn(&Value) -> Result<String, String> + Send + Sync + 'static,
     ) -> ToolContext {
-        let mut ctx = crate::tools::test_support::stub_ctx(&AgentMode::Build);
-        let mut map = std::collections::HashMap::new();
-        map.insert(
+        let mut ctx = stub_ctx(&AgentMode::Build);
+        ctx.local_tools = Arc::new(HashMap::from([(
             name.to_owned(),
-            crate::tools::local_tool(move |input, _ctx| {
+            local_tool(ToolAudience::all(), move |input, _ctx| {
                 let result = f(&input);
                 Box::pin(async move { result })
             }),
-        );
-        ctx.local_tools = Arc::new(map);
+        )]));
         ctx
+    }
+
+    async fn dispatch(ctx: &ToolContext, name: &str, input: &Value) -> ToolDoneEvent {
+        run(TEST_ID.into(), name, input, ctx, CallOrigin::Model).await
+    }
+
+    async fn dispatch_nested(ctx: &ToolContext, name: &str, input: &Value) -> ToolDoneEvent {
+        run(TEST_ID.into(), name, input, ctx, CallOrigin::Nested).await
+    }
+
+    fn with_mcp(mut ctx: ToolContext, mcp: &McpSession) -> ToolContext {
+        ctx.mcp = Some(mcp.clone());
+        ctx
+    }
+
+    /// Publishes the tools with empty descriptions: search matches on the name.
+    fn stub_mcp(qualified: &[&str]) -> McpSession {
+        let tools: Vec<_> = qualified.iter().map(|name| (*name, "")).collect();
+        stub_session(&tools)
+    }
+
+    fn mcp_ctx(mcp: &McpSession) -> ToolContext {
+        with_mcp(stub_ctx(&AgentMode::Build), mcp)
+    }
+
+    fn registered(tool: Arc<dyn Tool>) -> Arc<ToolRegistry> {
+        let registry = ToolRegistry::new();
+        register(&registry, tool);
+        Arc::new(registry)
+    }
+
+    fn register(registry: &ToolRegistry, tool: Arc<dyn Tool>) {
+        registry
+            .register(
+                tool,
+                ToolSource::Lua {
+                    plugin: TEST_PLUGIN.into(),
+                },
+            )
+            .unwrap();
+    }
+
+    fn registry_with(names: &[&str]) -> Arc<ToolRegistry> {
+        let registry = ToolRegistry::new();
+        for name in names {
+            register(&registry, mock_tool(name, ToolAudience::all()));
+        }
+        Arc::new(registry)
+    }
+
+    fn denying_ctx(tool: ToolKey) -> ToolContext {
+        let config = PermissionsConfig {
+            rules: vec![PermissionRule {
+                tool,
+                scope: None,
+                effect: Effect::Deny,
+            }],
+            ..Default::default()
+        };
+        let permissions = Arc::new(PermissionManager::new(
+            config,
+            PathBuf::from(TEST_ROOT),
+            Arc::default(),
+        ));
+        stub_ctx_with_permissions(&AgentMode::Build, permissions)
     }
 
     #[test]
     fn local_tool_shadows_registry_and_maps_errors() {
         smol::block_on(async {
-            let ctx = local_ctx("batch", |input| Ok(format!("local:{}", input["path"])));
-            let done = run(
-                ToolRegistry::global(),
-                None,
-                "t1".into(),
-                "batch",
-                &serde_json::json!({"path": "/a"}),
-                &ctx,
-                Emit::Silent,
-            )
-            .await;
+            let mut ctx = local_ctx(SHADOWED_NAME, |input| {
+                Ok(format!("local:{}", input["path"]))
+            });
+            ctx.registry = registry_with(&[SHADOWED_NAME]);
+            let done = dispatch(&ctx, SHADOWED_NAME, &serde_json::json!({"path": "/a"})).await;
             assert!(!done.is_error);
             assert_eq!(done.output.as_text(), r#"local:"/a""#);
 
             let ctx = local_ctx("boom", |_| Err("nope".into()));
-            let done = run(
-                ToolRegistry::global(),
-                None,
-                "t2".into(),
-                "boom",
-                &serde_json::json!({}),
-                &ctx,
-                Emit::Silent,
-            )
-            .await;
+            let done = dispatch(&ctx, "boom", &serde_json::json!({})).await;
             assert!(done.is_error);
             assert_eq!(done.output.as_text(), "nope");
         });
@@ -704,16 +889,7 @@ mod tests {
     fn functions_prefixed_name_dispatches_to_canonical_tool() {
         smol::block_on(async {
             let ctx = local_ctx("ok", |_| Ok("ran".into()));
-            let done = run(
-                ToolRegistry::global(),
-                None,
-                "t1".into(),
-                "functions.ok",
-                &serde_json::json!({}),
-                &ctx,
-                Emit::Silent,
-            )
-            .await;
+            let done = dispatch(&ctx, "functions.ok", &serde_json::json!({})).await;
             assert!(!done.is_error);
             assert_eq!(done.output.as_text(), "ran");
         });
@@ -726,27 +902,16 @@ mod tests {
             let event_tx = crate::EventSender::new(tx, 0);
             let mut ctx =
                 crate::tools::test_support::stub_ctx_with(&AgentMode::Build, Some(&event_tx), None);
-            let mut map = std::collections::HashMap::new();
-            map.insert(
+            ctx.local_tools = Arc::new(HashMap::from([(
                 "local_echo".to_owned(),
-                crate::tools::local_tool(|input, _ctx| {
+                local_tool(ToolAudience::all(), |input: Value, _ctx| {
                     let out = input.to_string();
                     Box::pin(async move { Ok(out) })
                 }),
-            );
-            ctx.local_tools = Arc::new(map);
+            )]));
 
             let input = serde_json::json!({"path": "/a"});
-            let done = run(
-                ToolRegistry::global(),
-                None,
-                "t1".into(),
-                "local_echo",
-                &input,
-                &ctx,
-                Emit::Notify,
-            )
-            .await;
+            let done = dispatch(&ctx, "local_echo", &input).await;
             assert!(!done.is_error);
 
             let envelope = rx
@@ -764,26 +929,21 @@ mod tests {
     #[test]
     fn tool_search_routes_and_loads_matches() {
         smol::block_on(async {
-            let mcp = crate::mcp::stub_session(&[("srv.fetch_issue", "Fetch a GitHub issue")]);
-            let ctx = crate::tools::test_support::stub_ctx(&AgentMode::Build);
-            let done = run(
-                ToolRegistry::global(),
-                Some(&mcp),
-                "t1".into(),
+            let mcp = stub_mcp(&[PROBE_QUALIFIED]);
+            let done = dispatch(
+                &mcp_ctx(&mcp),
                 TOOL_SEARCH_TOOL_NAME,
-                &serde_json::json!({"query": "issue"}),
-                &ctx,
-                Emit::Silent,
+                &serde_json::json!({"query": "probe"}),
             )
             .await;
             assert!(!done.is_error, "got: {}", done.output.as_text());
             assert_eq!(done.tool.as_ref(), TOOL_SEARCH_TOOL_NAME);
-            assert!(done.output.as_text().contains("srv__fetch_issue"));
+            assert!(done.output.as_text().contains(PROBE_WIRE));
 
             let mut tools = serde_json::json!([]);
             mcp.extend_tools(&mut tools);
             assert!(
-                crate::mcp::tool_names(&tools).contains(&"srv__fetch_issue"),
+                tool_names(&tools).contains(&PROBE_WIRE),
                 "searched tool must join the next request"
             );
         });
@@ -793,16 +953,10 @@ mod tests {
     #[test_case(serde_json::json!({}) ; "missing_query")]
     fn tool_search_bad_query_is_error_event(input: Value) {
         smol::block_on(async {
-            let mcp = crate::mcp::stub_session(&[("srv.tool", "")]);
-            let ctx = crate::tools::test_support::stub_ctx(&AgentMode::Build);
-            let done = run(
-                ToolRegistry::global(),
-                Some(&mcp),
-                "t1".into(),
+            let done = dispatch(
+                &mcp_ctx(&stub_mcp(&[PROBE_QUALIFIED])),
                 TOOL_SEARCH_TOOL_NAME,
                 &input,
-                &ctx,
-                Emit::Silent,
             )
             .await;
             assert!(done.is_error);
@@ -813,27 +967,37 @@ mod tests {
     #[test]
     fn calling_deferred_mcp_tool_marks_it_loaded() {
         smol::block_on(async {
-            let mcp = crate::mcp::stub_session(&[("srv.fetch_issue", "")]);
-            let mut ctx = crate::tools::test_support::stub_ctx(&AgentMode::Build);
-            ctx.mcp = Some(mcp.clone());
-            let done = run(
-                ToolRegistry::global(),
-                Some(&mcp),
-                "t1".into(),
-                "srv__fetch_issue",
-                &serde_json::json!({}),
-                &ctx,
-                Emit::Silent,
-            )
-            .await;
-            assert_eq!(done.tool.as_ref(), "srv.fetch_issue", "must route to MCP");
+            let mcp = stub_mcp(&[PROBE_QUALIFIED]);
+            let done = dispatch(&mcp_ctx(&mcp), PROBE_WIRE, &serde_json::json!({})).await;
+            assert_eq!(done.tool.as_ref(), PROBE_QUALIFIED, "must route to MCP");
 
             let mut tools = serde_json::json!([]);
             mcp.extend_tools(&mut tools);
             assert_eq!(
-                crate::mcp::tool_names(&tools),
-                vec!["srv__fetch_issue"],
+                tool_names(&tools),
+                vec![PROBE_WIRE],
                 "called tool must join the next request"
+            );
+        });
+    }
+
+    /// `McpSession::new` rebuilds the loaded set from the `ToolUse` blocks in
+    /// history, which hold no nested call, so loading one here would make the
+    /// live tool array differ from the resumed one.
+    #[test_case(PROBE_WIRE, serde_json::json!({}), PROBE_QUALIFIED ; "tool_call")]
+    #[test_case(TOOL_SEARCH_TOOL_NAME, serde_json::json!({"query": "probe"}), TOOL_SEARCH_TOOL_NAME ; "tool_search")]
+    fn nested_call_reaches_mcp_without_loading_anything(name: &str, input: Value, routed: &str) {
+        smol::block_on(async {
+            let mcp = stub_mcp(&[PROBE_QUALIFIED]);
+            let done = dispatch_nested(&mcp_ctx(&mcp), name, &input).await;
+            assert_eq!(done.tool.as_ref(), routed, "must route to MCP");
+
+            let mut tools = serde_json::json!([]);
+            mcp.extend_tools(&mut tools);
+            assert_eq!(
+                tool_names(&tools),
+                vec![TOOL_SEARCH_TOOL_NAME],
+                "a nested call must not change the next request"
             );
         });
     }
@@ -841,36 +1005,9 @@ mod tests {
     #[test]
     fn denied_mcp_call_does_not_load_definition() {
         smol::block_on(async {
-            let mcp = crate::mcp::stub_session(&[("srv.fetch_issue", "")]);
-            let deny_cfg = PermissionsConfig {
-                rules: vec![PermissionRule {
-                    tool: ToolKey::parse("srv.fetch_issue").unwrap(),
-                    scope: None,
-                    effect: Effect::Deny,
-                }],
-                ..Default::default()
-            };
-            let dir = TempDir::new().unwrap();
-            let permissions = Arc::new(PermissionManager::new(
-                deny_cfg,
-                dir.path().to_path_buf(),
-                Arc::default(),
-            ));
-            let mut ctx = crate::tools::test_support::stub_ctx_with_permissions(
-                &AgentMode::Build,
-                permissions,
-            );
-            ctx.mcp = Some(mcp.clone());
-            let done = run(
-                ToolRegistry::global(),
-                Some(&mcp),
-                "t1".into(),
-                "srv__fetch_issue",
-                &serde_json::json!({}),
-                &ctx,
-                Emit::Silent,
-            )
-            .await;
+            let mcp = stub_mcp(&[PROBE_QUALIFIED]);
+            let ctx = with_mcp(denying_ctx(ToolKey::parse(PROBE_QUALIFIED).unwrap()), &mcp);
+            let done = dispatch(&ctx, PROBE_WIRE, &serde_json::json!({})).await;
             assert!(done.is_error);
             assert!(
                 done.output.as_text().starts_with(PERMISSION_DENIED_PREFIX),
@@ -881,7 +1018,7 @@ mod tests {
             let mut tools = serde_json::json!([]);
             mcp.extend_tools(&mut tools);
             assert_eq!(
-                crate::mcp::tool_names(&tools),
+                tool_names(&tools),
                 vec![TOOL_SEARCH_TOOL_NAME],
                 "denied call must not load the definition"
             );
@@ -891,16 +1028,15 @@ mod tests {
     #[test]
     fn local_tool_named_tool_search_shadows_mcp_search() {
         smol::block_on(async {
-            let mcp = crate::mcp::stub_session(&[("srv.tool", "")]);
-            let ctx = local_ctx(TOOL_SEARCH_TOOL_NAME, |_| Ok("local wins".into()));
-            let done = run(
-                ToolRegistry::global(),
-                Some(&mcp),
-                "t1".into(),
-                TOOL_SEARCH_TOOL_NAME,
-                &serde_json::json!({"query": "tool"}),
+            let mcp = stub_mcp(&[PROBE_QUALIFIED]);
+            let ctx = with_mcp(
+                local_ctx(TOOL_SEARCH_TOOL_NAME, |_| Ok("local wins".into())),
+                &mcp,
+            );
+            let done = dispatch(
                 &ctx,
-                Emit::Silent,
+                TOOL_SEARCH_TOOL_NAME,
+                &serde_json::json!({"query": "probe"}),
             )
             .await;
             assert_eq!(done.output.as_text(), "local wins");
@@ -908,101 +1044,165 @@ mod tests {
     }
 
     #[test]
-    fn unknown_tool_returns_error_event() {
+    fn telemetry_source_names_the_plugin_for_registry_tools() {
+        let mut ctx = mcp_ctx(&stub_mcp(&[PROBE_QUALIFIED, OTHER_QUALIFIED]));
+        ctx.registry = registry_with(&[PROBE_WIRE]);
+        assert_eq!(resolve(&ctx, PROBE_WIRE).route.source(), TEST_PLUGIN_SOURCE);
+        assert_eq!(resolve(&ctx, OTHER_WIRE).route.source(), SOURCE_MCP);
+    }
+
+    #[test]
+    fn resolve_prefers_local_over_registry_and_registry_over_mcp() {
+        let mcp = stub_mcp(&[PROBE_QUALIFIED]);
+        let mut ctx = with_mcp(local_ctx(PROBE_WIRE, |_| Ok(String::new())), &mcp);
+        ctx.registry = registry_with(&[PROBE_WIRE]);
+
+        assert!(matches!(resolve(&ctx, PROBE_WIRE).route, Route::Local(_)));
+
+        ctx.local_tools = Arc::default();
+        assert!(matches!(resolve(&ctx, PROBE_WIRE).route, Route::Native(_)));
+
+        ctx.registry = Arc::new(ToolRegistry::new());
+        assert!(matches!(resolve(&ctx, PROBE_WIRE).route, Route::Mcp(..)));
+    }
+
+    fn callable_names(ctx: &ToolContext) -> Vec<String> {
+        callable(ctx).into_iter().map(|c| c.name).collect()
+    }
+
+    /// A deferred MCP tool is missing from the request's tool array and is still
+    /// a name the sandbox may bind.
+    #[test]
+    fn callable_lists_host_and_deferred_mcp_names() {
+        let mcp = stub_mcp(&[PROBE_QUALIFIED, OTHER_QUALIFIED]);
+        let ctx = with_mcp(local_ctx(CLIENT_NAME, |_| Ok(String::new())), &mcp);
+        assert_eq!(
+            callable_names(&ctx),
+            [CLIENT_NAME, OTHER_WIRE, PROBE_WIRE, TOOL_SEARCH_TOOL_NAME]
+        );
+    }
+
+    /// A shadowed name appears once, described by whatever `resolve` picks:
+    /// listing it under the loser's audience is how a script gets handed a tool
+    /// its own audience was denied.
+    #[test]
+    fn callable_describes_a_shadowed_name_by_what_dispatch_runs() {
+        let mcp = stub_mcp(&[PROBE_QUALIFIED]);
+        let mut ctx = with_mcp(local_ctx(PROBE_WIRE, |_| Ok(String::new())), &mcp);
+        ctx.registry = registry_with(&[PROBE_WIRE]);
+
+        let probe = |ctx: &ToolContext| {
+            let all = callable(ctx);
+            assert_eq!(all.iter().filter(|c| c.name == PROBE_WIRE).count(), 1);
+            all.into_iter()
+                .find(|c| c.name == PROBE_WIRE)
+                .expect("the name is dispatchable")
+        };
+        assert_eq!(probe(&ctx).source, SOURCE_LOCAL);
+
+        ctx.local_tools = Arc::default();
+        let native = probe(&ctx);
+        assert_eq!(native.source, SOURCE_NATIVE);
+        assert!(native.schema.is_some(), "registry tools carry their schema");
+    }
+
+    /// The sandbox gets the same tools the request's array does, so a tool the
+    /// user disabled is not reachable by writing a script instead.
+    #[test]
+    fn callable_drops_what_the_config_disabled() {
+        let mut ctx = stub_ctx(&AgentMode::Build);
+        ctx.registry = registry_with(&[PROBE_WIRE, OTHER_WIRE]);
+        ctx.config.disabled_tools = vec![PROBE_WIRE.to_owned()];
+        assert_eq!(callable_names(&ctx), [OTHER_WIRE]);
+    }
+
+    /// Losing on audience is not the same as freeing the name: MCP publishing
+    /// the wire name of a gated registry tool must not become a way around it.
+    #[test]
+    fn mcp_cannot_republish_a_name_the_registry_gated() {
+        let mut ctx = mcp_ctx(&stub_mcp(&[PROBE_QUALIFIED]));
+        ctx.registry = registered(mock_tool(PROBE_WIRE, ToolAudience::MAIN));
+        ctx.audience = ToolAudience::GENERAL_SUB;
+        assert!(!callable_names(&ctx).contains(&PROBE_WIRE.to_owned()));
+    }
+
+    /// A host tool this session's audience excludes is not a callable name, even
+    /// though `resolve` would route to it.
+    #[test]
+    fn callable_drops_names_this_audience_cannot_reach() {
+        let mut ctx = stub_ctx(&AgentMode::Build);
+        ctx.local_tools = Arc::new(HashMap::from([(
+            CLIENT_NAME.to_owned(),
+            local_tool(ToolAudience::MAIN, |_, _| {
+                Box::pin(async { Ok(String::new()) })
+            }),
+        )]));
+        assert_eq!(callable_names(&ctx), [CLIENT_NAME]);
+
+        ctx.audience = ToolAudience::GENERAL_SUB;
+        assert!(callable_names(&ctx).is_empty());
+    }
+
+    #[test_case("srv.get_docs", "srv__get_docs", None                  ; "identifier_needs_no_alias")]
+    #[test_case("srv.get-docs", "srv__get-docs", Some("srv__get_docs") ; "hyphen_becomes_underscore")]
+    fn alias_is_set_only_when_the_name_is_not_an_identifier(
+        qualified: &str,
+        wire: &str,
+        expected: Option<&str>,
+    ) {
+        let ctx = mcp_ctx(&stub_mcp(&[qualified]));
+        let entry = callable(&ctx)
+            .into_iter()
+            .find(|c| c.name == wire)
+            .expect("the published tool is callable");
+        assert_eq!(entry.alias.as_deref(), expected);
+    }
+
+    /// Two names collapsing onto one alias would silently point a caller at the
+    /// wrong tool, so neither gets one.
+    #[test]
+    fn colliding_aliases_are_dropped() {
+        let ctx = mcp_ctx(&stub_mcp(&["srv.get-docs", "srv.get_docs"]));
+        assert!(callable(&ctx).iter().all(|c| c.alias.is_none()));
+    }
+
+    /// The model only fixes names it recognizes, so it hears back what it sent.
+    #[test_case(None, "nonexistent.tool" ; "without_mcp")]
+    #[test_case(Some(PROBE_QUALIFIED), OTHER_WIRE ; "unpublished_wire_name")]
+    fn unknown_tool_errors_and_echoes_the_name_verbatim(published: Option<&str>, name: &str) {
         smol::block_on(async {
-            let ctx = crate::tools::test_support::stub_ctx(&AgentMode::Build);
-            let done = run(
-                &ctx.registry,
-                None,
-                "t1".into(),
-                "nonexistent.tool",
-                &serde_json::json!({}),
-                &ctx,
-                Emit::Silent,
-            )
-            .await;
+            let mcp = published.map(|tool| stub_mcp(&[tool]));
+            let ctx = match &mcp {
+                Some(mcp) => mcp_ctx(mcp),
+                None => stub_ctx(&AgentMode::Build),
+            };
+            let done = dispatch(&ctx, name, &serde_json::json!({})).await;
             assert!(done.is_error);
             assert_eq!(done.tool.as_ref(), UNKNOWN_MCP);
             let text = done.output.as_text();
-            assert!(text.starts_with(UNKNOWN_TOOL_PREFIX));
-            assert!(text.contains("nonexistent.tool"));
+            assert!(text.starts_with(UNKNOWN_TOOL_PREFIX), "got: {text}");
+            assert!(text.contains(name), "got: {text}");
         });
     }
 
     #[test]
     fn mcp_tool_blocked_in_plan_mode() {
         smol::block_on(async {
-            let result = dispatch_mcp(
-                &crate::tools::test_support::stub_ctx(&AgentMode::Plan(PathBuf::from(
-                    "/tmp/plan.md",
-                ))),
-                "t1",
-                "myserver.mytool",
-                &serde_json::json!({}),
-            )
-            .await;
-            assert!(result.is_error);
-            assert_eq!(result.output.as_text(), MCP_BLOCKED_IN_PLAN);
-        });
-    }
-
-    #[test]
-    fn mcp_tool_errors_without_mcp_manager() {
-        smol::block_on(async {
-            let result = dispatch_mcp(
-                &crate::tools::test_support::stub_ctx(&AgentMode::Build),
-                "t1",
-                "myserver.mytool",
-                &serde_json::json!({}),
-            )
-            .await;
-            assert!(result.is_error);
-            assert!(result.output.as_text().contains("not available"));
+            let plan = AgentMode::Plan(PathBuf::from(PLAN_PATH));
+            let ctx = with_mcp(stub_ctx(&plan), &stub_mcp(&[PROBE_QUALIFIED]));
+            let done = dispatch(&ctx, PROBE_WIRE, &serde_json::json!({})).await;
+            assert!(done.is_error);
+            assert_eq!(done.output.as_text(), MCP_BLOCKED_IN_PLAN);
         });
     }
 
     #[test]
     fn permission_denial_short_circuits_execute() {
         smol::block_on(async {
-            let deny_cfg = PermissionsConfig {
-                rules: vec![PermissionRule {
-                    tool: ToolKey::native(GUARDED_TOOL_NAME),
-                    scope: None,
-                    effect: Effect::Deny,
-                }],
-                ..Default::default()
-            };
-            let dir = TempDir::new().unwrap();
-            let permissions = Arc::new(PermissionManager::new(
-                deny_cfg,
-                dir.path().to_path_buf(),
-                Arc::default(),
-            ));
-            let ctx = crate::tools::test_support::stub_ctx_with_permissions(
-                &AgentMode::Build,
-                permissions,
-            );
+            let mut ctx = denying_ctx(ToolKey::native(GUARDED_TOOL_NAME));
+            ctx.registry = registered(Arc::new(GuardedMock));
 
-            let registry = ToolRegistry::new();
-            registry
-                .register(
-                    Arc::new(GuardedMock),
-                    ToolSource::Lua {
-                        plugin: "test".into(),
-                    },
-                )
-                .unwrap();
-
-            let done = run(
-                &registry,
-                None,
-                "t1".into(),
-                GUARDED_TOOL_NAME,
-                &serde_json::json!({}),
-                &ctx,
-                Emit::Silent,
-            )
-            .await;
+            let done = dispatch(&ctx, GUARDED_TOOL_NAME, &serde_json::json!({})).await;
 
             assert!(done.is_error, "permission denial must produce error event");
             assert!(
@@ -1012,15 +1212,6 @@ mod tests {
             );
         });
     }
-
-    const START_PROBE_NAME: &str = "start_probe";
-
-    use std::sync::atomic::{AtomicBool, Ordering};
-
-    use crate::tools::{
-        BoxFuture, DescriptionContext, ExecFuture, HeaderFuture, HeaderResult, ParseError,
-        PermissionScopes, Tool, ToolExecResult,
-    };
 
     #[derive(Default)]
     struct StartProbe {
@@ -1076,47 +1267,12 @@ mod tests {
     #[test]
     fn start_runs_before_permission_denial_blocks_execute() {
         smol::block_on(async {
-            let deny_cfg = PermissionsConfig {
-                rules: vec![PermissionRule {
-                    tool: ToolKey::native(START_PROBE_NAME),
-                    scope: None,
-                    effect: Effect::Deny,
-                }],
-                ..Default::default()
-            };
-            let dir = TempDir::new().unwrap();
-            let permissions = Arc::new(PermissionManager::new(
-                deny_cfg,
-                dir.path().to_path_buf(),
-                Arc::default(),
-            ));
-            let ctx = crate::tools::test_support::stub_ctx_with_permissions(
-                &AgentMode::Build,
-                permissions,
-            );
-
+            let mut ctx = denying_ctx(ToolKey::native(START_PROBE_NAME));
             let probe = StartProbe::default();
             let (started, executed) = (Arc::clone(&probe.started), Arc::clone(&probe.executed));
-            let registry = ToolRegistry::new();
-            registry
-                .register(
-                    Arc::new(probe),
-                    ToolSource::Lua {
-                        plugin: "test".into(),
-                    },
-                )
-                .unwrap();
+            ctx.registry = registered(Arc::new(probe));
 
-            let done = run(
-                &registry,
-                None,
-                "t1".into(),
-                START_PROBE_NAME,
-                &serde_json::json!({}),
-                &ctx,
-                Emit::Silent,
-            )
-            .await;
+            let done = dispatch(&ctx, START_PROBE_NAME, &serde_json::json!({})).await;
 
             assert!(done.is_error, "denial must error");
             assert!(

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -102,11 +102,14 @@ struct AgentSetup {
     tools: Value,
 }
 
+/// Takes the handle rather than a second `bool`: two adjacent flags is one
+/// silent swap away from a session that describes tools it cannot call.
 fn setup(
     model: &Model,
     config: &AgentConfig,
     excluded_tools: &[&'static str],
     workflow: bool,
+    mcp: Option<&McpHandle>,
 ) -> AgentSetup {
     let vars = template::env_vars();
     let instructions = agent::load_instructions(&vars.apply("{cwd}"));
@@ -117,6 +120,7 @@ fn setup(
         excluded_tools,
         workflow,
         ToolRegistry::global(),
+        mcp.is_some(),
     );
 
     AgentSetup {
@@ -135,12 +139,14 @@ fn tool_definitions(
     excluded_tools: &[&'static str],
     workflow: bool,
     registry: &ToolRegistry,
+    mcp: bool,
 ) -> Value {
     let filter = ToolFilter::from_config(config, model, excluded_tools);
     let ctx = DescriptionContext {
         filter: &filter,
         audience: ToolAudience::MAIN,
         workflow,
+        mcp,
     };
     registry.definitions(vars, &ctx, model.supports_tool_examples())
 }
@@ -167,6 +173,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
         &params.config,
         &params.excluded_tools,
         params.workflow,
+        params.mcp_handle.as_ref(),
     );
 
     let system = agent::build_system_prompt(
@@ -318,6 +325,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
         &params.config,
         &params.excluded_tools,
         params.workflow,
+        params.mcp_handle.as_ref(),
     );
 
     let mcp = params
@@ -411,6 +419,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                                 &params.excluded_tools,
                                 params.workflow,
                                 ToolRegistry::global(),
+                                mcp.is_some(),
                             );
                             model = new_model;
                         }
@@ -616,7 +625,8 @@ mod tests {
     #[test]
     fn advertised_names_show_tool_search_not_deferred_tools() {
         let base = serde_json::json!([{"name": "read"}]);
-        let mcp = crate::mcp::stub_session(&[("srv.fetch_issue", "Fetch a GitHub issue")]);
+        let mcp =
+            crate::mcp::test_support::stub_session(&[("srv.fetch_issue", "Fetch a GitHub issue")]);
         let names = advertised_tool_names(&base, Some(&mcp));
         assert_eq!(
             names,

--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -43,6 +43,7 @@ use self::error::McpError;
 use self::http::HttpTransport;
 use self::stdio::StdioTransport;
 use self::transport::McpTransport;
+use crate::tools::CallOrigin;
 use crate::tools::schema::sanitize_tool_input_schema;
 
 const SEPARATOR: &str = ".";
@@ -61,6 +62,10 @@ const DESCRIPTION_HIT_SCORE: usize = 1;
 const MAX_OVERFLOW_NAMES: usize = 20;
 const SEARCH_NO_MATCH: &str = "No deferred MCP tools matched";
 const SEARCH_OVERFLOW_PREFIX: &str = "Also matched but not loaded: ";
+/// A nested search loads nothing, so it must not promise a next request that
+/// carries the matches.
+const SEARCH_HEADER_MODEL: (&str, &str) = ("Loaded", ", callable from your next message:");
+const SEARCH_HEADER_NESTED: (&str, &str) = ("Matched", ", callable here by name:");
 pub(crate) const SEARCH_EMPTY_QUERY: &str = "query must not be empty";
 
 /// Convert internal qualified name (`server.tool`) to wire format (`server__tool`)
@@ -387,10 +392,12 @@ impl McpSession {
         }
     }
 
-    /// Rank deferred tools against `query` keywords (exact name first,
-    /// then name hits over description hits) and mark the top
-    /// `MAX_SEARCH_LOADS` loaded; their definitions join the next request.
-    pub fn search_tools(&self, query: &str) -> Result<String, String> {
+    /// Rank deferred tools against `query` keywords (exact name first, then
+    /// name hits over description hits). A model-originated search marks the
+    /// top `MAX_SEARCH_LOADS` loaded so their definitions join the next
+    /// request; a nested one only reports the names, which the sandbox can
+    /// already call.
+    pub fn search_tools(&self, query: &str, origin: CallOrigin) -> Result<String, String> {
         let q = query.trim().to_lowercase();
         let tokens: Vec<&str> = q
             .split(|c: char| !c.is_alphanumeric())
@@ -433,35 +440,41 @@ impl McpSession {
                 .cmp(&(a.0, a.1))
                 .then_with(|| a.2.wire_name().cmp(b.2.wire_name()))
         });
-        let mut loaded = self.lock_loaded();
-        let mut hits: Vec<&str> = Vec::new();
-        let mut overflow: Vec<&str> = Vec::new();
-        for (_, _, d) in &matches {
-            if hits.len() < MAX_SEARCH_LOADS {
+        let (hits, overflow) = matches.split_at(matches.len().min(MAX_SEARCH_LOADS));
+        if origin.is_model() {
+            let mut loaded = self.lock_loaded();
+            for (_, _, d) in hits {
                 loaded.insert(Arc::clone(&d.qualified_name));
-                hits.push(d.wire_name());
-            } else {
-                overflow.push(d.wire_name());
             }
         }
-        drop(loaded);
-        info!(query = %q, loaded = hits.len(), overflow = overflow.len(), "MCP tool search");
+        info!(
+            query = %q,
+            hits = hits.len(),
+            overflow = overflow.len(),
+            origin = ?origin,
+            "MCP tool search"
+        );
         if hits.is_empty() {
             return Ok(format!(
                 "{SEARCH_NO_MATCH} '{query}'. Try other keywords or an exact name from the catalog."
             ));
         }
         let plural = if hits.len() == 1 { "tool" } else { "tools" };
-        let mut out = format!(
-            "Loaded {} {plural}, callable from your next message:",
-            hits.len()
-        );
-        for hit in &hits {
-            out.push_str(&format!("\n- `{hit}`"));
+        let (verb, tail) = if origin.is_model() {
+            SEARCH_HEADER_MODEL
+        } else {
+            SEARCH_HEADER_NESTED
+        };
+        let mut out = format!("{verb} {} {plural}{tail}", hits.len());
+        for (_, _, d) in hits {
+            out.push_str(&format!("\n- `{}`", d.wire_name()));
         }
         if !overflow.is_empty() {
             let shown = overflow.len().min(MAX_OVERFLOW_NAMES);
-            let names: Vec<String> = overflow[..shown].iter().map(|n| format!("`{n}`")).collect();
+            let names: Vec<String> = overflow[..shown]
+                .iter()
+                .map(|(_, _, d)| format!("`{}`", d.wire_name()))
+                .collect();
             out.push_str(&format!("\n{SEARCH_OVERFLOW_PREFIX}{}", names.join(", ")));
             if overflow.len() > shown {
                 out.push_str(&format!(" and {} more", overflow.len() - shown));
@@ -471,10 +484,29 @@ impl McpSession {
         Ok(out)
     }
 
+    /// Every published tool's wire name, deferred ones included. Whoever
+    /// enumerates callable names has to see past the `tool_search` catalog that
+    /// `extend_tools` hides deferred tools behind.
+    pub fn wire_names(&self) -> Vec<String> {
+        self.handle
+            .index
+            .load()
+            .descriptors
+            .iter()
+            .map(|d| d.wire_name().to_owned())
+            .collect()
+    }
+
     /// Invoked on every MCP dispatch: a deferred tool the model calls by
     /// catalog name gets its full definition on the next request.
-    pub fn mark_loaded(&self, qualified_name: &str) {
-        self.lock_loaded().insert(Arc::from(qualified_name));
+    ///
+    /// Nested calls are ignored: history holds none to replay, so a script
+    /// fanning out over deferred tools would otherwise leave a resumed session
+    /// with a different tool array than the live one.
+    pub fn mark_loaded(&self, qualified_name: &str, origin: CallOrigin) {
+        if origin.is_model() {
+            self.lock_loaded().insert(Arc::from(qualified_name));
+        }
     }
 
     fn lock_loaded(&self) -> std::sync::MutexGuard<'_, HashSet<Arc<str>>> {
@@ -500,17 +532,19 @@ impl McpHandle {
         McpSnapshotReader(Arc::clone(&self.snapshot))
     }
 
-    pub fn has_tool(&self, name: &str) -> bool {
-        self.index.load().tools.contains_key(name)
-    }
-
-    pub fn interned_name(&self, name: &str) -> Arc<str> {
-        self.index
-            .load()
-            .tools
-            .get_key_value(name)
-            .map(|(k, _)| Arc::clone(k))
-            .unwrap_or_else(|| Arc::from(UNKNOWN_MCP))
+    /// Where wire names (`server__tool`, what providers send) and internal names
+    /// (`server.tool`, what the index holds) meet. Returns the interned qualified
+    /// name every other MCP entry point takes, or `None` when no server publishes
+    /// it. Deferred tools resolve too: hidden from the tool array is not the same
+    /// as uncallable.
+    pub fn resolve(&self, name: &str) -> Option<Arc<str>> {
+        let index = self.index.load();
+        let interned = |n: &str| index.tools.get_key_value(n).map(|(k, _)| Arc::clone(k));
+        interned(name).or_else(|| {
+            name.contains(WIRE_SEPARATOR)
+                .then(|| interned(&internal_tool_name(name)))
+                .flatten()
+        })
     }
 
     pub async fn call_tool(&self, qualified_name: &str, args: &Value) -> Result<String, McpError> {
@@ -1043,48 +1077,99 @@ fn publish(inner: &McpManagerInner, index: &ArcSwap<ToolIndex>, snapshot: &ArcSw
     }));
 }
 
-/// Session for dispatch-level tests outside this module, built through the
-/// real `publish` path so it can't drift from production index construction.
-#[cfg(test)]
-pub(crate) fn stub_session(tools: &[(&str, &str)]) -> McpSession {
-    let entry = ServerEntry {
-        name: "stub".into(),
-        config: None,
-        transport_kind: "stub",
-        origin: PathBuf::new(),
-        status: McpServerStatus::Running,
-        transport: Some(Arc::new(StubTransport(Arc::from("stub")))),
-        tools: tools
-            .iter()
-            .map(|(qualified, description)| McpToolDef {
-                qualified_name: Arc::from(*qualified),
-                raw_name: qualified
-                    .split_once(SEPARATOR)
-                    .map_or(*qualified, |(_, r)| r)
-                    .into(),
-                description: (*description).into(),
-                input_schema: json!({}),
+/// Sessions for dispatch-level tests. Always compiled, so tests outside this
+/// crate can build a `ToolContext` that carries MCP.
+pub mod test_support {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use arc_swap::ArcSwap;
+    use serde_json::{Value, json};
+
+    use super::config::McpServerStatus;
+    use super::error::McpError;
+    use super::transport::{self, McpTransport};
+    use super::{
+        McpHandle, McpManagerInner, McpSession, McpSnapshot, McpToolDef, SEPARATOR, ServerEntry,
+        ToolIndex, publish,
+    };
+
+    /// Goes through the real `publish` path, so it cannot drift from how the
+    /// index is built in production. Tools are named `server.tool`.
+    pub fn stub_session(tools: &[(&str, &str)]) -> McpSession {
+        let entry = ServerEntry {
+            name: "stub".into(),
+            config: None,
+            transport_kind: "stub",
+            origin: PathBuf::new(),
+            status: McpServerStatus::Running,
+            transport: Some(Arc::new(StubTransport(Arc::from("stub")))),
+            tools: tools
+                .iter()
+                .map(|(qualified, description)| McpToolDef {
+                    qualified_name: Arc::from(*qualified),
+                    raw_name: qualified
+                        .split_once(SEPARATOR)
+                        .map_or(*qualified, |(_, r)| r)
+                        .into(),
+                    description: (*description).into(),
+                    input_schema: json!({}),
+                })
+                .collect(),
+            prompts: Vec::new(),
+        };
+        let inner = McpManagerInner {
+            entries: vec![entry],
+            generation: 0,
+        };
+        let index = Arc::new(ArcSwap::from_pointee(ToolIndex::default()));
+        let snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot::default()));
+        publish(&inner, &index, &snapshot);
+        McpSession::new(
+            McpHandle {
+                cmd_tx: flume::unbounded().0,
+                index,
+                snapshot,
+                defer_tools: 0,
+                ready_rx: flume::bounded(0).1,
+            },
+            &[],
+        )
+    }
+
+    /// Fails every call with `UnknownTool`, which is how a test proves the call
+    /// reached MCP at all.
+    struct StubTransport(Arc<str>);
+
+    impl McpTransport for StubTransport {
+        fn send_request<'a>(
+            &'a self,
+            method: &'a str,
+            _params: Option<Value>,
+        ) -> transport::BoxFuture<'a, Result<Value, McpError>> {
+            Box::pin(async move {
+                Err(McpError::UnknownTool {
+                    name: method.into(),
+                })
             })
-            .collect(),
-        prompts: Vec::new(),
-    };
-    let inner = McpManagerInner {
-        entries: vec![entry],
-        generation: 0,
-    };
-    let index = Arc::new(ArcSwap::from_pointee(ToolIndex::default()));
-    let snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot::default()));
-    publish(&inner, &index, &snapshot);
-    McpSession::new(
-        McpHandle {
-            cmd_tx: flume::unbounded().0,
-            index,
-            snapshot,
-            defer_tools: 0,
-            ready_rx: flume::bounded(0).1,
-        },
-        &[],
-    )
+        }
+        fn send_notification<'a>(
+            &'a self,
+            _method: &'a str,
+            _params: Option<Value>,
+        ) -> transport::BoxFuture<'a, Result<(), McpError>> {
+            Box::pin(async { Ok(()) })
+        }
+        fn shutdown<'a>(&'a self) -> transport::BoxFuture<'a, ()> {
+            Box::pin(async {})
+        }
+        fn server_name(&self) -> &Arc<str> {
+            &self.0
+        }
+        fn transport_kind(&self) -> &'static str {
+            "stub"
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1095,40 +1180,6 @@ pub(crate) fn tool_names(tools: &Value) -> Vec<&str> {
         .iter()
         .filter_map(|t| t["name"].as_str())
         .collect()
-}
-
-#[cfg(test)]
-struct StubTransport(Arc<str>);
-
-#[cfg(test)]
-impl McpTransport for StubTransport {
-    fn send_request<'a>(
-        &'a self,
-        method: &'a str,
-        _params: Option<Value>,
-    ) -> transport::BoxFuture<'a, Result<Value, McpError>> {
-        Box::pin(async move {
-            Err(McpError::UnknownTool {
-                name: method.into(),
-            })
-        })
-    }
-    fn send_notification<'a>(
-        &'a self,
-        _method: &'a str,
-        _params: Option<Value>,
-    ) -> transport::BoxFuture<'a, Result<(), McpError>> {
-        Box::pin(async { Ok(()) })
-    }
-    fn shutdown<'a>(&'a self) -> transport::BoxFuture<'a, ()> {
-        Box::pin(async {})
-    }
-    fn server_name(&self) -> &Arc<str> {
-        &self.0
-    }
-    fn transport_kind(&self) -> &'static str {
-        "stub"
-    }
 }
 
 fn build_haystack(definition: &Value) -> String {
@@ -1447,6 +1498,8 @@ mod tests {
         assert_eq!(tool_names(&tools), vec!["eager__tool", "lazy__tool"]);
     }
 
+    /// Deferring is about the request's tool array alone: the router and the
+    /// name enumerator must still find the tool.
     #[test]
     fn extend_tools_defers_behind_tool_search_by_default() {
         let (_inner, handle) = setup(vec![fake_entry("srv", FakeTransport::new())]);
@@ -1455,7 +1508,17 @@ mod tests {
         assert_eq!(tool_names(&tools), vec![TOOL_SEARCH_TOOL_NAME]);
         let catalog = tools[0]["description"].as_str().unwrap();
         assert!(catalog.contains("srv: tool"), "catalog groups by server");
-        assert!(handle.has_tool(TOOL_NAME), "deferred tools stay callable");
+        assert!(handle.resolve(TOOL_NAME).is_some());
+        assert_eq!(handle.wire_names(), vec![WIRE_TOOL_NAME]);
+    }
+
+    #[test_case(TOOL_NAME, Some(TOOL_NAME) ; "internal_name")]
+    #[test_case(WIRE_TOOL_NAME, Some(TOOL_NAME) ; "wire_name")]
+    #[test_case("read", None ; "native_name")]
+    #[test_case("gone__tool", None ; "unpublished_server")]
+    fn resolve_maps_published_names_only(name: &str, expected: Option<&str>) {
+        let (_inner, handle) = setup(vec![fake_entry("srv", FakeTransport::new())]);
+        assert_eq!(handle.resolve(name).as_deref(), expected);
     }
 
     #[test]
@@ -1475,7 +1538,7 @@ mod tests {
     #[test]
     fn search_loads_tools_into_next_extend() {
         let (_inner, handle) = setup(vec![fake_entry("srv", FakeTransport::new())]);
-        let result = handle.search_tools("TOOL").unwrap();
+        let result = handle.search_tools("TOOL", CallOrigin::Model).unwrap();
         assert!(result.contains(WIRE_TOOL_NAME), "got: {result}");
 
         let mut tools = json!([]);
@@ -1486,7 +1549,9 @@ mod tests {
     #[test]
     fn search_reports_no_match_without_loading() {
         let (_inner, handle) = setup(vec![fake_entry("srv", FakeTransport::new())]);
-        let result = handle.search_tools("nonexistent-capability").unwrap();
+        let result = handle
+            .search_tools("nonexistent-capability", CallOrigin::Model)
+            .unwrap();
         assert!(result.contains(SEARCH_NO_MATCH), "got: {result}");
         let mut tools = json!([]);
         handle.extend_tools(&mut tools);
@@ -1507,7 +1572,7 @@ mod tests {
             .collect();
         let (_inner, handle) = setup(vec![entry]);
 
-        let result = handle.search_tools("tool").unwrap();
+        let result = handle.search_tools("tool", CallOrigin::Model).unwrap();
         let expected = format!(
             "{SEARCH_OVERFLOW_PREFIX}`srv__tool-{}`, `srv__tool-{}`",
             MAX_SEARCH_LOADS,
@@ -1547,7 +1612,7 @@ mod tests {
         let (_inner, handle) = setup(vec![entry_with_tools("srv", tools)]);
         // Alphabetical tie-break alone would leave the last tool in overflow.
         let last = format!("{prefix}{MAX_SEARCH_LOADS}");
-        let result = handle.search_tools(&last).unwrap();
+        let result = handle.search_tools(&last, CallOrigin::Model).unwrap();
         let overflow = result
             .lines()
             .find(|l| l.starts_with(SEARCH_OVERFLOW_PREFIX))
@@ -1566,7 +1631,7 @@ mod tests {
             tool_def("srv", "create_issue", "Open a ticket", json!({})),
         ];
         let (_inner, handle) = setup(vec![entry_with_tools("srv", tools)]);
-        let result = handle.search_tools("issue").unwrap();
+        let result = handle.search_tools("issue", CallOrigin::Model).unwrap();
         let pos = |name: &str| {
             result
                 .find(name)
@@ -1587,7 +1652,9 @@ mod tests {
             json!({}),
         )];
         let (_inner, handle) = setup(vec![entry_with_tools("srv", tools)]);
-        let result = handle.search_tools("pull request").unwrap();
+        let result = handle
+            .search_tools("pull request", CallOrigin::Model)
+            .unwrap();
         assert!(result.contains("srv__create_pr"), "got: {result}");
     }
 
@@ -1596,7 +1663,7 @@ mod tests {
         let schema = json!({"type": "object", "properties": {"labels": {"type": "array"}}});
         let tools = vec![tool_def("srv", "update", "Update a thing", schema)];
         let (_inner, handle) = setup(vec![entry_with_tools("srv", tools)]);
-        let result = handle.search_tools("labels").unwrap();
+        let result = handle.search_tools("labels", CallOrigin::Model).unwrap();
         assert!(result.contains("srv__update"), "got: {result}");
     }
 
@@ -1641,8 +1708,8 @@ mod tests {
             tool_def("srv", "gamma", "", json!({})),
         ];
         let (_inner, handle) = setup_with_defer(vec![entry_with_tools("srv", defs)], 2);
-        handle.mark_loaded("srv.alpha");
-        handle.mark_loaded("srv.beta");
+        handle.mark_loaded("srv.alpha", CallOrigin::Model);
+        handle.mark_loaded("srv.beta", CallOrigin::Model);
         let mut tools = json!([]);
         handle.extend_tools(&mut tools);
         let names = tool_names(&tools);
@@ -1664,7 +1731,7 @@ mod tests {
     #[test]
     fn mark_loaded_declares_tool_and_drops_empty_catalog() {
         let (_inner, handle) = setup(vec![fake_entry("srv", FakeTransport::new())]);
-        handle.mark_loaded(TOOL_NAME);
+        handle.mark_loaded(TOOL_NAME, CallOrigin::Model);
         let mut tools = json!([]);
         handle.extend_tools(&mut tools);
         assert_eq!(
@@ -1672,6 +1739,16 @@ mod tests {
             vec![WIRE_TOOL_NAME],
             "loaded tool must be declared; an empty catalog must not be advertised"
         );
+    }
+
+    /// A nested search loads nothing, so the names it reports are callable
+    /// right away and never "from your next message".
+    #[test]
+    fn nested_search_names_matches_without_promising_a_next_request() {
+        let (_inner, handle) = setup(vec![fake_entry("srv", FakeTransport::new())]);
+        let result = handle.search_tools("tool", CallOrigin::Nested).unwrap();
+        assert!(result.contains(WIRE_TOOL_NAME), "got: {result}");
+        assert!(!result.contains(SEARCH_HEADER_MODEL.0), "got: {result}");
     }
 
     #[test]
@@ -1716,7 +1793,7 @@ mod tests {
     #[test]
     fn search_ignores_always_load_tools() {
         let (_inner, handle) = setup(vec![always_load_entry("eager", FakeTransport::new())]);
-        let result = handle.search_tools("tool").unwrap();
+        let result = handle.search_tools("tool", CallOrigin::Model).unwrap();
         assert!(
             result.contains(SEARCH_NO_MATCH),
             "always_load tools are already declared: {result}"
@@ -1727,7 +1804,7 @@ mod tests {
     fn search_loads_stay_scoped_to_their_session() {
         let (_inner, session_a) = setup(vec![fake_entry("srv", FakeTransport::new())]);
         let session_b = session_a.fresh();
-        session_a.search_tools("tool").unwrap();
+        session_a.search_tools("tool", CallOrigin::Model).unwrap();
 
         let mut tools_a = json!([]);
         session_a.extend_tools(&mut tools_a);
@@ -1812,7 +1889,7 @@ mod tests {
             let t = FakeTransport::new();
             let (mut inner, handle) = setup(vec![fake_entry("srv", Arc::clone(&t) as _)]);
 
-            assert!(handle.has_tool(TOOL_NAME));
+            assert!(handle.resolve(TOOL_NAME).is_some());
             let mut tools = json!([]);
             handle.extend_tools(&mut tools);
             assert_eq!(tools[0]["name"], TOOL_SEARCH_TOOL_NAME);
@@ -1825,7 +1902,7 @@ mod tests {
             assert!(entry.tools.is_empty());
             assert!(entry.transport.is_none());
             assert_eq!(entry.status, McpServerStatus::Disabled);
-            assert!(!handle.has_tool(TOOL_NAME));
+            assert!(handle.resolve(TOOL_NAME).is_none());
             let mut tools = json!([]);
             handle.extend_tools(&mut tools);
             assert!(tools.as_array().unwrap().is_empty());

--- a/maki-agent/src/tools/interpreter_bridge.rs
+++ b/maki-agent/src/tools/interpreter_bridge.rs
@@ -1,24 +1,15 @@
 use serde_json::Value;
 
-use crate::agent::tool_dispatch::{self, Emit};
+use crate::agent::tool_dispatch;
 
-use super::ToolContext;
+use super::{CallOrigin, ToolContext};
 
 pub const IMAGE_NOT_VISIBLE_NOTE: &str =
     "image pixels are not visible from here; call the view_image tool directly";
 
 pub async fn dispatch(ctx: &ToolContext, name: &str, input: &Value) -> Result<String, String> {
     ctx.deadline.check()?;
-    let done = tool_dispatch::run(
-        &ctx.registry,
-        ctx.mcp.as_ref(),
-        String::new(),
-        name,
-        input,
-        ctx,
-        Emit::Silent,
-    )
-    .await;
+    let done = tool_dispatch::run(String::new(), name, input, ctx, CallOrigin::Nested).await;
     flatten(&done)
 }
 

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -40,10 +40,30 @@ use maki_providers::RequestOptions;
 use maki_providers::provider::Provider;
 use maki_storage::id::SessionRef;
 
+/// Who made a tool call. A resumed session rebuilds its state from the `ToolUse`
+/// blocks in history, and those hold the model's own calls only, so a nested
+/// call must never change what the next request carries.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CallOrigin {
+    /// Emitted by the model and recorded in history under its own id.
+    Model,
+    /// Made on the model's behalf and invisible to history: batch children,
+    /// `code_execution` scripts, Lua `call_tool`.
+    Nested,
+}
+
+impl CallOrigin {
+    pub fn is_model(self) -> bool {
+        matches!(self, Self::Model)
+    }
+}
+
 pub struct DescriptionContext<'a> {
     pub filter: &'a ToolFilter,
     pub audience: ToolAudience,
     pub workflow: bool,
+    /// Whether the session being described can reach MCP tools.
+    pub mcp: bool,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -187,15 +207,28 @@ pub fn timeout_annotation(secs: u64) -> String {
 
 pub type LocalToolResult = BoxFuture<'static, Result<String, String>>;
 pub type LocalToolFn = Arc<dyn Fn(Value, ToolContext) -> LocalToolResult + Send + Sync>;
-pub type LocalTools = Arc<HashMap<String, LocalToolFn>>;
+pub type LocalTools = Arc<HashMap<String, LocalTool>>;
 
-/// Coerces a closure into a [`LocalToolFn`]; the bound gives the boxed
+/// A tool the session's host supplies: an ACP client tool, a subagent's
+/// `structured_output`. Dispatch puts it ahead of the registry, so it carries
+/// its own audience: a host tool must not reach a sandbox by wearing the name
+/// of a registry tool that may.
+#[derive(Clone)]
+pub struct LocalTool {
+    pub handler: LocalToolFn,
+    pub audience: ToolAudience,
+}
+
+/// Coerces a closure into a [`LocalTool`]; the bound gives the boxed
 /// future a coercion target that `Arc::new` alone does not.
-pub fn local_tool<F>(f: F) -> LocalToolFn
+pub fn local_tool<F>(audience: ToolAudience, f: F) -> LocalTool
 where
     F: Fn(Value, ToolContext) -> LocalToolResult + Send + Sync + 'static,
 {
-    Arc::new(f)
+    LocalTool {
+        handler: Arc::new(f),
+        audience,
+    }
 }
 
 #[derive(Clone)]
@@ -486,6 +519,52 @@ pub mod test_support {
     use super::*;
 
     pub const GUARDED_TOOL_NAME: &str = "guarded_mock";
+
+    /// Registry and routing tests care about the name and audience only, never
+    /// about what the tool returns.
+    pub fn mock_tool(name: &str, audience: ToolAudience) -> Arc<dyn registry::Tool> {
+        Arc::new(MockTool {
+            name: name.to_owned(),
+            audience,
+        })
+    }
+
+    struct MockTool {
+        name: String,
+        audience: ToolAudience,
+    }
+
+    struct MockInvocation;
+
+    impl registry::ToolInvocation for MockInvocation {
+        fn start_header(&self) -> registry::HeaderFuture {
+            registry::HeaderFuture::Ready(registry::HeaderResult::plain("mock".into()))
+        }
+        fn execute<'a>(self: Box<Self>, _ctx: &'a ToolContext) -> registry::ExecFuture<'a> {
+            Box::pin(async { Ok(ToolOutput::Plain(String::new().into())).into() })
+        }
+    }
+
+    impl registry::Tool for MockTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn description(&self, _ctx: &DescriptionContext) -> Cow<'_, str> {
+            "mock tool".into()
+        }
+        fn schema(&self) -> Value {
+            serde_json::json!({"type": "object", "properties": {}, "additionalProperties": false})
+        }
+        fn audience(&self) -> ToolAudience {
+            self.audience
+        }
+        fn parse(
+            &self,
+            _input: &Value,
+        ) -> Result<Box<dyn registry::ToolInvocation>, registry::ParseError> {
+            Ok(Box::new(MockInvocation))
+        }
+    }
 
     pub struct GuardedMock;
 

--- a/maki-agent/src/tools/registry.rs
+++ b/maki-agent/src/tools/registry.rs
@@ -25,6 +25,10 @@ bitflags! {
         const GENERAL_SUB  = 0b0000_0100;
         const INTERPRETER  = 0b0000_1000;
         const WORKFLOW     = 0b0001_0000;
+        /// Every audience a model speaks from, and none of the ones a sandbox
+        /// calls from: the default for a tool whose owner never opted into
+        /// being called by a script.
+        const MODEL = Self::MAIN.bits() | Self::RESEARCH_SUB.bits() | Self::GENERAL_SUB.bits();
     }
 }
 
@@ -514,49 +518,10 @@ mod tests {
     use crate::template::Vars;
     use test_case::test_case;
 
-    struct MockTool {
-        name: String,
-        audience: ToolAudience,
-    }
-
-    struct MockInvocation;
-
-    impl ToolInvocation for MockInvocation {
-        fn start_header(&self) -> HeaderFuture {
-            HeaderFuture::Ready(HeaderResult::plain("mock".into()))
-        }
-        fn execute<'a>(self: Box<Self>, _ctx: &'a super::ToolContext) -> ExecFuture<'a> {
-            Box::pin(async { Ok(ToolOutput::Plain(String::new().into())).into() })
-        }
-    }
-
-    impl Tool for MockTool {
-        fn name(&self) -> &str {
-            &self.name
-        }
-        fn description(&self, _ctx: &DescriptionContext) -> Cow<'_, str> {
-            "mock tool".into()
-        }
-        fn schema(&self) -> Value {
-            json!({"type": "object", "properties": {}, "additionalProperties": false})
-        }
-        fn audience(&self) -> ToolAudience {
-            self.audience
-        }
-        fn parse(&self, _input: &Value) -> Result<Box<dyn ToolInvocation>, ParseError> {
-            Ok(Box::new(MockInvocation))
-        }
-    }
+    use crate::tools::test_support::mock_tool;
 
     fn mock(name: &str) -> Arc<dyn Tool> {
-        mock_scoped(name, ToolAudience::all())
-    }
-
-    fn mock_scoped(name: &str, audience: ToolAudience) -> Arc<dyn Tool> {
-        Arc::new(MockTool {
-            name: name.to_owned(),
-            audience,
-        })
+        mock_tool(name, ToolAudience::all())
     }
 
     fn lua_source(plugin: &str) -> ToolSource {
@@ -591,6 +556,7 @@ mod tests {
             filter: &filter,
             audience: ToolAudience::MAIN,
             workflow: false,
+            mcp: false,
         };
         let vars = Vars::new();
         let defs = reg.definitions(&vars, &ctx, false);
@@ -742,7 +708,7 @@ mod tests {
     fn definitions_excludes_wrong_audience() {
         let reg = ToolRegistry::new();
         reg.register(
-            mock_scoped("main_only_tool", ToolAudience::MAIN),
+            mock_tool("main_only_tool", ToolAudience::MAIN),
             lua_source("p"),
         )
         .unwrap();
@@ -755,6 +721,7 @@ mod tests {
                 filter: &filter,
                 audience,
                 workflow: false,
+                mcp: false,
             };
             reg.definitions(&vars, &ctx, false)
                 .as_array()

--- a/maki-docgen/src/gen_tools.rs
+++ b/maki-docgen/src/gen_tools.rs
@@ -263,6 +263,7 @@ pub fn generate() -> String {
             filter: &ToolFilter::All,
             audience: ToolAudience::MAIN,
             workflow: false,
+            mcp: false,
         },
         false,
     );

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -8,13 +8,13 @@ use std::time::{Duration, Instant};
 
 use async_lock::Mutex as AsyncMutex;
 use futures::future::{Either, select};
-use maki_agent::agent::tool_dispatch::{self, Emit};
+use maki_agent::agent::tool_dispatch;
 use maki_agent::cancel::{CancelMap, CancelSlot};
 use maki_agent::tools::interpreter_bridge;
 use maki_agent::tools::registry::ToolRegistry;
 use maki_agent::tools::schema::sanitize_tool_input_schema;
 use maki_agent::tools::{
-    Deadline, DescriptionContext, FileReadTracker, LocalToolFn, LocalTools, ToolAudience,
+    CallOrigin, Deadline, DescriptionContext, FileReadTracker, LocalTool, LocalTools, ToolAudience,
     ToolContext, ToolFilter, ToolLive,
 };
 use maki_agent::{
@@ -31,6 +31,7 @@ use mlua::{Function, IntoLuaMulti, Lua, Result as LuaResult, Table, Value as Lua
 use serde_json::Value as JsonValue;
 use tracing::info;
 
+use crate::api::tool::{audiences_to_lua, parse_audience};
 use crate::api::ui::buf::BufHandle;
 use crate::api::util::convert::{json_to_lua, lua_to_json, lua_tool_result};
 use crate::api::util::ctx::{AgentContext, LuaCtx};
@@ -214,6 +215,9 @@ async fn system_prompt(
 ///   `except` (string[]?) - exclude these tool names.
 ///   `workflow` (boolean?) - use workflow-mode descriptions. Default: `false`.
 ///   `spec` (string?) - evaluate capability exclusions against this model spec.
+///   `mcp` (boolean?) - describe tools as if MCP is reachable. Default: `true`.
+///     Pass what you pass to `maki.agent.session()`. Otherwise the descriptions
+///     advertise MCP tools that the session has no way to call.
 /// @return (table?, string?) Array of tool definition tables, or `(nil, err)` on failure.
 /// @example
 /// local defs, err = maki.agent.tools(ctx, {
@@ -235,6 +239,7 @@ async fn tools(lua: Lua, ctx: mlua::UserDataRef<LuaCtx>, opts: Table) -> LuaResu
     let except: Option<Vec<String>> = opts.get("except")?;
     let workflow: bool = opts.get::<Option<bool>>("workflow")?.unwrap_or(false);
     let spec_str: Option<String> = opts.get("spec")?;
+    let mcp_enabled: bool = opts.get::<Option<bool>>("mcp")?.unwrap_or(true);
 
     let parsed = spec_str
         .as_deref()
@@ -261,12 +266,62 @@ async fn tools(lua: Lua, ctx: mlua::UserDataRef<LuaCtx>, opts: Table) -> LuaResu
         filter: &filter,
         audience,
         workflow,
+        mcp: mcp_enabled && agent.mcp.is_some(),
     };
     // Base definitions only: the session injects MCP definitions per
     // request, so baking them into a tools array would freeze the catalog.
     let defs = ToolRegistry::global().definitions(&vars, &ctx_desc, model.supports_tool_examples());
 
     Ok((Some(json_to_lua(&lua, &defs)?), None))
+}
+
+/// Every tool name this context can dispatch: registry tools, MCP tools
+/// (deferred ones included), host tools (ACP client tools, a subagent's
+/// `structured_output`) and `tool_search`. Reach for it when you expose tools
+/// inside a sandbox and need the names to bind. `maki.api.get_tools()` covers
+/// the registry alone and has no view of the session.
+///
+/// The list already accounts for this session's audience, the config's
+/// `disabled_tools` and the model's capabilities. Read `audiences` to layer
+/// your own policy on top. A sandbox wants `interpreter`.
+///
+/// Each name shows up once, described by the tool a call would really reach, so
+/// a host tool that shadows a registry name reports its own audience rather
+/// than the shadowed one's.
+///
+/// @param ctx LuaCtx Agent context.
+/// @return (table?, string?) Array of `{ name, alias?, source, audiences, schema? }`,
+///   or `(nil, err)` on failure. `source` is one of `"native"`, `"local"`,
+///   `"mcp"`. `alias` is a safe identifier to bind, set only when `name` is not
+///   one (say `srv__get-docs`). Dispatch `name` in every case. `schema` comes
+///   with registry tools only.
+/// @example
+/// local tools, err = maki.agent.callable_tools(ctx)
+/// if err then error(err) end
+/// for _, t in ipairs(tools) do
+///   print(t.source, t.alias or t.name)
+/// end
+#[lua_fn]
+async fn callable_tools(lua: Lua, ctx: mlua::UserDataRef<LuaCtx>) -> LuaResult<Pair<Table>> {
+    let agent = try_pair!(dispatch_ctx(&ctx, "callable_tools"));
+    let out = lua.create_table()?;
+    for (i, tool) in tool_dispatch::callable(&agent.to_tool_context())
+        .into_iter()
+        .enumerate()
+    {
+        let t = lua.create_table()?;
+        t.set("name", tool.name)?;
+        if let Some(alias) = tool.alias {
+            t.set("alias", alias)?;
+        }
+        t.set("source", tool.source)?;
+        t.set("audiences", audiences_to_lua(&lua, tool.audience)?)?;
+        if let Some(schema) = tool.schema {
+            t.set("schema", json_to_lua(&lua, &schema)?)?;
+        }
+        out.set(i + 1, t)?;
+    }
+    Ok((Some(out), None))
 }
 
 /// Run a tool by name and wait for the result. This is how you call built-in
@@ -360,7 +415,9 @@ async fn call_tool(
 ///   `local_tools` (table?) - map of `name -> spec` for Lua-backed tools. Each spec
 ///     requires `description` (string), `input_schema` (table), and
 ///     `handler` (function). The handler receives the input table and must return
-///     `(string)` or `(nil, err)`.
+///     `(string)` or `(nil, err)`. Optional `audiences` (string[]) gates who may
+///     call it, the same way `maki.api.register_tool` does. The default is the
+///     model alone, so a script cannot reach it through `code_execution`.
 ///   `name` (string?) - display name for logs and UI.
 ///   `audience` (string?) - tool audience for capability gating. Default: `"general_sub"`.
 ///   `mcp` (boolean?) - give the session access to MCP tools. Their
@@ -436,7 +493,7 @@ async fn session(
         None => JsonValue::Array(vec![]),
     };
 
-    let mut local_map: HashMap<String, LocalToolFn> = HashMap::new();
+    let mut local_map: HashMap<String, LocalTool> = HashMap::new();
     if let Some(tbl) = local_tools_tbl {
         let defs = tools_json.as_array_mut().expect("checked above");
         for pair in tbl.pairs::<String, Table>() {
@@ -456,10 +513,12 @@ async fn session(
                 "description": description,
                 "input_schema": sanitized_schema,
             }));
+            let audience =
+                parse_audience(spec.get::<Option<Table>>("audiences")?, ToolAudience::MODEL)?;
             let weak = lua.weak();
             local_map.insert(
                 name,
-                maki_agent::tools::local_tool(move |input, _ctx| {
+                maki_agent::tools::local_tool(audience, move |input, _ctx| {
                     let result = call_local_tool(&weak, &handler, &input);
                     Box::pin(async move { result })
                 }),
@@ -592,7 +651,7 @@ lua_table! {
     /// sess:close()
     /// ```
     "maki.agent" => pub(crate) fn create_agent_table(), DOCS [
-        resolve_model, system_prompt, tools, call_tool, session,
+        resolve_model, system_prompt, tools, callable_tools, call_tool, session,
     ]
 }
 
@@ -635,15 +694,7 @@ async fn dispatch_racing_live(
     rx: Option<flume::Receiver<ToolLive>>,
     cbs: &LiveCallbacks<'_>,
 ) -> ToolDoneEvent {
-    let run = tool_dispatch::run(
-        &tctx.registry,
-        tctx.mcp.as_ref(),
-        String::new(),
-        name,
-        input,
-        tctx,
-        Emit::Silent,
-    );
+    let run = tool_dispatch::run(String::new(), name, input, tctx, CallOrigin::Nested);
     let Some(rx) = rx else {
         return run.await;
     };

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -86,6 +86,7 @@ fn dctx_json(ctx: &DescriptionContext) -> Value {
     let mut obj = json!({
         "audience": ctx.audience.name().unwrap_or("main"),
         "workflow": ctx.workflow,
+        "mcp": ctx.mcp,
     });
     match ctx.filter {
         ToolFilter::All => {}
@@ -1019,18 +1020,21 @@ pub(crate) fn create_api_table(
     Ok(t)
 }
 
-fn tool_entry_to_lua(lua: &Lua, entry: &RegisteredTool) -> LuaResult<Table> {
-    let audience = entry.tool.audience();
-    let audiences = lua.create_table()?;
+pub(crate) fn audiences_to_lua(lua: &Lua, audience: ToolAudience) -> LuaResult<Table> {
+    let out = lua.create_table()?;
     for (flag, name) in maki_agent::tools::registry::AUDIENCE_NAMES {
         if audience.contains(*flag) {
-            audiences.push(*name)?;
+            out.push(*name)?;
         }
     }
+    Ok(out)
+}
+
+fn tool_entry_to_lua(lua: &Lua, entry: &RegisteredTool) -> LuaResult<Table> {
     let t = lua.create_table()?;
     t.set("name", entry.name())?;
     t.set("schema", json_to_lua(lua, &entry.tool.schema())?)?;
-    t.set("audiences", audiences)?;
+    t.set("audiences", audiences_to_lua(lua, entry.tool.audience())?)?;
     if let Some(kind) = entry.tool.tool_kind() {
         t.set("kind", kind)?;
     }
@@ -1150,9 +1154,12 @@ fn is_valid_tool_name(name: &str) -> bool {
     chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
-fn parse_audience(audiences: Option<mlua::Table>) -> LuaResult<ToolAudience> {
+pub(crate) fn parse_audience(
+    audiences: Option<mlua::Table>,
+    default: ToolAudience,
+) -> LuaResult<ToolAudience> {
     let Some(arr) = audiences else {
-        return Ok(ToolAudience::default());
+        return Ok(default);
     };
     let mut flags = ToolAudience::empty();
     let mut count = 0;
@@ -1295,7 +1302,7 @@ fn register_tool_from_lua(lua: &Lua, spec: &Table, pending: PendingTools) -> Lua
         .get::<String>("kind")
         .ok()
         .map(|s| Arc::from(s.as_str()));
-    let audience = parse_audience(audiences)?;
+    let audience = parse_audience(audiences, ToolAudience::default())?;
     let timeout = parse_timeout(spec)?;
     let start_annotation = parse_start_annotation(spec, &schema_val)?;
     let handler_key: RegistryKey = lua.create_registry_value(handler)?;
@@ -1710,6 +1717,7 @@ mod tests {
             filter: &ToolFilter::All,
             audience: ToolAudience::MAIN,
             workflow: false,
+            mcp: false,
         };
         assert_eq!(tool.description(&ctx), "test");
     }

--- a/maki-lua/src/api/util/ctx.rs
+++ b/maki-lua/src/api/util/ctx.rs
@@ -5,9 +5,7 @@ use std::time::{Duration, Instant};
 
 use maki_agent::agent::LoadedInstructions;
 use maki_agent::cancel::CancelToken;
-use maki_agent::tools::{
-    Deadline, FileReadTracker, LocalTools, ToolAudience, ToolContext, ToolLive,
-};
+use maki_agent::tools::{Deadline, FileReadTracker, ToolAudience, ToolContext, ToolLive};
 use maki_config::{AgentConfig, ToolOutputLines};
 use maki_storage::id::SessionRef;
 use mlua::{LuaSerdeExt, MultiValue, UserData, UserDataMethods, Value as LuaValue};
@@ -42,6 +40,11 @@ fn send_live_buf(lua: &mlua::Lua, buf: &mlua::AnyUserData) -> mlua::Result<()> {
 
 /// Captured snapshot of the parent `ToolContext`. Per-call state (deadline,
 /// instructions, output lines) is reset so child calls start clean.
+///
+/// Routing state is kept verbatim, `local_tools` included: a name a Lua tool
+/// dispatches must land where the same name lands when the model calls it, or
+/// shadowing quietly inverts for nested calls. A child session does not inherit
+/// them anyway, `session()` always sets its own.
 #[derive(Clone)]
 pub(crate) struct AgentContext(ToolContext);
 
@@ -51,7 +54,6 @@ impl From<&ToolContext> for AgentContext {
         c.loaded_instructions = LoadedInstructions::new();
         c.deadline = Deadline::None;
         c.tool_output_lines = ToolOutputLines::default();
-        c.local_tools = LocalTools::default();
         Self(c)
     }
 }
@@ -402,8 +404,8 @@ mod tests {
     use std::collections::HashMap;
 
     use maki_agent::AgentMode;
-    use maki_agent::tools::LocalToolFn;
     use maki_agent::tools::test_support::stub_ctx_with;
+    use maki_agent::tools::{LocalTool, ToolAudience};
 
     use super::*;
 
@@ -429,10 +431,12 @@ mod tests {
             !ctx.loaded_instructions
                 .contains_or_insert(PathBuf::from(INSTRUCTION_PATH))
         );
-        let mut tools: HashMap<String, LocalToolFn> = HashMap::new();
+        let mut tools: HashMap<String, LocalTool> = HashMap::new();
         tools.insert(
             LOCAL_TOOL_NAME.into(),
-            maki_agent::tools::local_tool(|_, _| Box::pin(async { Ok(String::new()) })),
+            maki_agent::tools::local_tool(ToolAudience::MODEL, |_, _| {
+                Box::pin(async { Ok(String::new()) })
+            }),
         );
         ctx.local_tools = Arc::new(tools);
         ctx.live_sink = Some(flume::unbounded().0);
@@ -450,7 +454,10 @@ mod tests {
         );
         assert!(matches!(agent.deadline, Deadline::None));
         assert_eq!(agent.tool_output_lines, ToolOutputLines::default());
-        assert!(agent.local_tools.is_empty());
+        assert!(
+            agent.local_tools.contains_key(LOCAL_TOOL_NAME),
+            "a nested call must route names exactly like the model's own call"
+        );
         assert!(
             !agent
                 .loaded_instructions

--- a/maki-lua/tests/code_execution_policy.rs
+++ b/maki-lua/tests/code_execution_policy.rs
@@ -2,11 +2,15 @@
 //! gates both `describe` text and the handler's fn-map, so what the model
 //! sees is exactly what the interpreter can call.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use maki_agent::AgentMode;
+use maki_agent::mcp::test_support::stub_session;
 use maki_agent::tools::test_support::stub_ctx;
-use maki_agent::tools::{DescriptionContext, ToolAudience, ToolContext, ToolFilter, ToolRegistry};
+use maki_agent::tools::{
+    DescriptionContext, ToolAudience, ToolContext, ToolFilter, ToolRegistry, local_tool,
+};
 use maki_lua::PluginHost;
 
 const CODE_EXECUTION_SRC: &str = include_str!("../../plugins/code_execution/init.lua");
@@ -20,6 +24,22 @@ const WORKFLOW_NOTE_SUBSTR: &str = "Workflow mode: orchestrate subagents";
 const INTERP_ECHO_SIG: &str = "- interp_echo(msg: str, count: int = None, flag: bool = None, items: list = None, raw: any = None) -> str";
 const WF_TASK_SIG: &str = "- wf_task(prompt: str, model_tier: str = None) -> str";
 const SUB_TOOL_SIG: &str = "- sub_tool() -> str";
+const MCP_NOTE_SUBSTR: &str = "MCP tools are callable too";
+const MCP_TOOL_QUALIFIED: &str = "srv.fetch_issue";
+const MCP_TOOL_WIRE: &str = "srv__fetch_issue";
+/// Servers publish names Python cannot spell; the sandbox binds the alias.
+const HYPHEN_QUALIFIED: &str = "srv.get-docs";
+const HYPHEN_ALIAS: &str = "srv__get_docs";
+/// The stub transport fails every request with this, so seeing it proves the
+/// call reached MCP instead of dying at name lookup.
+const MCP_REACHED_ERR: &str = "unknown MCP tool";
+const NAME_ERROR: &str = "NameError";
+const CODE_EXECUTION: &str = "code_execution";
+const TOOLS_MCP_PROBE: &str = "tools_mcp_probe";
+/// Stands in for an ACP client tool: dispatched from the context, not the
+/// registry.
+const CLIENT_TOOL: &str = "client_probe";
+const CLIENT_TOOL_OUT: &str = "client ran";
 
 fn fixture_plugin() -> String {
     format!(
@@ -63,6 +83,25 @@ maki.api.register_tool({{
     handler = function() return {{ llm_output = "{FAIL_MSG}", is_error = true }} end,
 }})
 maki.api.register_tool({{
+    name = "{TOOLS_MCP_PROBE}",
+    description = "returns the code_execution description agent.tools built",
+    audiences = {{ "main" }},
+    schema = {{
+        type = "object",
+        required = {{ "mcp" }},
+        properties = {{ mcp = {{ type = "boolean" }} }},
+        additionalProperties = false,
+    }},
+    handler = function(input, ctx)
+        local defs, err = maki.agent.tools(ctx, {{ audience = "main", mcp = input.mcp }})
+        if err then return {{ llm_output = err, is_error = true }} end
+        for _, d in ipairs(defs) do
+            if d.name == "{CODE_EXECUTION}" then return d.description end
+        end
+        return {{ llm_output = "{CODE_EXECUTION} missing", is_error = true }}
+    end,
+}})
+maki.api.register_tool({{
     name = "sub_tool",
     description = "subagent fixture",
     audiences = {{ "general_sub", "interpreter" }},
@@ -86,9 +125,9 @@ fn setup() -> (Arc<ToolRegistry>, PluginHost) {
     setup_with(Arc::new(ToolRegistry::new()))
 }
 
-/// Uses the global native registry because `interpreter_bridge::dispatch` does.
-/// Safe: nextest runs each test in its own process.
-fn setup_native() -> (Arc<ToolRegistry>, PluginHost) {
+/// `maki.agent.tools` describes the process-wide registry, so the fixtures have
+/// to land there. Safe: nextest runs each test in its own process.
+fn setup_global() -> (Arc<ToolRegistry>, PluginHost) {
     setup_with(Arc::clone(ToolRegistry::global_arc()))
 }
 
@@ -98,25 +137,26 @@ fn describe(
     audience: ToolAudience,
     workflow: bool,
 ) -> String {
-    reg.get("code_execution")
+    reg.get(CODE_EXECUTION)
         .expect("code_execution registered")
         .tool
         .description(&DescriptionContext {
             filter,
             audience,
             workflow,
+            mcp: false,
         })
         .into_owned()
 }
 
-fn exec_code(reg: &ToolRegistry, ctx: &ToolContext, code: &str) -> Result<String, String> {
-    let entry = reg
-        .get("code_execution")
-        .expect("code_execution registered");
-    let inv = entry
-        .tool
-        .parse(&serde_json::json!({ "code": code, "timeout": 10 }))
-        .expect("parse failed");
+fn run_tool(
+    reg: &ToolRegistry,
+    ctx: &ToolContext,
+    name: &str,
+    input: serde_json::Value,
+) -> Result<String, String> {
+    let entry = reg.get(name).unwrap_or_else(|| panic!("{name} registered"));
+    let inv = entry.tool.parse(&input).expect("parse failed");
     smol::block_on(async { inv.execute(ctx).await })
         .output
         .map(|out| match out {
@@ -125,16 +165,31 @@ fn exec_code(reg: &ToolRegistry, ctx: &ToolContext, code: &str) -> Result<String
         })
 }
 
-fn run_code_in(code: &str, workflow: bool) -> Result<String, String> {
-    let (reg, _host) = setup_native();
+fn exec_code(reg: &ToolRegistry, ctx: &ToolContext, code: &str) -> Result<String, String> {
+    run_tool(
+        reg,
+        ctx,
+        CODE_EXECUTION,
+        serde_json::json!({ "code": code, "timeout": 10 }),
+    )
+}
+
+/// One seam for every scenario: `shape` sets whatever the case is about
+/// (audience, workflow, MCP, host tools) on an otherwise stock context.
+fn shaped_ctx(reg: &Arc<ToolRegistry>, shape: impl FnOnce(&mut ToolContext)) -> ToolContext {
     let mut ctx = stub_ctx(&AgentMode::Build);
-    ctx.registry = Arc::clone(&reg);
-    ctx.workflow = workflow;
-    exec_code(&reg, &ctx, code)
+    ctx.registry = Arc::clone(reg);
+    shape(&mut ctx);
+    ctx
+}
+
+fn run_code_with(code: &str, shape: impl FnOnce(&mut ToolContext)) -> Result<String, String> {
+    let (reg, _host) = setup();
+    exec_code(&reg, &shaped_ctx(&reg, shape), code)
 }
 
 fn run_code(code: &str) -> Result<String, String> {
-    run_code_in(code, false)
+    run_code_with(code, |_| {})
 }
 
 #[test]
@@ -240,9 +295,73 @@ fn workflow_tool_not_callable_when_workflow_false() {
 /// audience/workflow reads, leaving workflow tools uncallable.
 #[test]
 fn workflow_tool_callable_when_workflow_true() {
-    let out = run_code_in("result = await wf_task(prompt='x')\nprint(result)", true)
-        .expect("workflow tool must be callable when workflow=true");
+    let out = run_code_with("result = await wf_task(prompt='x')\nprint(result)", |ctx| {
+        ctx.workflow = true
+    })
+    .expect("workflow tool must be callable when workflow=true");
     assert!(out.contains(&format!("{TASK_PREFIX}x")), "got: {out}");
+}
+
+// --- context tools (MCP, client tools) ---
+
+fn with_mcp(qualified: &'static str) -> impl FnOnce(&mut ToolContext) {
+    move |ctx| ctx.mcp = Some(stub_session(&[(qualified, "")]))
+}
+
+/// A caller that drops MCP for a subagent must not hand it a description
+/// promising MCP tools that subagent cannot call.
+#[test_case::test_case(true ; "session_keeps_mcp")]
+#[test_case::test_case(false ; "session_drops_mcp")]
+fn agent_tools_describes_mcp_only_when_the_session_keeps_it(enabled: bool) {
+    let (reg, _host) = setup_global();
+    let ctx = shaped_ctx(&reg, with_mcp(MCP_TOOL_QUALIFIED));
+    let desc = run_tool(
+        &reg,
+        &ctx,
+        TOOLS_MCP_PROBE,
+        serde_json::json!({ "mcp": enabled }),
+    )
+    .expect("probe must describe code_execution");
+    assert_eq!(desc.contains(MCP_NOTE_SUBSTR), enabled, "got: {desc}");
+}
+
+/// The stub leaves the tool deferred, so binding it means reading the MCP index
+/// rather than the request's tool array.
+#[test_case::test_case(MCP_TOOL_QUALIFIED, MCP_TOOL_WIRE ; "deferred_tool_binds_its_wire_name")]
+#[test_case::test_case(HYPHEN_QUALIFIED, HYPHEN_ALIAS    ; "hyphenated_tool_binds_an_alias")]
+fn mcp_tool_is_callable_from_the_sandbox(qualified: &'static str, bound: &str) {
+    let err = run_code_with(&format!("await {bound}()"), with_mcp(qualified))
+        .expect_err("the stub transport fails every call");
+    assert!(err.contains(MCP_REACHED_ERR), "got: {err}");
+}
+
+fn with_client_tool(audience: ToolAudience) -> impl FnOnce(&mut ToolContext) {
+    let tool = local_tool(audience, |_, _| {
+        Box::pin(async { Ok(CLIENT_TOOL_OUT.to_owned()) })
+    });
+    move |ctx| ctx.local_tools = Arc::new(HashMap::from([(CLIENT_TOOL.to_owned(), tool)]))
+}
+
+#[test]
+fn client_tool_is_callable_when_it_admits_the_interpreter() {
+    let out = run_code_with(
+        &format!("print(await {CLIENT_TOOL}())"),
+        with_client_tool(ToolAudience::MAIN | ToolAudience::INTERPRETER),
+    )
+    .expect("a client tool the interpreter may call must be callable");
+    assert!(out.contains(CLIENT_TOOL_OUT), "got: {out}");
+}
+
+/// `MODEL` is what a host tool gets when nobody opted it in, and a subagent's
+/// `structured_output` rides on that default.
+#[test]
+fn model_only_client_tool_stays_out_of_the_sandbox() {
+    let err = run_code_with(
+        &format!("await {CLIENT_TOOL}()"),
+        with_client_tool(ToolAudience::MODEL),
+    )
+    .expect_err("a model-only host tool must not be bound at all");
+    assert!(err.contains(NAME_ERROR), "got: {err}");
 }
 
 // --- script rendering ---
@@ -339,7 +458,7 @@ fn final_body_text(rx: &flume::Receiver<maki_agent::Envelope>) -> String {
 /// Some call paths skip `start`, so `handler` must render the script itself.
 #[test]
 fn handler_renders_script_when_start_never_ran() {
-    let (reg, _host) = setup_native();
+    let (reg, _host) = setup();
     let inv = parse_code(&reg, "print('hi')");
     let (ctx, rx) = event_ctx(&reg);
     smol::block_on(inv.execute(&ctx))
@@ -366,7 +485,7 @@ fn start_preview_renders_single_line(code: &str) {
 
 #[test]
 fn handler_error_keeps_script_and_drops_waiting_notice() {
-    let (reg, _host) = setup_native();
+    let (reg, _host) = setup();
     let inv = parse_code(&reg, "print(boom_undefined)");
     let (ctx, rx) = event_ctx(&reg);
     let err = smol::block_on(inv.execute(&ctx))

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -301,6 +301,7 @@ impl AgentLoop {
             filter: &filter,
             audience: ToolAudience::MAIN,
             workflow,
+            mcp: self.mcp.is_some(),
         };
         ToolRegistry::global().definitions(&self.vars, &ctx, examples)
     }

--- a/plugins/code_execution/init.lua
+++ b/plugins/code_execution/init.lua
@@ -48,9 +48,17 @@ async def gather(*calls):
             results.append('%s' + str(e))
     return results
 ]]):format(ERROR_PREFIX)
-local TOOLS_HEADER = "\n\nAvailable tools (called as Python functions with keyword arguments):\n"
+local TOOLS_HEADER = "\n\nAvailable tools (async Python functions, keyword args only):\n"
 local WORKFLOW_TOOLS_NOTE =
   "\nWorkflow mode: orchestrate subagents from this script. Await every `task(...)` call and use `gather(task(...), task(...))` for parallel fan-out. Pass `output_schema` to task for machine-readable results (a JSON string, parse with `json.loads`).\n"
+-- MCP names and schemas already sit in the tool array (or the tool_search
+-- catalog), so point at those instead of repeating them here.
+local MCP_NOTE =
+  "\nMCP tools are callable too, with the arguments their definitions declare. Hyphens become underscores (`srv__get-docs` is `srv__get_docs`).\n"
+local CALLABLE_TOOLS_ERR = "cannot list callable tools: "
+-- `alias` covers hyphens; what is left is a name no substitution can fix, like
+-- a leading digit. Binding it would raise a SyntaxError the model cannot act on.
+local PY_IDENTIFIER = "^[%a_][%w_]*$"
 local PY_TYPES = { string = "str", integer = "int", boolean = "bool", array = "list" }
 
 local opts = maki.api.register_options(output_limits.extend({
@@ -110,7 +118,7 @@ local function build_body(ctx, code)
   return buf, view, highlight
 end
 
-local description = [[Execute Python code in a sandboxed interpreter with tools as callable functions.
+local description = [[Execute Python in a sandbox where every tool is an async function.
 
 Use for chained/dependent tool calls and filtering/processing results, e.g. filtering web tool output. **DRAMATICALLY** cheaper than sequential tool calls!
 
@@ -130,7 +138,7 @@ local schema = {
   properties = {
     code = {
       type = "string",
-      description = "Python code to execute. Tools are async functions that return strings (not objects). You MUST await every call: `result = await read(path='/file', offset=1, limit=0)`. Use `await gather(...)` for concurrency.",
+      description = "Python code. Tools return strings, not objects, and you MUST await every call: `result = await read(path='/file', offset=1, limit=0)`.",
     },
     timeout = {
       type = "integer",
@@ -167,7 +175,7 @@ local function interpreter_tools(tools, audience, workflow)
     for _, a in ipairs(t.audiences) do
       aud[a] = true
     end
-    if t.enabled and aud[audience] and (aud.interpreter or (workflow and aud.workflow)) then
+    if aud[audience] and (aud.interpreter or (workflow and aud.workflow)) then
       t.workflow_only = not aud.interpreter
       out[#out + 1] = t
     end
@@ -233,6 +241,9 @@ local function describe(dctx)
   if has_workflow_only then
     parts[#parts + 1] = WORKFLOW_TOOLS_NOTE
   end
+  if dctx.mcp then
+    parts[#parts + 1] = MCP_NOTE
+  end
   return table.concat(parts)
 end
 
@@ -246,7 +257,6 @@ local function start(input, ctx)
 end
 
 local function handler(input, ctx)
-  local config = ctx:config()
   local timeout = input.timeout or opts.timeout_secs
 
   local buf, view, highlight = build_body(ctx, input.code)
@@ -283,12 +293,22 @@ local function handler(input, ctx)
     ctx:finish(cut(reason))
   end)
 
+  -- Registry, MCP and host tools in one list, already filtered by
+  -- `disabled_tools`, each entry carrying the audience of the tool a call to
+  -- that name would really reach.
+  local callable, callable_err = maki.agent.callable_tools(ctx)
+  if callable_err then
+    return { llm_output = CALLABLE_TOOLS_ERR .. callable_err, is_error = true }
+  end
+
   local tools = {}
-  for _, t in ipairs(interpreter_tools(maki.api.get_tools({ config = config }), ctx:audience(), ctx:workflow())) do
-    local name = t.name
-    local call_opts = t.workflow_only and {} or { timeout = timeout }
-    tools[name] = function(tool_input)
-      return maki.agent.call_tool(ctx, name, tool_input, call_opts)
+  for _, t in ipairs(interpreter_tools(callable, ctx:audience(), ctx:workflow())) do
+    local bind, name = t.alias or t.name, t.name
+    if bind:match(PY_IDENTIFIER) then
+      local call_opts = t.workflow_only and {} or { timeout = timeout }
+      tools[bind] = function(tool_input)
+        return maki.agent.call_tool(ctx, name, tool_input, call_opts)
+      end
     end
   end
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -847,6 +847,9 @@ available.
   - `except` (`string[]?`) exclude these tool names.
   - `workflow` (`boolean?`) use workflow-mode descriptions. Default: `false`.
   - `spec` (`string?`) evaluate capability exclusions against this model spec.
+  - `mcp` (`boolean?`) describe tools as if MCP is reachable. Default: `true`.
+    Pass what you pass to `maki.agent.session()`. Otherwise the descriptions
+    advertise MCP tools that the session has no way to call.
 
 **Returns:** (`table?`, `string?`) Array of tool definition tables, or `(nil, err)` on failure.
 
@@ -859,6 +862,48 @@ local defs, err = maki.agent.tools(ctx, {
 })
 if err then error(err) end
 print(#defs .. " tools available")
+```
+
+---
+
+### `maki.agent.callable_tools()` {#maki-agent-callable_tools}
+
+```lua
+maki.agent.callable_tools({ctx})
+```
+
+Every tool name this context can dispatch: registry tools, MCP tools
+(deferred ones included), host tools (ACP client tools, a subagent's
+`structured_output`) and `tool_search`. Reach for it when you expose tools
+inside a sandbox and need the names to bind. `maki.api.get_tools()` covers
+the registry alone and has no view of the session.
+
+The list already accounts for this session's audience, the config's
+`disabled_tools` and the model's capabilities. Read `audiences` to layer
+your own policy on top. A sandbox wants `interpreter`.
+
+Each name shows up once, described by the tool a call would really reach, so
+a host tool that shadows a registry name reports its own audience rather
+than the shadowed one's.
+
+**Parameters:**
+
+- `{ctx}` (`LuaCtx`) Agent context.
+
+**Returns:** (`table?`, `string?`) Array of `{ name, alias?, source, audiences, schema? }`,
+  or `(nil, err)` on failure. `source` is one of `"native"`, `"local"`,
+  `"mcp"`. `alias` is a safe identifier to bind, set only when `name` is not
+  one (say `srv__get-docs`). Dispatch `name` in every case. `schema` comes
+  with registry tools only.
+
+**Example:**
+
+```lua
+local tools, err = maki.agent.callable_tools(ctx)
+if err then error(err) end
+for _, t in ipairs(tools) do
+  print(t.source, t.alias or t.name)
+end
 ```
 
 ---
@@ -927,7 +972,9 @@ and tool set.
   - `local_tools` (`table?`) map of `name -> spec` for Lua-backed tools. Each spec
     requires `description` (string), `input_schema` (table), and
     `handler` (function). The handler receives the input table and must return
-    `(string)` or `(nil, err)`.
+    `(string)` or `(nil, err)`. Optional `audiences` (string[]) gates who may
+    call it, the same way `maki.api.register_tool` does. The default is the
+    model alone, so a script cannot reach it through `code_execution`.
   - `name` (`string?`) display name for logs and UI.
   - `audience` (`string?`) tool audience for capability gating. Default: `"general_sub"`.
   - `mcp` (`boolean?`) give the session access to MCP tools. Their

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -142,11 +142,11 @@ Executes multiple independent tool calls concurrently to reduce round-trips.
 
 ### `code_execution` {#code_execution}
 
-Execute Python code in a sandboxed interpreter with tools as callable functions.
+Execute Python in a sandbox where every tool is an async function.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `code` | string | yes |  | Python code to execute. Tools are async functions that return strings (not objects). You MUST await every call: `result = await read(path='/file', offset=1, limit=0)`. Use `await gather(...)` for concurrency. |
+| `code` | string | yes |  | Python code. Tools return strings, not objects, and you MUST await every call: `result = await read(path='/file', offset=1, limit=0)`. |
 | `timeout` | integer | no | 30 | Script execution timeout in seconds |
 
 ### `question` {#question}

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -687,6 +687,7 @@ pub fn prompt(
             filter: &ToolFilter::All,
             audience: ToolAudience::MAIN,
             workflow: false,
+            mcp: false,
         };
         let defs = reg.definitions(&vars, &ctx, true);
         if names {


### PR DESCRIPTION
Calling `srv__tool(...)` inside a `code_execution` script raised `NameError`, because the plugin bound its Python names from the tool registry alone, while MCP tools, ACP client tools and `tool_search` are granted by the `ToolContext` itself.

`tool_dispatch::callable` now enumerates every dispatchable name in one list, and it sits next to `resolve` which routes them, so the router and whoever binds the names cannot drift apart.

A name belongs to the first source `resolve` reaches and is claimed before any filter runs, because a registry tool that loses on audience must keep its name reserved, or an MCP server publishing the same wire name becomes a way around the gate.

Every entry reports the audience of the tool that will really run, which is why host tools now declare one (`ToolAudience::MODEL` by default, so a script cannot reach a subagent's `structured_output`), and a hyphenated MCP name gets an `alias` the sandbox binds while it keeps dispatching the real name.

Deferred MCP tools bind too, and nested calls never mark them loaded, so a script fanning out over twenty of them leaves the next request's tool array untouched.