### PR TITLE
feat(agent): allow MCP tool calls in plan mode

### DIFF
--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -19,7 +19,6 @@ use maki_config::ToolKey;
 
 const DOOM_LOOP_THRESHOLD: usize = 3;
 const DOOM_LOOP_MESSAGE: &str = "You have called this tool with identical input 3 times in a row. You are stuck in a loop. Break out and try a different approach.";
-const MCP_BLOCKED_IN_PLAN: &str = "MCP tools are not available in plan mode";
 const UNKNOWN_TOOL_PREFIX: &str = "unknown tool";
 const MCP_PERM_SCOPE_MAX_BYTES: usize = 200;
 
@@ -538,10 +537,6 @@ async fn execute_mcp_tool(
         annotation: None,
         written_path: None,
     };
-
-    if ctx.mode.plan_path().is_some() {
-        return done(MCP_BLOCKED_IN_PLAN.into(), true);
-    }
 
     let perm_tool = match ToolKey::parse(&tool) {
         Ok(k) => k,
@@ -1186,13 +1181,58 @@ mod tests {
     }
 
     #[test]
-    fn mcp_tool_blocked_in_plan_mode() {
+    fn mcp_tool_allowed_in_plan_mode() {
         smol::block_on(async {
             let plan = AgentMode::Plan(PathBuf::from(PLAN_PATH));
             let ctx = with_mcp(stub_ctx(&plan), &stub_mcp(&[PROBE_QUALIFIED]));
             let done = dispatch(&ctx, PROBE_WIRE, &serde_json::json!({})).await;
-            assert!(done.is_error);
-            assert_eq!(done.output.as_text(), MCP_BLOCKED_IN_PLAN);
+            // The stub transport fails every call, so a successful run surfaces
+            // its error: the proof the call was neither plan-blocked nor
+            // permission-denied and actually reached MCP.
+            assert_eq!(done.tool.as_ref(), PROBE_QUALIFIED, "must route to MCP");
+            let text = done.output.as_text();
+            assert!(
+                !text.starts_with(PERMISSION_DENIED_PREFIX)
+                    && text != crate::tools::PLAN_WRITE_RESTRICTED,
+                "plan mode must not block or deny the call, got: {text}"
+            );
+            let mut tools = serde_json::json!([]);
+            ctx.mcp.as_ref().unwrap().extend_tools(&mut tools);
+            assert!(
+                tool_names(&tools).contains(&&PROBE_WIRE.to_owned()[..]),
+                "a permitted plan-mode call must load the definition"
+            );
+        });
+    }
+
+    #[test]
+    fn mcp_tool_denied_by_rule_in_plan_mode() {
+        smol::block_on(async {
+            let config = PermissionsConfig {
+                rules: vec![PermissionRule {
+                    tool: ToolKey::parse(PROBE_QUALIFIED).unwrap(),
+                    scope: None,
+                    effect: Effect::Deny,
+                }],
+                ..Default::default()
+            };
+            let permissions = Arc::new(PermissionManager::new(
+                config,
+                PathBuf::from(TEST_ROOT),
+                Arc::default(),
+            ));
+            let plan = AgentMode::Plan(PathBuf::from(PLAN_PATH));
+            let ctx = with_mcp(
+                stub_ctx_with_permissions(&plan, permissions),
+                &stub_mcp(&[PROBE_QUALIFIED]),
+            );
+            let done = dispatch(&ctx, PROBE_WIRE, &serde_json::json!({})).await;
+            assert!(done.is_error, "plan mode must not bypass deny rules");
+            assert!(
+                done.output.as_text().starts_with(PERMISSION_DENIED_PREFIX),
+                "got: {}",
+                done.output.as_text()
+            );
         });
     }
 

--- a/site/docs/content/permissions/_index.md
+++ b/site/docs/content/permissions/_index.md
@@ -37,7 +37,7 @@ plan file write?    ── yes ──►  runs
 default: prompt / allow / deny
 ```
 
-Deny rules are checked across all layers before anything else, so a deny cannot be bypassed by YOLO or the plan-file auto-allow. In plan mode, writes to any path other than the plan file are rejected before this flow, and MCP tools are blocked entirely. `default` resolves per-tool first, then global; the built-in default is `"prompt"`.
+Deny rules are checked across all layers before anything else, so a deny cannot be bypassed by YOLO or the plan-file auto-allow. In plan mode, writes to any path other than the plan file are rejected before this flow; this applies to the file-write tools only. All other tools, including MCP tools, follow the check flow below as usual. `default` resolves per-tool first, then global; the built-in default is `"prompt"`.
 
 ## Builtin Defaults
 


### PR DESCRIPTION
## Summary

Closes #858

Removes the hard block on MCP tool calls in plan mode. Plan mode is best effort, not a sandbox, so MCP calls now go through the normal permission flow (deny rules -> yolo -> per-tool -> server -> global -> prompt), exactly as they do in build mode. Per the author feedback in the issue, no `readonly` / `allowed_in_plan` config attribute is added.

## Changes

- `maki-agent/src/agent/tool_dispatch.rs`
  - Delete `MCP_BLOCKED_IN_PLAN` const and the plan-mode gate in `execute_mcp_tool`
  - `permissions.enforce(...)` still receives `ctx.mode.plan_path()`; the native-tool write restriction (`mutable_path()` / `PLAN_WRITE_RESTRICTED`) is untouched
  - Replace `mcp_tool_blocked_in_plan_mode` with `mcp_tool_allowed_in_plan_mode` (permitted call routes to MCP and marks the tool loaded) and add `mcp_tool_denied_by_rule_in_plan_mode` (explicit deny rule still wins in plan mode)
- `site/docs/content/permissions/_index.md`: plan mode rejects writes outside the plan file; MCP tools go through the same permission flow
- `maki-agent/src/prompts/plan.md`: note that MCP tools remain available for research

## Testing

- `cargo clippy -p maki-agent --tests -- -D warnings` clean
- `cargo test -p maki-agent`: 648 passed, 1 pre-existing unrelated failure (`tools::tests::walk_builder_excludes_dot_git_shows_dotfiles_and_filters_globs`, fails on clean `main` too)
- `cargo fmt --all -- --check` clean