### PR TITLE
Fix the `/btw` styling for thinking

### DIFF
--- a/maki-ui/src/app/btw.rs
+++ b/maki-ui/src/app/btw.rs
@@ -88,11 +88,12 @@ async fn run_btw(
 
     let forward_fut = async {
         while let Ok(event) = event_rx.recv_async().await {
-            let delta = match event {
-                ProviderEvent::TextDelta { text } | ProviderEvent::ThinkingDelta { text } => text,
+            let event = match event {
+                ProviderEvent::TextDelta { text } => BtwEvent::TextDelta(text),
+                ProviderEvent::ThinkingDelta { text } => BtwEvent::ThinkingDelta(text),
                 _ => continue,
             };
-            if btw_tx.send(BtwEvent::TextDelta(delta)).is_err() {
+            if btw_tx.send(event).is_err() {
                 return;
             }
         }

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -300,7 +300,7 @@ impl App {
             rewind_picker: RewindPicker::new(),
             help_modal: HelpModal::new(),
             usage_modal: UsageModal::new(),
-            btw_modal: BtwModal::new(typewriter),
+            btw_modal: BtwModal::new(typewriter, ui_config.show_thinking),
             float_mgr: FloatManager::new(),
             search_modal: SearchModal::new(),
             file_picker: FilePickerModal::new(),

--- a/maki-ui/src/components/btw_modal.rs
+++ b/maki-ui/src/components/btw_modal.rs
@@ -3,6 +3,7 @@ use crate::components::Overlay;
 use crate::components::modal::Modal;
 use crate::components::scrollbar::render_vertical_scrollbar;
 use crate::components::streaming_content::StreamingContent;
+use crate::components::tool_display::{assistant_style, thinking_indicator, thinking_style};
 use crate::theme;
 
 use crossterm::event::{KeyCode, KeyEvent};
@@ -20,6 +21,7 @@ const MAX_HEIGHT_PERCENT: u16 = 80;
 
 pub enum BtwEvent {
     TextDelta(String),
+    ThinkingDelta(String),
     Done,
     Error(String),
 }
@@ -28,17 +30,32 @@ pub struct BtwModal {
     open: bool,
     question: String,
     answer: StreamingContent,
+    thinking: StreamingContent,
+    /// A copy of the transcript's setting, so both hide thinking the same way.
+    show_thinking: bool,
+    /// `StreamingContent` keeps its styles by value and the modal outlives any
+    /// number of theme switches, so this is what tells us to hand it new ones.
+    theme_generation: u64,
     scroll: ModalScroll,
     rx: Option<flume::Receiver<BtwEvent>>,
 }
 
 impl BtwModal {
-    pub fn new(ms_per_char: u64) -> Self {
-        let theme = theme::current();
+    pub fn new(ms_per_char: u64, show_thinking: bool) -> Self {
+        let thinking = thinking_style();
+        let answer = assistant_style();
         Self {
             open: false,
             question: String::new(),
-            answer: StreamingContent::new("", theme.assistant, theme.assistant, ms_per_char),
+            answer: StreamingContent::new("", answer.text_style, answer.prefix_style, ms_per_char),
+            thinking: StreamingContent::new(
+                thinking.prefix,
+                thinking.text_style,
+                thinking.prefix_style,
+                ms_per_char,
+            ),
+            show_thinking,
+            theme_generation: theme::generation(),
             scroll: ModalScroll::new(),
             rx: None,
         }
@@ -55,6 +72,7 @@ impl BtwModal {
         self.open = false;
         self.question.clear();
         self.answer.clear();
+        self.thinking.clear();
         self.scroll.reset();
         self.rx = None;
     }
@@ -68,7 +86,12 @@ impl BtwModal {
     /// A pending stream is drained by [`Self::poll`], which reports its own
     /// [`Dirty`].
     pub fn cadence(&self) -> Cadence {
-        Cadence::when(self.open && self.answer.is_animating(), Cadence::SMOOTH)
+        // Hidden thinking draws a line count, so its typewriter reveals
+        // nothing; believing it would pin the loop at full frame rate for the
+        // whole reasoning phase (same guard as the transcript's cadence).
+        let smooth =
+            self.answer.is_animating() || (self.show_thinking && self.thinking.is_animating());
+        Cadence::when(self.open && smooth, Cadence::SMOOTH)
     }
 
     pub fn is_open(&self) -> bool {
@@ -84,6 +107,7 @@ impl BtwModal {
             dirty = Dirty::YES;
             match event {
                 BtwEvent::TextDelta(text) => self.answer.push(&text),
+                BtwEvent::ThinkingDelta(text) => self.thinking.push(&text),
                 BtwEvent::Done => {
                     self.rx = None;
                     break;
@@ -119,21 +143,11 @@ impl BtwModal {
             return Rect::default();
         }
 
-        let theme = theme::current();
         let border_chrome: u16 = 2;
         let padded_width = (area.width as u32 * WIDTH_PERCENT as u32 / 100)
             .saturating_sub((border_chrome + H_PAD * 2) as u32) as u16;
 
-        let mut lines: Vec<Line> = Vec::new();
-        lines.push(Line::from(Span::styled(
-            format!("Q: {}", self.question),
-            theme.tool_dim,
-        )));
-        lines.push(Line::default());
-
-        let md_lines = self.answer.render_lines(padded_width);
-        lines.extend_from_slice(md_lines);
-
+        let lines = self.body_lines(padded_width);
         let total = Paragraph::new(lines.clone())
             .wrap(Wrap { trim: false })
             .line_count(padded_width) as u16;
@@ -164,9 +178,52 @@ impl BtwModal {
         popup
     }
 
+    /// Question, then the reasoning, then the answer. Kept out of [`Self::view`]
+    /// because the height pass and the paint pass have to agree on the lines.
+    fn body_lines(&mut self, width: u16) -> Vec<Line<'static>> {
+        self.restyle_on_theme_change();
+        let theme = theme::current();
+        let mut lines = vec![
+            Line::from(Span::styled(
+                format!("Q: {}", self.question),
+                theme.tool_dim,
+            )),
+            Line::default(),
+        ];
+        if !self.thinking.is_empty() {
+            if self.show_thinking {
+                lines.extend_from_slice(self.thinking.render_lines(width));
+            } else {
+                lines.extend(thinking_indicator(self.thinking.line_count(), false));
+            }
+            lines.push(Line::default());
+        }
+        lines.extend_from_slice(self.answer.render_lines(width));
+        lines
+    }
+
+    fn restyle_on_theme_change(&mut self) {
+        let generation = theme::generation();
+        if self.theme_generation == generation {
+            return;
+        }
+        self.theme_generation = generation;
+        let thinking = thinking_style();
+        let answer = assistant_style();
+        self.thinking
+            .set_style(thinking.prefix, thinking.text_style, thinking.prefix_style);
+        self.answer
+            .set_style("", answer.text_style, answer.prefix_style);
+    }
+
     #[cfg(test)]
     pub fn answer_eq(&self, expected: &str) -> bool {
         self.answer == expected
+    }
+
+    #[cfg(test)]
+    pub fn thinking_eq(&self, expected: &str) -> bool {
+        self.thinking == expected
     }
 }
 
@@ -189,7 +246,21 @@ mod tests {
     use super::*;
     use crate::components::key as key_ev;
     use crossterm::event::KeyCode;
+    use ratatui::style::Style;
     use test_case::test_case;
+
+    const INSTANT: u64 = 0;
+    const SHOW_THINKING: bool = true;
+    const WIDTH: u16 = 80;
+    const THEME_A: &str = "dracula";
+    const THEME_B: &str = "tokyonight";
+    const REASONING: &str = "hmm, sqlite";
+    const ANSWER: &str = "Because it is embedded.";
+    const HIDDEN_COUNT: &str = "(1 lines)";
+
+    fn modal() -> BtwModal {
+        BtwModal::new(INSTANT, SHOW_THINKING)
+    }
 
     fn open_modal(m: &mut BtwModal, question: &str) -> flume::Sender<BtwEvent> {
         let (tx, rx) = flume::bounded(64);
@@ -197,9 +268,35 @@ mod tests {
         tx
     }
 
+    fn answer_a_question(m: &mut BtwModal) {
+        let tx = open_modal(m, "q");
+        tx.send(BtwEvent::ThinkingDelta(REASONING.into())).unwrap();
+        tx.send(BtwEvent::TextDelta(ANSWER.into())).unwrap();
+        let _ = m.poll();
+    }
+
+    fn body_text(m: &mut BtwModal) -> String {
+        m.body_lines(WIDTH)
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+            .collect()
+    }
+
+    /// The chrome around the body already reads the live theme, so looking at
+    /// the two streams on their own is what proves they were restyled too.
+    fn stream_styles(m: &mut BtwModal) -> Vec<Style> {
+        m.body_lines(WIDTH);
+        m.thinking
+            .cached_lines()
+            .iter()
+            .chain(m.answer.cached_lines())
+            .flat_map(|l| l.spans.iter().map(|s| s.style))
+            .collect()
+    }
+
     #[test]
     fn open_sets_question_and_state() {
-        let mut m = BtwModal::new(0);
+        let mut m = modal();
         let _tx = open_modal(&mut m, "why?");
         assert!(m.is_open());
         assert_eq!(m.question, "why?");
@@ -209,23 +306,22 @@ mod tests {
 
     #[test]
     fn close_resets_all_fields() {
-        let mut m = BtwModal::new(0);
-        let tx = open_modal(&mut m, "q");
-        tx.send(BtwEvent::TextDelta("some answer".into())).unwrap();
-        let _ = m.poll();
+        let mut m = modal();
+        answer_a_question(&mut m);
         m.scroll.update_dimensions(100, 10);
         m.scroll.scroll(-5);
         m.close();
         assert!(!m.is_open());
         assert!(m.question.is_empty());
         assert!(m.answer.is_empty());
+        assert!(m.thinking.is_empty());
         assert_eq!(m.scroll.offset(), 0);
         assert!(!m.is_streaming());
     }
 
     #[test]
     fn poll_accumulates_text() {
-        let mut m = BtwModal::new(0);
+        let mut m = modal();
         let tx = open_modal(&mut m, "q");
         tx.send(BtwEvent::TextDelta("hello ".into())).unwrap();
         tx.send(BtwEvent::TextDelta("world".into())).unwrap();
@@ -235,7 +331,7 @@ mod tests {
 
     #[test]
     fn poll_done_sets_done_and_drops_rx() {
-        let mut m = BtwModal::new(0);
+        let mut m = modal();
         let tx = open_modal(&mut m, "q");
         tx.send(BtwEvent::Done).unwrap();
         let _ = m.poll();
@@ -244,7 +340,7 @@ mod tests {
 
     #[test]
     fn poll_error_replaces_answer_and_marks_done() {
-        let mut m = BtwModal::new(0);
+        let mut m = modal();
         let tx = open_modal(&mut m, "q");
         tx.send(BtwEvent::TextDelta("partial".into())).unwrap();
         tx.send(BtwEvent::Error("oops".into())).unwrap();
@@ -257,7 +353,7 @@ mod tests {
     #[test_case(KeyCode::Enter ; "enter_closes")]
     #[test_case(KeyCode::Char(' ') ; "space_closes")]
     fn dismiss_keys_close(code: KeyCode) {
-        let mut m = BtwModal::new(0);
+        let mut m = modal();
         let _tx = open_modal(&mut m, "q");
         m.handle_key(key_ev(code));
         assert!(!m.is_open());
@@ -266,7 +362,7 @@ mod tests {
 
     #[test]
     fn other_keys_consumed_but_stay_open() {
-        let mut m = BtwModal::new(0);
+        let mut m = modal();
         let _tx = open_modal(&mut m, "q");
         m.handle_key(key_ev(KeyCode::Char('a')));
         assert!(m.is_open());
@@ -274,7 +370,7 @@ mod tests {
 
     #[test]
     fn scroll_up_down() {
-        let mut m = BtwModal::new(0);
+        let mut m = modal();
         let _tx = open_modal(&mut m, "q");
         m.scroll.update_dimensions(100, 10);
         m.scroll.scroll(-5);
@@ -289,7 +385,7 @@ mod tests {
 
     #[test]
     fn double_open_resets_first() {
-        let mut m = BtwModal::new(0);
+        let mut m = modal();
         let tx1 = open_modal(&mut m, "first");
         tx1.send(BtwEvent::TextDelta("leftover".into())).unwrap();
         let _ = m.poll();
@@ -304,7 +400,7 @@ mod tests {
 
     #[test]
     fn close_drops_rx_signaling_sender() {
-        let mut m = BtwModal::new(0);
+        let mut m = modal();
         let tx = open_modal(&mut m, "q");
         m.close();
         assert!(tx.send(BtwEvent::TextDelta("x".into())).is_err());
@@ -312,8 +408,50 @@ mod tests {
 
     #[test]
     fn poll_noop_when_no_rx() {
-        let mut m = BtwModal::new(0);
+        let mut m = modal();
         let _ = m.poll();
         assert!(!m.is_open());
+    }
+
+    /// Both deltas used to be pushed into the answer, which left the reasoning
+    /// indistinguishable from the response. They need separate streams because
+    /// each carries its own colour and prefix.
+    #[test]
+    fn thinking_deltas_are_kept_apart_from_the_answer() {
+        let mut m = modal();
+        answer_a_question(&mut m);
+        assert!(m.answer_eq(ANSWER));
+        assert!(m.thinking_eq(REASONING));
+    }
+
+    /// The count comes off the full buffer, not the typewriter's visible slice,
+    /// which never advances here because nothing draws it.
+    #[test]
+    fn hidden_thinking_is_summarised_not_printed() {
+        let mut m = BtwModal::new(INSTANT, false);
+        answer_a_question(&mut m);
+        let body = body_text(&mut m);
+        assert!(!body.contains(REASONING), "reasoning leaked: {body}");
+        assert!(body.contains(HIDDEN_COUNT), "no line count: {body}");
+        assert!(body.contains(ANSWER), "answer missing: {body}");
+    }
+
+    /// The modal is built once at startup and lives through every theme switch,
+    /// so the streams have to be handed the new colours before they repaint.
+    #[test]
+    fn theme_switch_repaints_the_streams() {
+        theme::set(theme::load_by_name(THEME_A).expect(THEME_A));
+        let mut m = modal();
+        answer_a_question(&mut m);
+        let before = stream_styles(&mut m);
+        assert!(!before.is_empty(), "nothing rendered to compare");
+
+        theme::set(theme::load_by_name(THEME_B).expect(THEME_B));
+
+        assert_ne!(
+            before,
+            stream_styles(&mut m),
+            "a theme switch must restyle the body, not keep the startup palette"
+        );
     }
 }

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -14,7 +14,7 @@ use self::segment::{Segment, SegmentCache};
 use super::tool_display::{
     RenderCtx, ToolLines, append_annotation, append_right_info, assistant_style,
     build_instructions_lines, build_tool_lines, done_style, error_style, format_timestamp_now,
-    thinking_style, truncate_to_header, user_style,
+    thinking_indicator, thinking_style, truncate_to_header, user_style,
 };
 use super::{DisplayMessage, DisplayRole, ToolRole, ToolStatus, code_view::SectionFlags};
 use crate::animation::spinner_str;
@@ -48,7 +48,6 @@ use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
 use tracing::warn;
 
-const THINKING_HIDDEN_HEADER: &str = "thinking> ...";
 const REFLOW_MARGIN_VIEWPORTS: u32 = 1;
 /// Spacer plus instruction segment, inserted as a pair.
 const INSTRUCTION_SEGMENTS: usize = 2;
@@ -1216,11 +1215,11 @@ impl MessagesPanel {
     }
 
     fn build_streaming_collapsed_lines(&self) -> Vec<Line<'static>> {
-        thinking_indicator(self.streaming_thinking.line_count())
+        thinking_indicator(self.streaming_thinking.line_count(), true)
     }
 
     fn build_cached_thinking_indicator(&self, text: &str) -> Vec<Line<'static>> {
-        thinking_indicator(logical_line_count(text))
+        thinking_indicator(logical_line_count(text), true)
     }
 
     /// `pos` is past the cached segments, so it names a tail part: the click
@@ -1510,20 +1509,6 @@ impl MessagesPanel {
         seg.set_lines(lines);
         seg.search_text = search_text;
     }
-}
-
-/// Two-line thinking indicator: a header (`thinking> ...`) followed by a
-/// `(N lines) (click to expand)` footer. Shared by the streaming and cached
-/// views when `show_thinking` is off.
-fn thinking_indicator(line_count: usize) -> Vec<Line<'static>> {
-    let theme = theme::current();
-    vec![
-        Line::from(Span::styled(THINKING_HIDDEN_HEADER, theme.thinking)),
-        Line::from(vec![
-            Span::styled(format!("({line_count} lines) "), theme.tool_dim),
-            Span::styled("(click to expand)", theme.thinking),
-        ]),
-    ]
 }
 
 fn logical_line_count(text: &str) -> usize {

--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -38,6 +38,8 @@ pub(crate) const SPINNER_STYLE_NAME: &str = "spinner";
 pub(crate) const SPINNER_STYLE_PREFIX: &str = "spinner:";
 
 const CODE_OUTPUT_DIVIDER: &str = "  ────────────";
+const THINKING_HIDDEN_HEADER: &str = "thinking> ...";
+const THINKING_EXPAND_HINT: &str = " (click to expand)";
 
 pub struct RoleStyle {
     pub prefix: &'static str,
@@ -75,6 +77,24 @@ pub fn thinking_style() -> RoleStyle {
         use_markdown: true,
         max_line_bytes: None,
     }
+}
+
+/// The stand-in for thinking the reader chose not to see. The transcript and
+/// the `/btw` modal both draw it, so it lives here to keep them in step, but
+/// only the transcript rows can be clicked, hence `expandable`.
+pub(crate) fn thinking_indicator(line_count: usize, expandable: bool) -> Vec<Line<'static>> {
+    let theme = theme::current();
+    let mut footer = vec![Span::styled(
+        format!("({line_count} lines)"),
+        theme.tool_dim,
+    )];
+    if expandable {
+        footer.push(Span::styled(THINKING_EXPAND_HINT, theme.thinking));
+    }
+    vec![
+        Line::from(Span::styled(THINKING_HIDDEN_HEADER, theme.thinking)),
+        Line::from(footer),
+    ]
 }
 
 pub fn error_style() -> RoleStyle {


### PR DESCRIPTION
The `/btw` model doesn't format or style thinking output. This makes it difficult to parse visually. 

This PR makes the model use the same styling as the main transcript.

BTW the reflow refactor you did looks good!  