### PR TITLE
feat(ui): deliver queued messages together in one turn

### DIFF
--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -37,6 +37,8 @@ const RECENT_TOOL_WINDOW: usize = 5;
 /// turn, and a model resuming its own cut-off text can wedge the session
 /// (seen with llama.cpp stuck on an unterminated tool call).
 const CANCELLED_TEXT_NOTE: &str = "[Response cut off by user cancel]";
+const INTERRUPT_NOTE: &str =
+    "The user sent a new message while you were working. Address it and continue.";
 
 pub fn resolve_compaction_model(
     provider: &Arc<dyn Provider>,
@@ -563,20 +565,27 @@ impl<'h> Agent<'h> {
             return Ok(false);
         };
         match cmd {
-            ExtractedCommand::Interrupt(mut input, _) => {
-                self.event_tx.send(AgentEvent::QueueItemConsumed {
-                    text: input.message.clone(),
-                    image_count: input.images.len(),
-                })?;
-                self.push_input_context(std::mem::take(&mut input.preamble));
-                self.mode = input.mode.clone();
-                let display = input.message.clone();
-                let wrapped = format!(
-                    "<user-interrupt>\nThe user sent a new message while you were working. Address it and continue.\n\n{display}\n</user-interrupt>"
-                );
-                self.history.push(Message::user_display(wrapped, display));
+            // The burst lands as consecutive user messages, so one request
+            // carries all of it.
+            ExtractedCommand::Interrupt(inputs) => {
+                for input in inputs {
+                    self.event_tx.send(AgentEvent::QueueItemConsumed {
+                        text: input.message.clone(),
+                        image_count: input.images.len(),
+                    })?;
+                    self.push_input_context(input.preamble);
+                    self.mode = input.mode;
+                    let wrapped = format!(
+                        "<user-interrupt>\n{INTERRUPT_NOTE}\n\n{}\n</user-interrupt>",
+                        input.message
+                    );
+                    self.history.push(Message {
+                        display_text: Some(input.message),
+                        ..Message::user_with_images(wrapped, input.images)
+                    });
+                }
             }
-            ExtractedCommand::Compact(_) => {
+            ExtractedCommand::Compact => {
                 self.do_compact().await?;
             }
         }
@@ -624,6 +633,8 @@ mod tests {
     use crate::Envelope;
     use crate::mcp::tool_names;
     use crate::permissions::PermissionManager;
+
+    const QUEUED_MESSAGES: [&str; 3] = ["first", "second", "third"];
 
     struct MockInterruptSource {
         commands: Mutex<VecDeque<ExtractedCommand>>,
@@ -850,7 +861,7 @@ mod tests {
             SessionMailbox::notify(id, "mailbox".into(), false).unwrap();
             let mut input = default_input();
             input.preamble = vec![Message::observation("preamble".into())];
-            let source = MockInterruptSource::new(vec![ExtractedCommand::Interrupt(input, 0)]);
+            let source = MockInterruptSource::new(vec![ExtractedCommand::Interrupt(vec![input])]);
             let mut history = History::new(Vec::new());
             let (mut agent, _event_rx) = make_agent(MockProvider::new(Vec::new()), &mut history);
             agent.mailbox = Some(mailbox);
@@ -1030,8 +1041,7 @@ mod tests {
         smol::block_on(async {
             let source = if queued.is_some() {
                 Some(MockInterruptSource::new(vec![ExtractedCommand::Interrupt(
-                    default_input(),
-                    0,
+                    vec![default_input()],
                 )]))
             } else {
                 None
@@ -1072,9 +1082,51 @@ mod tests {
         });
     }
 
+    /// Two responses are the whole budget: the opening turn, then the one turn
+    /// that answers all three queued messages. Answering them one by one would
+    /// ask the mock for a response it does not have.
+    #[test]
+    fn queued_messages_are_delivered_in_one_turn() {
+        smol::block_on(async {
+            let inputs = Vec::from(QUEUED_MESSAGES.map(|text| AgentInput {
+                message: text.into(),
+                ..default_input()
+            }));
+            let source = MockInterruptSource::new(vec![ExtractedCommand::Interrupt(inputs)]);
+            let mut history = History::new(Vec::new());
+            let (agent, event_rx) = make_agent(
+                MockProvider::new(vec![
+                    text_response(StopReason::EndTurn),
+                    text_response(StopReason::EndTurn),
+                ]),
+                &mut history,
+            );
+
+            let mut agent = agent.with_interrupt_source(source);
+            agent.run(default_input()).await.unwrap();
+            let events = drain_events(&event_rx);
+            drop(agent);
+
+            let user_texts: Vec<_> = history
+                .as_slice()
+                .iter()
+                .filter(|m| matches!(m.role, Role::User))
+                .filter_map(Message::user_text)
+                .collect();
+            assert_eq!(user_texts[1..], QUEUED_MESSAGES);
+            assert_eq!(
+                events
+                    .iter()
+                    .filter(|e| matches!(e.event, AgentEvent::QueueItemConsumed { .. }))
+                    .count(),
+                QUEUED_MESSAGES.len()
+            );
+        });
+    }
+
     #[test_case(
         (0..10).map(|i| Message::user(format!("msg {i}"))).collect(),
-        vec![ExtractedCommand::Compact(0)],
+        vec![ExtractedCommand::Compact],
         vec![tool_call_response("glob", "t1"), text_response(StopReason::EndTurn), text_response(StopReason::EndTurn)]
         ; "compaction_via_interrupt_source"
     )]

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -60,8 +60,12 @@ impl AgentMode {
 }
 
 pub enum ExtractedCommand {
-    Interrupt(AgentInput, u64),
-    Compact(u64),
+    /// Every message the user queued back to back, so one turn answers them
+    /// all. A source must stop there and hand anything else over on its own,
+    /// since a command like `/compact` rewrites the history the later messages
+    /// land in.
+    Interrupt(Vec<AgentInput>),
+    Compact,
 }
 
 pub trait InterruptSource: Send + Sync {

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -24,7 +24,7 @@ use tracing::error;
 
 use super::ModelSlot;
 use super::cancel_map::RunCancelMap;
-use super::shared_queue::{QueueItem, QueueReceiver};
+use super::shared_queue::{self, QueueReceiver, QueueRun};
 
 pub(super) struct AgentLoop {
     model_slot: Arc<ArcSwap<ModelSlot>>,
@@ -110,12 +110,12 @@ impl AgentLoop {
 
         while let Ok(()) = self.queue.recv_notify().await {
             let mut last_run_id = None;
-            while let Some(entry) = self.queue.pop() {
-                if entry.run_id() < self.min_run_id {
+            while let Some(mut run) = self.queue.pop_run() {
+                let Some(run_id) = run.drop_cancelled(self.min_run_id) else {
                     continue;
-                }
-                last_run_id = Some(entry.run_id());
-                self.process_entry(entry).await;
+                };
+                last_run_id = Some(run_id);
+                self.process_run(run, run_id).await;
             }
             if let Some(run_id) = last_run_id {
                 let event_tx = EventSender::new(self.agent_tx.clone(), run_id);
@@ -125,24 +125,29 @@ impl AgentLoop {
         }
     }
 
-    async fn process_entry(&mut self, entry: QueueItem) {
-        let run_id = entry.run_id();
+    async fn process_run(&mut self, run: QueueRun, run_id: u64) {
         let event_tx = EventSender::new(self.agent_tx.clone(), run_id);
 
-        let result = match entry {
-            QueueItem::Message {
-                text,
-                image_count,
-                input,
-                displayed,
-                ..
-            } => {
-                if !displayed {
-                    let _ = event_tx.send(AgentEvent::QueueItemConsumed { text, image_count });
-                }
+        let result = match run {
+            QueueRun::Compact { .. } => self.do_compact(&event_tx).await,
+            QueueRun::Messages(messages) => {
+                let inputs = messages
+                    .into_iter()
+                    .map(|queued| {
+                        if !queued.displayed {
+                            let _ = event_tx.send(AgentEvent::QueueItemConsumed {
+                                text: queued.text,
+                                image_count: queued.image_count,
+                            });
+                        }
+                        queued.input
+                    })
+                    .collect();
+                let Some(input) = shared_queue::merge_inputs(inputs) else {
+                    return;
+                };
                 self.do_agent_run(input, event_tx, run_id).await
             }
-            QueueItem::Compact { .. } => self.do_compact(&event_tx).await,
         };
 
         if let Err(e) = result {

--- a/maki-ui/src/agent/shared_queue.rs
+++ b/maki-ui/src/agent/shared_queue.rs
@@ -10,7 +10,8 @@ use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
-use maki_agent::{AgentInput, ExtractedCommand, ImageSource, InterruptSource};
+use maki_agent::{AgentInput, AgentMode, ExtractedCommand, ImageSource, InterruptSource};
+use maki_providers::Message;
 
 use crate::components::input::Submission;
 use crate::components::queue_panel::QueueEntry;
@@ -19,6 +20,8 @@ use crate::theme;
 const COMPACT_LABEL: &str = "/compact";
 
 type Items = Arc<Mutex<VecDeque<QueueItem>>>;
+/// What a message must agree on with its neighbours to share their turn.
+type BatchKey = (AgentMode, bool);
 
 pub(crate) struct QueuedMessage {
     pub(crate) text: String,
@@ -34,34 +37,75 @@ impl From<Submission> for QueuedMessage {
     }
 }
 
+pub(crate) struct QueuedInput {
+    pub(crate) text: String,
+    pub(crate) image_count: usize,
+    pub(crate) input: AgentInput,
+    pub(crate) run_id: u64,
+    /// `true` when the UI already drew the bubble (immediate dispatch).
+    /// The agent then skips `QueueItemConsumed` so we don't draw it twice.
+    /// `false` when the user typed while the agent was busy: the UI waits
+    /// for `QueueItemConsumed` before drawing.
+    pub(crate) displayed: bool,
+}
+
+impl QueuedInput {
+    /// The set of messages this one may share a turn with, or `None` when it
+    /// has to run alone: the agent resolves one MCP prompt per run. `mode` is
+    /// a permission boundary and `workflow` picks the tool catalog, so a
+    /// message queued under either may not execute under another one.
+    ///
+    /// Destructured on purpose: a new `AgentInput` field then has to be
+    /// classified here instead of silently merging across.
+    fn batch_key(&self) -> Option<BatchKey> {
+        let AgentInput {
+            mode,
+            workflow,
+            prompt,
+            message: _,
+            images: _,
+            preamble: _,
+            thinking: _,
+            fast: _,
+        } = &self.input;
+        prompt.is_none().then(|| (mode.clone(), *workflow))
+    }
+}
+
 pub(crate) enum QueueItem {
-    Message {
-        text: String,
-        image_count: usize,
-        input: AgentInput,
-        run_id: u64,
-        /// `true` when the UI already drew the bubble (immediate dispatch).
-        /// The agent then skips `QueueItemConsumed` so we don't draw it twice.
-        /// `false` when the user typed while the agent was busy: the UI waits
-        /// for `QueueItemConsumed` before drawing.
-        displayed: bool,
-    },
-    Compact {
-        run_id: u64,
-    },
+    Message(QueuedInput),
+    Compact { run_id: u64 },
+}
+
+/// One turn's worth of work. Plain messages typed back to back under the same
+/// mode and workflow travel together, so the whole burst costs one run and one
+/// request. Everything else travels alone and keeps its place, since
+/// `/compact` rewrites the history the later messages land in.
+pub(crate) enum QueueRun {
+    Messages(Vec<QueuedInput>),
+    Compact { run_id: u64 },
+}
+
+impl QueueRun {
+    /// Forgets whatever the user cancelled before we got to it, and reports
+    /// the id the rest rides on: the newest one, the only run the UI still
+    /// considers current.
+    pub(crate) fn drop_cancelled(&mut self, min_run_id: u64) -> Option<u64> {
+        match self {
+            Self::Messages(messages) => {
+                messages.retain(|queued| queued.run_id >= min_run_id);
+                Some(messages.last()?.run_id)
+            }
+            Self::Compact { run_id } => (*run_id >= min_run_id).then_some(*run_id),
+        }
+    }
 }
 
 impl QueueItem {
-    pub(crate) fn run_id(&self) -> u64 {
-        match self {
-            Self::Message { run_id, .. } | Self::Compact { run_id } => *run_id,
-        }
-    }
-
     fn as_queue_entry(&self) -> QueueEntry<'static> {
         match self {
-            Self::Message { text, .. } => QueueEntry {
-                text: Cow::Owned(text.clone()),
+            Self::Message(queued) => QueueEntry {
+                text: Cow::Owned(queued.text.clone()),
                 color: theme::current().foreground,
             },
             Self::Compact { .. } => QueueEntry {
@@ -74,10 +118,10 @@ impl QueueItem {
         }
     }
 
-    fn into_extracted_command(self) -> ExtractedCommand {
+    fn batch_key(&self) -> Option<BatchKey> {
         match self {
-            Self::Message { input, run_id, .. } => ExtractedCommand::Interrupt(input, run_id),
-            Self::Compact { run_id } => ExtractedCommand::Compact(run_id),
+            Self::Message(queued) => queued.batch_key(),
+            Self::Compact { .. } => None,
         }
     }
 
@@ -86,7 +130,7 @@ impl QueueItem {
     /// which used to make the bubble hop up by one frame.
     fn visible_in_panel(&self) -> bool {
         match self {
-            Self::Message { displayed, .. } => !displayed,
+            Self::Message(queued) => !queued.displayed,
             Self::Compact { .. } => true,
         }
     }
@@ -147,7 +191,7 @@ impl QueueSender {
             .iter()
             .filter(|item| item.visible_in_panel())
             .filter_map(|item| match item {
-                QueueItem::Message { text, .. } => Some(text.clone()),
+                QueueItem::Message(queued) => Some(queued.text.clone()),
                 QueueItem::Compact { .. } => None,
             })
             .collect()
@@ -170,8 +214,23 @@ impl QueueSender {
 }
 
 impl QueueReceiver {
-    pub(crate) fn pop(&self) -> Option<QueueItem> {
-        lock(&self.items).pop_front()
+    /// Takes the next item plus every message queued right behind it that
+    /// shares its batch key.
+    pub(crate) fn pop_run(&self) -> Option<QueueRun> {
+        let mut items = lock(&self.items);
+        let first = match items.pop_front()? {
+            QueueItem::Compact { run_id } => return Some(QueueRun::Compact { run_id }),
+            QueueItem::Message(first) => first,
+        };
+        let key = first.batch_key();
+        let mut run = vec![first];
+        while key.is_some() && items.front().and_then(QueueItem::batch_key) == key {
+            let Some(QueueItem::Message(next)) = items.pop_front() else {
+                break;
+            };
+            run.push(next);
+        }
+        Some(QueueRun::Messages(run))
     }
 
     /// Runs `publish` under the queue lock, so a drain event can never
@@ -190,8 +249,36 @@ impl QueueReceiver {
 
 impl InterruptSource for QueueReceiver {
     fn poll(&self) -> Option<ExtractedCommand> {
-        self.pop().map(QueueItem::into_extracted_command)
+        Some(match self.pop_run()? {
+            QueueRun::Compact { .. } => ExtractedCommand::Compact,
+            QueueRun::Messages(run) => {
+                ExtractedCommand::Interrupt(run.into_iter().map(|queued| queued.input).collect())
+            }
+        })
     }
+}
+
+/// Folds a run of queued messages into one agent input. The last message
+/// drives the run and the earlier ones ride in front of it as their own user
+/// messages, so each keeps its images and the model answers the burst in one
+/// request. The run shares one mode and one workflow by construction, so only
+/// the preferences (thinking, fast) come from the last message, the user's
+/// most recent intent.
+pub(crate) fn merge_inputs(mut inputs: Vec<AgentInput>) -> Option<AgentInput> {
+    let mut last = inputs.pop()?;
+    let mut preamble = Vec::new();
+    for earlier in inputs {
+        preamble.extend(earlier.preamble);
+        let message = Message::user_with_images(earlier.message, earlier.images);
+        // An input with neither text nor images would become a user message
+        // with no content at all, which providers reject.
+        if !message.content.is_empty() {
+            preamble.push(message);
+        }
+    }
+    preamble.append(&mut last.preamble);
+    last.preamble = preamble;
+    Some(last)
 }
 
 #[cfg(test)]
@@ -200,31 +287,90 @@ mod tests {
     use std::sync::Barrier;
     use std::thread;
 
+    use maki_agent::{ImageMediaType, McpPromptRef};
+
     use super::*;
     use test_case::test_case;
 
-    fn msg(displayed: bool) -> QueueItem {
-        QueueItem::Message {
-            text: "t".into(),
-            image_count: 0,
-            input: AgentInput {
-                message: String::new(),
-                mode: Default::default(),
-                images: Vec::new(),
-                preamble: Vec::new(),
-                thinking: Default::default(),
-                fast: false,
-                workflow: false,
-                prompt: None,
-            },
-            run_id: 0,
-            displayed,
+    const FIRST: &str = "first";
+    const SECOND: &str = "second";
+    const THIRD: &str = "third";
+    const PROMPT_NAME: &str = "server/review";
+    const PLAN_PATH: &str = "plan.md";
+    const NOT_AN_INTERRUPT: &str = "expected an interrupt carrying the queued messages";
+    /// One image block plus one text block.
+    const BLOCKS_PER_MESSAGE: usize = 2;
+
+    fn input(message: &str) -> AgentInput {
+        AgentInput {
+            message: message.into(),
+            mode: Default::default(),
+            images: Vec::new(),
+            preamble: Vec::new(),
+            thinking: Default::default(),
+            fast: false,
+            workflow: false,
+            prompt: None,
         }
     }
 
-    #[test_case(msg(false),                       true  ; "deferred_message_visible")]
-    #[test_case(msg(true),                        false ; "displayed_message_hidden")]
-    #[test_case(QueueItem::Compact { run_id: 0 }, true  ; "compact_visible")]
+    fn queued(text: &str, run_id: u64) -> QueuedInput {
+        QueuedInput {
+            text: text.into(),
+            image_count: 0,
+            input: input(text),
+            run_id,
+            displayed: false,
+        }
+    }
+
+    fn message(text: &str) -> QueueItem {
+        QueueItem::Message(queued(text, 0))
+    }
+
+    fn plan_message(text: &str) -> QueueItem {
+        let mut queued = queued(text, 0);
+        queued.input.mode = AgentMode::Plan(PLAN_PATH.into());
+        QueueItem::Message(queued)
+    }
+
+    fn workflow_message(text: &str) -> QueueItem {
+        let mut queued = queued(text, 0);
+        queued.input.workflow = true;
+        QueueItem::Message(queued)
+    }
+
+    fn prompt_message(text: &str) -> QueueItem {
+        let mut queued = queued(text, 0);
+        queued.input.prompt = Some(Box::new(McpPromptRef {
+            qualified_name: PROMPT_NAME.into(),
+            arguments: Default::default(),
+        }));
+        QueueItem::Message(queued)
+    }
+
+    fn compact() -> QueueItem {
+        QueueItem::Compact { run_id: 0 }
+    }
+
+    /// Drains the queue and names every run it hands over: the texts of a
+    /// burst of messages, or `/compact` on its own.
+    fn runs(rx: &QueueReceiver) -> Vec<Vec<String>> {
+        let mut runs = Vec::new();
+        while let Some(run) = rx.pop_run() {
+            runs.push(match run {
+                QueueRun::Messages(messages) => {
+                    messages.into_iter().map(|queued| queued.text).collect()
+                }
+                QueueRun::Compact { .. } => vec![COMPACT_LABEL.into()],
+            });
+        }
+        runs
+    }
+
+    #[test_case(message(FIRST), true  ; "deferred_message_visible")]
+    #[test_case(QueueItem::Message(QueuedInput { displayed: true, ..queued(FIRST, 0) }), false ; "displayed_message_hidden")]
+    #[test_case(compact(), true  ; "compact_visible")]
     fn panel_visibility(item: QueueItem, visible: bool) {
         let (tx, _rx) = queue();
         tx.push(item);
@@ -236,7 +382,7 @@ mod tests {
     #[test]
     fn nonempty_queue_does_not_publish_drain() {
         let (tx, rx) = queue();
-        tx.push(msg(false));
+        tx.push(message(FIRST));
         let called = Cell::new(false);
 
         rx.publish_if_empty(|| called.set(true));
@@ -252,7 +398,7 @@ mod tests {
         let worker_order = Arc::clone(&order);
         let worker = thread::spawn(move || {
             worker_barrier.wait();
-            tx.push(msg(false));
+            tx.push(message(FIRST));
             lock(&worker_order).push("push");
         });
 
@@ -263,5 +409,75 @@ mod tests {
         worker.join().unwrap();
 
         assert_eq!(*lock(&order), ["drain", "push"]);
+    }
+
+    #[test_case(vec![message(FIRST), message(SECOND), message(THIRD)], vec![vec![FIRST, SECOND, THIRD]] ; "adjacent_messages_ride_together")]
+    #[test_case(vec![message(FIRST), compact(), message(SECOND)], vec![vec![FIRST], vec![COMPACT_LABEL], vec![SECOND]] ; "compact_splits_the_drain_and_keeps_its_place")]
+    #[test_case(vec![message(FIRST), prompt_message(SECOND), message(THIRD)], vec![vec![FIRST], vec![SECOND], vec![THIRD]] ; "mcp_prompt_runs_alone")]
+    #[test_case(vec![message(FIRST)], vec![vec![FIRST]] ; "single_message_unchanged")]
+    #[test_case(vec![plan_message(FIRST), plan_message(SECOND)], vec![vec![FIRST, SECOND]] ; "one_mode_rides_together")]
+    #[test_case(vec![plan_message(FIRST), message(SECOND)], vec![vec![FIRST], vec![SECOND]] ; "mode_change_splits_the_drain")]
+    #[test_case(vec![message(FIRST), workflow_message(SECOND), message(THIRD)], vec![vec![FIRST], vec![SECOND], vec![THIRD]] ; "workflow_change_splits_the_drain")]
+    fn pop_run_groups_the_queue_into_turns(items: Vec<QueueItem>, expected: Vec<Vec<&str>>) {
+        let (tx, rx) = queue();
+        for item in items {
+            tx.push(item);
+        }
+
+        assert_eq!(runs(&rx), expected);
+        assert!(tx.is_empty());
+    }
+
+    #[test_case(0, Some(2) ; "nothing_cancelled")]
+    #[test_case(2, Some(2) ; "cancelled_message_dropped")]
+    #[test_case(3, None    ; "whole_run_cancelled")]
+    fn drop_cancelled_keeps_the_newest_run_id(min_run_id: u64, expected: Option<u64>) {
+        let mut run = QueueRun::Messages(vec![queued(FIRST, 1), queued(SECOND, 2)]);
+
+        assert_eq!(run.drop_cancelled(min_run_id), expected);
+    }
+
+    #[test]
+    fn poll_hands_the_whole_message_run_to_one_turn() {
+        let (tx, rx) = queue();
+        for text in [FIRST, SECOND, THIRD] {
+            tx.push(message(text));
+        }
+
+        let Some(ExtractedCommand::Interrupt(inputs)) = rx.poll() else {
+            panic!("{NOT_AN_INTERRUPT}");
+        };
+        let messages: Vec<_> = inputs.iter().map(|i| i.message.as_str()).collect();
+
+        assert_eq!(messages, [FIRST, SECOND, THIRD]);
+        assert!(rx.poll().is_none());
+    }
+
+    #[test_case(&[FIRST] ; "single_message_stays_alone")]
+    #[test_case(&[FIRST, SECOND, THIRD] ; "earlier_messages_ride_in_the_preamble")]
+    fn merge_inputs_keeps_every_message_with_its_own_image(texts: &[&str]) {
+        let inputs = texts
+            .iter()
+            .map(|text| AgentInput {
+                images: vec![ImageSource::new(ImageMediaType::Png, Arc::from(*text))],
+                ..input(text)
+            })
+            .collect();
+
+        let merged = merge_inputs(inputs).unwrap();
+
+        let (last, earlier) = texts.split_last().unwrap();
+        assert_eq!(merged.message, *last);
+        assert_eq!(merged.images.len(), 1);
+        let preamble: Vec<_> = merged
+            .preamble
+            .iter()
+            .map(|m| (m.user_text(), m.content.len()))
+            .collect();
+        let expected: Vec<_> = earlier
+            .iter()
+            .map(|text| (Some(*text), BLOCKS_PER_MESSAGE))
+            .collect();
+        assert_eq!(preamble, expected);
     }
 }

--- a/maki-ui/src/app/queue.rs
+++ b/maki-ui/src/app/queue.rs
@@ -4,7 +4,7 @@ use maki_agent::AgentInput;
 
 use super::{Action, App, Status, format_with_images};
 
-use crate::agent::shared_queue::{QueueItem, QueueSender};
+use crate::agent::shared_queue::{QueueItem, QueueSender, QueuedInput};
 use crate::components::queue_panel::QueueEntry;
 
 pub(crate) use crate::agent::shared_queue::QueuedMessage;
@@ -156,13 +156,13 @@ impl App {
             return false;
         };
         let input = self.build_agent_input(&msg);
-        shared.push(QueueItem::Message {
+        shared.push(QueueItem::Message(QueuedInput {
             text: msg.text,
             image_count: msg.images.len(),
             input,
             run_id: self.run_id,
             displayed: false,
-        });
+        }));
         true
     }
 

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -38,7 +38,10 @@ use serde_json::json;
 use tracing::{info, warn};
 
 use crate::AppSession;
-use crate::agent::{AgentCommand, AgentHandles, ModelSlot, shared_queue::QueueItem};
+use crate::agent::{
+    AgentCommand, AgentHandles, ModelSlot,
+    shared_queue::{QueueItem, QueuedInput},
+};
 use crate::app::shell::{ShellEvent, spawn_shell};
 use crate::app::tasks::{TaskStatus, diff_task_states};
 use crate::app::{App, Msg, Notification, QueuedMessage, SubmitOutcome, turn_response};
@@ -1323,13 +1326,13 @@ impl<'t> EventLoop<'t> {
                 let mut input = *input;
                 prepend_preamble(&mut input.preamble, rt.app.shell.drain_results());
                 let run_id = rt.app.run_id;
-                rt.handles.queue.push(QueueItem::Message {
+                rt.handles.queue.push(QueueItem::Message(QueuedInput {
                     text: input.message.clone(),
                     image_count: input.images.len(),
                     input,
                     run_id,
                     displayed: true,
-                });
+                }));
             }
             Action::CancelAgent { run_id } => {
                 let rt = &mut self.sessions[idx];


### PR DESCRIPTION
Typing three follow ups while the agent worked cost three runs and three requests, and the model only ever saw one of them at a time.

The queue now hands over every plain message queued back to back in one go, at both boundaries: `pop_run` for the idle agent loop and `poll` for the turn boundary inside a run.

They land as consecutive user messages, earlier ones riding in the preamble of the merged `AgentInput`, and the turn boundary now keeps each message's images too, so the whole burst costs one request.

Anything that is not a plain message stops the drain and keeps its place, and so does a change of `mode` or `workflow`, because `/compact` rewrites the history the later messages land in, an MCP prompt item needs a run of its own, and a message queued in Plan must not execute with the Build tools.

Closes #887.