### PR TITLE
fix(ui): a blank tab keeps the settings `/new` keeps

### DIFF
--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -264,12 +264,13 @@ impl App {
         }
     }
 
-    /// Shared by every restore path: `focus_session` picks between resuming in
-    /// place and spawning a fresh runtime by tab state alone, so the same key
-    /// press has to land on the same permissions. The stored value replaces
-    /// whatever the previous session was running with, and a session that
-    /// stored nothing falls back to `--yolo` / `always_yolo`.
-    fn apply_stored_yolo(&self, meta: &SessionMeta) {
+    /// A tab keeps one permission manager while sessions come and go under it,
+    /// so a swap has to state the new session's answer in full, rules and yolo
+    /// both, or the session inherits what the last one was granted. A session
+    /// that stored no yolo falls back to `--yolo` / `always_yolo`.
+    fn apply_stored_permissions(&self, meta: &SessionMeta) {
+        self.permissions
+            .load_session_rules(stored_to_rules(&meta.session_rules));
         self.permissions.set_session_yolo(meta.yolo);
     }
 
@@ -277,9 +278,7 @@ impl App {
     /// history, so no respawn follows and the restored queue must be
     /// flushed here.
     pub(crate) fn restore_resumed_session(&mut self) {
-        self.permissions
-            .load_session_rules(stored_to_rules(&self.state.session.meta.session_rules));
-        self.apply_stored_yolo(&self.state.session.meta);
+        self.apply_stored_permissions(&self.state.session.meta);
         self.restore_display();
         self.flush_restored_queue();
         for w in self.state.warnings.drain(..) {
@@ -299,6 +298,30 @@ impl App {
         }
     }
 
+    /// `/new` swaps a fresh session under this tab, `Ctrl-N` spawns a new tab
+    /// that rebuilds its whole state from this meta, so both gestures keep
+    /// exactly what is listed here. Written out field by field so a new
+    /// `SessionMeta` field has to pick a side: settings that say how the user
+    /// works ride along, anything a finished turn produced stays behind, or the
+    /// new session writes over work it never did.
+    pub(crate) fn blank_session(&self) -> AppSession {
+        let mut session = AppSession::new(&self.state.model.spec(), &self.state.session.cwd);
+        session.meta = SessionMeta {
+            mode: Some(self.state.mode.into()),
+            thinking: Some(self.state.thinking.into()),
+            fast: self.state.fast,
+            workflow: self.state.workflow,
+            plan_path: None,
+            plan_written: false,
+            session_rules: Vec::new(),
+            context_size: 0,
+            input_draft: None,
+            queued_messages: Vec::new(),
+            yolo: None,
+        };
+        session
+    }
+
     pub(super) fn reset_session(&mut self) -> Vec<Action> {
         self.checkpoint_now();
         self.reset_ui_chrome();
@@ -306,7 +329,6 @@ impl App {
         self.state.cost = None;
         self.state.context_size = 0;
         self.state.plan = PlanState::None;
-        self.permissions.set_session_yolo(None);
         if self.state.mode == Mode::Plan {
             self.enter_plan();
         }
@@ -314,10 +336,9 @@ impl App {
         // that just ended needs its id, and the stamp always reads
         // whichever session is current.
         self.fire_session_autocmd("SessionReset", serde_json::json!({}));
-        self.state.session = Arc::new(AppSession::new(
-            &self.state.session.model,
-            &self.state.session.cwd,
-        ));
+        let session = self.blank_session();
+        self.apply_stored_permissions(&session.meta);
+        self.state.session = Arc::new(session);
         maki_otel::emit::session_started(
             maki_otel::emit::START_FRESH,
             Some(&self.state.session.id.to_string()),
@@ -368,9 +389,7 @@ impl App {
         fallback_model: &Model,
     ) -> LoadedSession {
         self.checkpoint_now();
-        self.permissions
-            .load_session_rules(stored_to_rules(&session.meta.session_rules));
-        self.apply_stored_yolo(&session.meta);
+        self.apply_stored_permissions(&session.meta);
         self.state =
             SessionState::from_session(session, fallback_model, &self.storage, &self.model_policy);
         for w in self.state.warnings.drain(..) {

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -17,11 +17,11 @@ use maki_agent::{
     DoneReason, ImageMediaType, McpConfigErrors, McpServerInfo, McpServerStatus, McpSnapshot,
     McpSnapshotReader, ToolDoneEvent, ToolOutput, ToolStartEvent, TurnCompleteEvent,
 };
-use maki_config::{PermissionsConfig, UiConfig};
+use maki_config::{Effect, PermissionRule, PermissionsConfig, ToolKey, UiConfig};
 use maki_lua::test_support::{HintWriterHandle, hint_writer_pair};
 use maki_lua::{BuiltinAction, HintReader, KeymapReader, LuaCommandInfo, LuaCommandReader};
 use maki_providers::{ContentBlock, Effort, Message, Role, THINKING_USAGE, TokenUsage};
-use maki_storage::sessions::{StoredMode, StoredThinking};
+use maki_storage::sessions::{SessionMeta, StoredMode, StoredThinking};
 use ratatui::layout::Rect;
 use std::env;
 use std::path::{Path, PathBuf};
@@ -577,6 +577,14 @@ fn streaming_app_without_queue() -> App {
     app
 }
 
+fn session_rule() -> PermissionRule {
+    PermissionRule {
+        tool: ToolKey::parse("bash").unwrap(),
+        scope: None,
+        effect: Effect::Allow,
+    }
+}
+
 fn queued_msg(text: &str) -> QueuedMessage {
     QueuedMessage {
         text: text.into(),
@@ -701,6 +709,74 @@ fn reset_session_clears_plan() {
     assert!(app.queue.focus().is_none());
     assert!(!app.help_modal.is_open());
     assert!(!app.btw_modal.is_open());
+}
+
+/// A new session inheriting the plan path, the draft or the queue of the one it
+/// started from would take over work it never did, and the checkpoint here is
+/// what puts all of that in the old session's meta. The whole meta is asserted,
+/// so a field that starts riding along cannot slip by.
+#[test]
+fn blank_session_carries_the_settings_that_outlive_a_turn() {
+    let mut app = test_app();
+    app.state.thinking = ThinkingConfig::Effort(Effort::High);
+    app.state.fast = true;
+    app.state.workflow = true;
+    app.state.mode = Mode::Plan;
+    app.state.plan = PlanState::Ready(PathBuf::from("plan.md"));
+    app.state.context_size = MEASURED_CONTEXT;
+    app.input_box.set_input("half a thought".into());
+    app.queue_and_notify(queued_msg("q"));
+    app.permissions.load_session_rules(vec![session_rule()]);
+    app.permissions.set_session_yolo(Some(true));
+    app.checkpoint();
+
+    let session = app.blank_session();
+
+    assert_eq!(
+        session.meta,
+        SessionMeta {
+            mode: Some(StoredMode::Plan),
+            thinking: Some(StoredThinking::Effort {
+                level: Effort::High
+            }),
+            fast: true,
+            workflow: true,
+            ..Default::default()
+        }
+    );
+    assert!(session.messages().is_empty());
+    assert_eq!(session.model, app.state.model.spec());
+    assert_eq!(session.cwd, app.state.session.cwd);
+}
+
+/// A setting written into the meta but never read back still opens the tab
+/// wrong, so only the round trip through `SessionState` proves `Ctrl-N` works.
+#[test]
+fn a_spawned_tab_opens_on_the_settings_it_was_started_with() {
+    let tmp = TempDir::new().unwrap();
+    let storage = StateDir::from_path(tmp.path().to_path_buf());
+    let mut app = test_app();
+    set_opus_model(&mut app);
+    app.state.thinking = ThinkingConfig::Effort(Effort::High);
+    app.state.fast = true;
+    app.state.workflow = true;
+    app.state.mode = Mode::Plan;
+
+    let spawned = SessionState::from_session(
+        app.blank_session(),
+        &test_model(),
+        &storage,
+        &maki_config::ModelPolicy::default(),
+    );
+
+    assert_eq!(spawned.thinking, app.state.thinking);
+    assert_eq!(spawned.fast, app.state.fast);
+    assert_eq!(spawned.workflow, app.state.workflow);
+    assert_eq!(spawned.mode, app.state.mode);
+    assert!(
+        spawned.plan.path().is_some(),
+        "a plan-mode tab owes itself a plan file"
+    );
 }
 
 #[test]
@@ -2456,18 +2532,23 @@ fn loading_a_session_applies_stored_yolo(seed: bool, stored: Option<bool>) -> (b
 }
 
 /// A tab keeps one permission manager for its whole life, so without an
-/// explicit reset `/new` would inherit the resumed session's answer and then
-/// checkpoint it into a session the user never said anything about.
+/// explicit reset `/new` would inherit both answers the last session got, the
+/// stored bypass and the rules the user allowed during it, and checkpoint them
+/// into a session nobody granted them for.
 #[test_case(false => (false, None) ; "a_fresh_session_drops_a_stored_bypass")]
 #[test_case(true  => (true,  None) ; "a_fresh_session_returns_to_the_flag")]
-fn resetting_the_session_falls_back_to_the_yolo_seed(seed: bool) -> (bool, Option<bool>) {
+fn resetting_the_session_drops_what_the_last_one_was_granted(seed: bool) -> (bool, Option<bool>) {
     let (mut app, session) = app_and_session_with_yolo(seed, Some(!seed));
     app.state.session = Arc::new(session);
     app.restore_resumed_session();
+    app.permissions.load_session_rules(vec![session_rule()]);
     assert_eq!(app.permissions.is_yolo(), !seed);
 
     app.reset_session();
     app.checkpoint();
+
+    assert!(app.permissions.session_rules_snapshot().is_empty());
+    assert!(app.state.session.meta.session_rules.is_empty());
     (app.permissions.is_yolo(), app.state.session.meta.yolo)
 }
 

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -1046,11 +1046,7 @@ impl<'t> EventLoop<'t> {
                 let _ = reply_tx.send(Ok(json!(self.sessions[self.focused].id())));
             }
             SessionRequest::New { prompt, focus } => {
-                let session = {
-                    let slot = self.ctx.model_slot.load();
-                    let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());
-                    AppSession::new(&slot.model.spec(), &cwd.to_string_lossy())
-                };
+                let session = self.focused_app().blank_session();
                 let idx = self.push_runtime(self.ctx.spawn_runtime(session));
                 let id = self.sessions[idx].id();
                 maki_otel::emit::session_started(


### PR DESCRIPTION
Opening a session with `Ctrl-N` in the `/session` picker dropped thinking, fast, workflow and plan mode, because it built a bare `AppSession` while `/new` only swaps the session under the live state and keeps all four.

The spawned tab derives its state from `session.meta`, so `App::blank_session` now seeds that meta from the focused session, and both gestures start the same way.

Token usage, cost, context size, plan path and session yolo stay out of it, since `/new` clears those too.