### PR TITLE
feat(theme): let themes name terminal colors 🤖🤖🤖

### DIFF
--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -39,8 +39,8 @@ pub use maki_providers::{EMPTY_RESPONSE_MARKER, ImageMediaType, ImageSource, Thi
 pub use types::{
     AgentEvent, BufferSnapshot, DoneReason, Envelope, EventSender, GrepFileEntry, GrepLine,
     GrepMatchGroup, InstructionBlock, NO_FILES_FOUND, RunLedger, RunTotals, SessionEndReason,
-    SharedBuf, SnapshotLine, SnapshotSpan, SpanStyle, SubagentInfo, TextOutput, ToolDoneEvent,
-    ToolInput, ToolOutput, ToolStartEvent, TurnCompleteEvent,
+    SharedBuf, SnapshotLine, SnapshotSpan, SpanColor, SpanStyle, SubagentInfo, TextOutput,
+    ToolDoneEvent, ToolInput, ToolOutput, ToolStartEvent, TurnCompleteEvent,
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -886,10 +886,32 @@ pub enum SpanStyle {
     Inline(InlineStyle),
 }
 
+/// A color a plugin can ask for. `Ansi` and `Default` keep terminal-owned
+/// colors symbolic all the way to the renderer, so maki never has to guess
+/// what a given index looks like on the user's terminal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SpanColor {
+    /// Serializes as `[r, g, b]`, matching sessions written before palette
+    /// colors existed.
+    Rgb((u8, u8, u8)),
+    Ansi(u8),
+    /// Serializes as the string `"default"`, the same spelling themes use.
+    Default(DefaultColor),
+}
+
+/// Gives [`SpanColor::Default`] a distinct serialized shape under
+/// `#[serde(untagged)]`, which has no room for a unit variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DefaultColor {
+    Default,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct InlineStyle {
-    pub fg: Option<(u8, u8, u8)>,
-    pub bg: Option<(u8, u8, u8)>,
+    pub fg: Option<SpanColor>,
+    pub bg: Option<SpanColor>,
     pub bold: bool,
     pub italic: bool,
     pub underline: bool,
@@ -1449,7 +1471,7 @@ mod tests {
     #[test_case(SpanStyle::Default ; "default")]
     #[test_case(SpanStyle::Named("comment".into()) ; "named")]
     #[test_case(SpanStyle::Inline(InlineStyle {
-        fg: Some((255, 0, 0)),
+        fg: Some(SpanColor::Rgb((255, 0, 0))),
         bg: None,
         bold: true,
         italic: false,
@@ -1466,6 +1488,21 @@ mod tests {
         let json = serde_json::to_string(&span).unwrap();
         let parsed: SnapshotSpan = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, span);
+    }
+
+    /// `#[serde(untagged)]` exists purely so sessions written before palette
+    /// colors still load, so the wire shapes are pinned rather than left to
+    /// whatever the variant order happens to produce.
+    #[test_case(SpanColor::Rgb((255, 0, 0)), "[255,0,0]" ; "rgb stays a triple")]
+    #[test_case(SpanColor::Ansi(4), "4" ; "palette index is a bare number")]
+    #[test_case(SpanColor::Default(DefaultColor::Default), "\"default\"" ; "terminal default is a string")]
+    fn span_color_wire_format(color: SpanColor, expected: &str) {
+        assert_eq!(serde_json::to_string(&color).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<SpanColor>(expected).unwrap(),
+            color,
+            "a stored session must read back as what wrote it"
+        );
     }
 
     #[test_case("", true  ; "plain_output_is_empty_for_empty_string")]

--- a/maki-docgen/src/gen_config.rs
+++ b/maki-docgen/src/gen_config.rs
@@ -124,12 +124,35 @@ fn write_theme_section(out: &mut String) {
     .unwrap();
     writeln!(
         out,
-        "Themes use 24-bit colors, but not every terminal can show them. Maki \
-         checks the environment, terminfo, and the terminal itself, and when \
-         truecolor is missing it quietly falls back to the closest of the 256 \
-         classic terminal colors. If detection gets it wrong, set \
+        "Themes use 24-bit colors by default, but not every terminal can show \
+         them. Maki checks the environment, terminfo, and the terminal itself, \
+         and when truecolor is missing it quietly falls back to the closest of \
+         the 256 classic terminal colors. If detection gets it wrong, set \
          `MAKI_TRUECOLOR=1` to force truecolor or `MAKI_TRUECOLOR=0` to force \
          the fallback.\n"
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "Theme files can also name terminal colors instead of giving hex \
+         values, using the same names as Helix: `default`, `black`, `red`, \
+         `green`, `yellow`, `blue`, `magenta`, `cyan`, `gray`, `light-red`, \
+         `light-green`, `light-yellow`, `light-blue`, `light-magenta`, \
+         `light-cyan`, `light-gray`, and `white`. Write them exactly as \
+         listed. `lightgray`, `light_gray` and `LIGHT-GRAY` are all rejected. \
+         `default` means the terminal default. Maki also takes a number from \
+         `0` to `255` to pick a palette entry by index, which Helix does \
+         not.\n"
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "These work everywhere a hex value does, including syntax \
+         highlighting scopes, so a theme can be written entirely against the \
+         palette your terminal already defines. Maki passes them through as \
+         palette references rather than resolving them to RGB, so the colors \
+         stay correct in terminals that mangle truecolor, such as nested tmux \
+         over ssh.\n"
     )
     .unwrap();
 }

--- a/maki-highlight/src/lib.rs
+++ b/maki-highlight/src/lib.rs
@@ -15,12 +15,99 @@ const TOKEN_ALIASES: &[(&str, &str)] = &[("jsx", "js")];
 pub const TAB_SPACES: &str = "  ";
 const BLOCK_CACHE_MAX_BYTES: usize = 16 * 1024 * 1024;
 
+/// Bat encodes ANSI palette semantics in the syntect alpha channel, and
+/// syntect passes the bytes through untouched. `a = 0` means `r` holds a
+/// palette index, `a = 1` means the terminal default.
+const ANSI_ALPHA_INDEX: u8 = 0x00;
+const ANSI_ALPHA_DEFAULT: u8 = 0x01;
+pub const DEFAULT_COLOR_NAME: &str = "default";
+const HEX_RGB_LEN: usize = 6;
+
 type Rgb = (u8, u8, u8);
 pub type BlockSegments = Arc<Vec<Vec<StyledSegment>>>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SegmentColor {
+    Rgb(Rgb),
+    Ansi(u8),
+    Default,
+}
+
+impl SegmentColor {
+    pub fn from_syntect(c: syntect::highlighting::Color) -> Self {
+        match c.a {
+            ANSI_ALPHA_INDEX => Self::Ansi(c.r),
+            ANSI_ALPHA_DEFAULT => Self::Default,
+            _ => Self::Rgb((c.r, c.g, c.b)),
+        }
+    }
+
+    pub fn to_syntect(self) -> syntect::highlighting::Color {
+        let (r, g, b, a) = match self {
+            Self::Rgb((r, g, b)) => (r, g, b, 0xFF),
+            Self::Ansi(i) => (i, 0, 0, ANSI_ALPHA_INDEX),
+            Self::Default => (0, 0, 0, ANSI_ALPHA_DEFAULT),
+        };
+        syntect::highlighting::Color { r, g, b, a }
+    }
+
+    /// The one reader of the `#rrggbb | index | name | default` grammar, so
+    /// themes, syntax scopes and plugin spans cannot drift apart on what they
+    /// accept.
+    pub fn parse(s: &str) -> Option<Self> {
+        if let Some(hex) = s.strip_prefix('#') {
+            return parse_hex_rgb(hex).map(Self::Rgb);
+        }
+        if s == DEFAULT_COLOR_NAME {
+            return Some(Self::Default);
+        }
+        if s.bytes().all(|b| b.is_ascii_digit()) {
+            return s.parse().ok().map(Self::Ansi);
+        }
+        ansi_color_index(s).map(Self::Ansi)
+    }
+}
+
+/// Rejects the `+4` and `-0` that `u8::from_str` would otherwise accept, and
+/// any casing or separator sloppiness, so a spelling either resolves exactly
+/// or not at all.
+fn parse_hex_rgb(hex: &str) -> Option<Rgb> {
+    if hex.len() != HEX_RGB_LEN || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let channel = |i: usize| u8::from_str_radix(&hex[i..i + 2], 16).ok();
+    Some((channel(0)?, channel(2)?, channel(4)?))
+}
+
+/// Resolve a terminal color name to its palette index. These are Helix's
+/// palette names, so its themes load unchanged. Spelling is exact:
+/// `light-gray` resolves, `lightgray` and `LIGHT-GRAY` do not.
+pub fn ansi_color_index(name: &str) -> Option<u8> {
+    let index = match name {
+        "black" => 0,
+        "red" => 1,
+        "green" => 2,
+        "yellow" => 3,
+        "blue" => 4,
+        "magenta" => 5,
+        "cyan" => 6,
+        "gray" => 7,
+        "light-gray" => 8,
+        "light-red" => 9,
+        "light-green" => 10,
+        "light-yellow" => 11,
+        "light-blue" => 12,
+        "light-magenta" => 13,
+        "light-cyan" => 14,
+        "white" => 15,
+        _ => return None,
+    };
+    Some(index)
+}
+
 static SYNTAX_SET: OnceLock<SyntaxSet> = OnceLock::new();
 static THEME: OnceLock<RwLock<Arc<Theme>>> = OnceLock::new();
-static UI_COLORS: OnceLock<RwLock<HashMap<String, Rgb>>> = OnceLock::new();
+static UI_COLORS: OnceLock<RwLock<HashMap<String, SegmentColor>>> = OnceLock::new();
 static BLOCK_CACHE: OnceLock<RwLock<BlockCache>> = OnceLock::new();
 static THEME_GEN: AtomicU64 = AtomicU64::new(0);
 
@@ -149,15 +236,15 @@ pub fn theme() -> Arc<Theme> {
         .clone()
 }
 
-fn ui_colors_lock() -> &'static RwLock<HashMap<String, Rgb>> {
+fn ui_colors_lock() -> &'static RwLock<HashMap<String, SegmentColor>> {
     UI_COLORS.get_or_init(RwLock::default)
 }
 
-pub fn set_ui_colors(colors: HashMap<String, Rgb>) {
+pub fn set_ui_colors(colors: HashMap<String, SegmentColor>) {
     *ui_colors_lock().write().unwrap_or_else(|e| e.into_inner()) = colors;
 }
 
-pub fn theme_color(name: &str) -> Option<Rgb> {
+pub fn theme_color(name: &str) -> Option<SegmentColor> {
     if let Some(&c) = ui_colors_lock()
         .read()
         .unwrap_or_else(|e| e.into_inner())
@@ -167,13 +254,14 @@ pub fn theme_color(name: &str) -> Option<Rgb> {
     }
     let settings = &theme().settings;
     let map = serde_json::to_value(settings).ok()?;
-    let obj = map.as_object()?;
-    let val = obj.get(name)?;
-    let obj = val.as_object()?;
-    let r = obj.get("r")?.as_u64()? as u8;
-    let g = obj.get("g")?.as_u64()? as u8;
-    let b = obj.get("b")?.as_u64()? as u8;
-    Some((r, g, b))
+    let obj = map.as_object()?.get(name)?.as_object()?;
+    let channel = |k: &str| obj.get(k)?.as_u64().map(|v| v as u8);
+    Some(SegmentColor::from_syntect(syntect::highlighting::Color {
+        r: channel("r")?,
+        g: channel("g")?,
+        b: channel("b")?,
+        a: channel("a")?,
+    }))
 }
 
 pub fn syntax_set() -> &'static SyntaxSet {
@@ -279,7 +367,7 @@ impl Highlighter {
 #[derive(Debug, Clone, PartialEq)]
 pub struct StyledSegment {
     pub text: String,
-    pub fg: (u8, u8, u8),
+    pub fg: SegmentColor,
     pub bold: bool,
     pub italic: bool,
     pub underline: bool,
@@ -287,10 +375,9 @@ pub struct StyledSegment {
 
 impl StyledSegment {
     fn from_syntect(style: SynStyle, text: String) -> Self {
-        let f = style.foreground;
         Self {
             text,
-            fg: (f.r, f.g, f.b),
+            fg: SegmentColor::from_syntect(style.foreground),
             bold: style.font_style.contains(FontStyle::BOLD),
             italic: style.font_style.contains(FontStyle::ITALIC),
             underline: style.font_style.contains(FontStyle::UNDERLINE),
@@ -300,7 +387,7 @@ impl StyledSegment {
     fn fallback(text: String) -> Self {
         Self {
             text,
-            fg: (204, 204, 204),
+            fg: SegmentColor::Default,
             bold: false,
             italic: false,
             underline: false,
@@ -351,19 +438,29 @@ pub fn highlight_lines_independent(lang: &str, code: &str) -> Vec<Vec<StyledSegm
         .collect()
 }
 
-pub fn highlight_ansi(lang: &str, code: &str, bg: (u8, u8, u8)) -> String {
-    let bg_code = format!("\x1b[48;2;{};{};{}m", bg.0, bg.1, bg.2);
+pub fn highlight_ansi(lang: &str, code: &str, bg: SegmentColor) -> String {
+    let bg_code = match bg {
+        SegmentColor::Rgb((r, g, b)) => format!("\x1b[48;2;{r};{g};{b}m"),
+        SegmentColor::Ansi(i) => format!("\x1b[48;5;{i}m"),
+        SegmentColor::Default => "\x1b[49m".to_owned(),
+    };
     let mut hl = Highlighter::for_token(lang);
     let mut out = String::new();
     for line in LinesWithEndings::from(code) {
         out.push_str(&bg_code);
         for seg in hl.highlight_line(line) {
             let bold = if seg.bold { "1;" } else { "" };
-            let _ = write!(
-                out,
-                "\x1b[{bold}38;2;{};{};{}m{}",
-                seg.fg.0, seg.fg.1, seg.fg.2, seg.text
-            );
+            match seg.fg {
+                SegmentColor::Ansi(i) => {
+                    let _ = write!(out, "\x1b[{bold}38;5;{i}m{}", seg.text);
+                }
+                SegmentColor::Default => {
+                    let _ = write!(out, "\x1b[{bold}39m{}", seg.text);
+                }
+                SegmentColor::Rgb((r, g, b)) => {
+                    let _ = write!(out, "\x1b[{bold}38;2;{r};{g};{b}m{}", seg.text);
+                }
+            }
         }
         out.push_str("\x1b[K\x1b[0m\n");
     }
@@ -460,6 +557,69 @@ impl CodeHighlighter {
         }
 
         &self.cached_segments
+    }
+}
+
+#[cfg(test)]
+mod color_names {
+    use super::{SegmentColor, ansi_color_index};
+    use test_case::test_case;
+
+    /// Every name in Helix's default palette, which we accept unchanged.
+    /// https://docs.helix-editor.com/themes.html#color-palettes
+    #[test_case("black", 0)]
+    #[test_case("red", 1)]
+    #[test_case("green", 2)]
+    #[test_case("yellow", 3)]
+    #[test_case("blue", 4)]
+    #[test_case("magenta", 5)]
+    #[test_case("cyan", 6)]
+    #[test_case("gray", 7)]
+    #[test_case("light-red", 9)]
+    #[test_case("light-green", 10)]
+    #[test_case("light-yellow", 11)]
+    #[test_case("light-blue", 12)]
+    #[test_case("light-magenta", 13)]
+    #[test_case("light-cyan", 14)]
+    #[test_case("light-gray", 8)]
+    #[test_case("white", 15)]
+    fn helix_palette_names_resolve(name: &str, index: u8) {
+        assert_eq!(ansi_color_index(name), Some(index));
+    }
+
+    #[test_case("lightgray"; "missing separator")]
+    #[test_case("LIGHT-GRAY"; "uppercase")]
+    #[test_case("bright-red"; "bright is not a helix name")]
+    #[test_case("grey"; "grey is not a helix name")]
+    fn sloppy_spellings_are_rejected(name: &str) {
+        assert_eq!(ansi_color_index(name), None);
+    }
+
+    /// Themes, syntax scopes and plugin spans all read the grammar through
+    /// here, so the accepted spellings are pinned once at the source rather
+    /// than at each of the three call sites.
+    #[test_case("#fda331", SegmentColor::Rgb((0xfd, 0xa3, 0x31)); "lowercase hex")]
+    #[test_case("#FDA331", SegmentColor::Rgb((0xfd, 0xa3, 0x31)); "uppercase hex")]
+    #[test_case("light-blue", SegmentColor::Ansi(12); "helix name")]
+    #[test_case("0", SegmentColor::Ansi(0); "first index")]
+    #[test_case("255", SegmentColor::Ansi(255); "last index")]
+    #[test_case("default", SegmentColor::Default; "terminal default")]
+    fn accepted_spellings(input: &str, expected: SegmentColor) {
+        assert_eq!(SegmentColor::parse(input), Some(expected));
+    }
+
+    #[test_case("+4"; "signed index")]
+    #[test_case("-0"; "negative index")]
+    #[test_case("256"; "index out of range")]
+    #[test_case("ff0000"; "hex without a hash")]
+    #[test_case("#fff"; "three digit hex")]
+    #[test_case("#gggggg"; "hex with non hex digits")]
+    #[test_case("#ff000000"; "eight digit hex")]
+    #[test_case("lightgray"; "sloppy name")]
+    #[test_case("LIGHT-GRAY"; "uppercase name")]
+    #[test_case(""; "empty")]
+    fn rejected_spellings(input: &str) {
+        assert_eq!(SegmentColor::parse(input), None);
     }
 }
 
@@ -639,7 +799,11 @@ mod tests {
     #[test]
     fn highlight_ansi_formatting() {
         warmup();
-        let out = highlight_ansi("rust", "let x = 1;\nlet y = 2;\n", (30, 30, 30));
+        let out = highlight_ansi(
+            "rust",
+            "let x = 1;\nlet y = 2;\n",
+            SegmentColor::Rgb((30, 30, 30)),
+        );
         let bg_count = out.matches("\x1b[48;2;30;30;30m").count();
         assert_eq!(bg_count, 2, "each line should get its own bg escape");
         assert!(out.ends_with("\x1b[K\x1b[0m\n"));
@@ -901,5 +1065,33 @@ mod tests {
         let aliased = syntax_for_token(alias);
         let canonical_syntax = syntax_set().find_syntax_by_token(canonical).unwrap();
         assert_eq!(aliased.name, canonical_syntax.name);
+    }
+
+    #[test_case(ANSI_ALPHA_INDEX, SegmentColor::Ansi(9); "index marker")]
+    #[test_case(ANSI_ALPHA_DEFAULT, SegmentColor::Default; "default marker")]
+    #[test_case(0xFF, SegmentColor::Rgb((9, 2, 3)); "opaque rgb")]
+    fn alpha_marker_decodes_to_segment_color(alpha: u8, expected: SegmentColor) {
+        let c = syntect::highlighting::Color {
+            r: 9,
+            g: 2,
+            b: 3,
+            a: alpha,
+        };
+        assert_eq!(SegmentColor::from_syntect(c), expected);
+    }
+
+    #[test_case(SegmentColor::Rgb((9, 2, 3)); "rgb")]
+    #[test_case(SegmentColor::Ansi(9); "palette index")]
+    #[test_case(SegmentColor::Default; "terminal default")]
+    fn segment_color_survives_a_syntect_roundtrip(color: SegmentColor) {
+        assert_eq!(SegmentColor::from_syntect(color.to_syntect()), color);
+    }
+
+    #[test_case(SegmentColor::Ansi(4), "\x1b[48;5;4m"; "palette background")]
+    #[test_case(SegmentColor::Default, "\x1b[49m"; "terminal default background")]
+    fn highlight_ansi_keeps_non_rgb_backgrounds_symbolic(bg: SegmentColor, expected: &str) {
+        warmup();
+        let out = highlight_ansi("rust", "let x = 1;\n", bg);
+        assert!(out.contains(expected), "{out:?}");
     }
 }

--- a/maki-lua/src/api/ui/blit.rs
+++ b/maki-lua/src/api/ui/blit.rs
@@ -1,4 +1,4 @@
-use maki_agent::types::InlineStyle;
+use maki_agent::types::{InlineStyle, SpanColor};
 use maki_agent::{SnapshotLine, SnapshotSpan, SpanStyle};
 use thiserror::Error;
 use unicode_width::UnicodeWidthStr;
@@ -130,8 +130,8 @@ fn run_span((fg, bg, count): Run, cell: &str) -> SnapshotSpan {
     SnapshotSpan {
         text: cell.repeat(count),
         style: SpanStyle::Inline(InlineStyle {
-            fg: Some(fg),
-            bg,
+            fg: Some(SpanColor::Rgb(fg)),
+            bg: bg.map(SpanColor::Rgb),
             ..InlineStyle::default()
         }),
     }
@@ -147,6 +147,13 @@ mod tests {
     const BLUE: (u8, u8, u8) = (0, 0, 255);
     const WHITE: (u8, u8, u8) = (255, 255, 255);
 
+    fn unwrap_rgb(c: SpanColor) -> Rgb {
+        match c {
+            SpanColor::Rgb(rgb) => rgb,
+            other => panic!("expected rgb, got {other:?}"),
+        }
+    }
+
     fn assert_structure(lines: &[SnapshotLine], w: usize, h: usize) {
         assert_eq!(lines.len(), h.div_ceil(2));
         for line in lines {
@@ -161,7 +168,7 @@ mod tests {
 
     fn style(span: &SnapshotSpan) -> (Option<Rgb>, Option<Rgb>) {
         match &span.style {
-            SpanStyle::Inline(i) => (i.fg, i.bg),
+            SpanStyle::Inline(i) => (i.fg.map(unwrap_rgb), i.bg.map(unwrap_rgb)),
             other => panic!("expected inline style, got {other:?}"),
         }
     }

--- a/maki-lua/src/api/ui/buf.rs
+++ b/maki-lua/src/api/ui/buf.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use maki_agent::types::InlineStyle;
+use maki_agent::types::{DefaultColor, InlineStyle, SpanColor};
 use maki_agent::{SharedBuf, SnapshotLine, SnapshotSpan, SpanStyle};
+use maki_highlight::SegmentColor;
 use maki_lua_macro::{lua_class, lua_fn};
 use mlua::{Function, Lua, Result as LuaResult, Table, Value as LuaValue};
 
-use super::blit;
+use super::{blit, segment_color_to_lua};
 use crate::runtime::{TaskHandle, lock_cell};
 
 /// `live_buf` tracks the first buffer a handler creates, the one
@@ -149,8 +150,11 @@ pub(crate) fn buf_from_reply(val: &LuaValue) -> Option<Arc<SharedBuf>> {
 /// Appends a single line to the end of the buffer. You can pass a
 /// plain string for unstyled text, or a table of `{text, style?}` spans
 /// for rich content. Style can be a named string like "bold" or
-/// "keyword", or an inline table `{fg?, bg?, bold?, italic?, underline?, dim?, strikethrough?, reversed?}`
-/// with "#rrggbb" color strings.
+/// "keyword", or an inline table `{fg?, bg?, bold?, italic?, underline?, dim?, strikethrough?, reversed?}`.
+/// Colors accept "#rrggbb", a terminal color name like "blue" or "light-gray",
+/// or a palette index as a string like "4". Names must be spelled exactly,
+/// hyphens included. Named and indexed colors are left for the terminal to
+/// resolve, so they follow the user's palette.
 ///
 /// @param line string|table Plain string, or a sequence of spans: `{ {text, style?}, ... }`.
 /// @return
@@ -425,10 +429,10 @@ fn parse_style(val: &LuaValue) -> LuaResult<SpanStyle> {
         LuaValue::Table(t) => {
             let mut inline = InlineStyle::default();
             if let Ok(LuaValue::String(s)) = t.raw_get::<LuaValue>("fg") {
-                inline.fg = parse_hex_color(&s.to_str().map_err(mlua::Error::external)?);
+                inline.fg = parse_span_color(&s.to_str().map_err(mlua::Error::external)?);
             }
             if let Ok(LuaValue::String(s)) = t.raw_get::<LuaValue>("bg") {
-                inline.bg = parse_hex_color(&s.to_str().map_err(mlua::Error::external)?);
+                inline.bg = parse_span_color(&s.to_str().map_err(mlua::Error::external)?);
             }
             inline.bold = t.raw_get::<bool>("bold").unwrap_or(false);
             inline.italic = t.raw_get::<bool>("italic").unwrap_or(false);
@@ -465,11 +469,11 @@ fn span_to_lua(lua: &Lua, span: &SnapshotSpan) -> LuaResult<Table> {
 
 fn inline_to_lua(lua: &Lua, inline: &InlineStyle) -> LuaResult<Table> {
     let tbl = lua.create_table()?;
-    if let Some(rgb) = inline.fg {
-        tbl.raw_set("fg", hex_color(rgb))?;
+    if let Some(c) = inline.fg {
+        tbl.raw_set("fg", segment_color_to_lua(segment_color_from_span(c)))?;
     }
-    if let Some(rgb) = inline.bg {
-        tbl.raw_set("bg", hex_color(rgb))?;
+    if let Some(c) = inline.bg {
+        tbl.raw_set("bg", segment_color_to_lua(segment_color_from_span(c)))?;
     }
     for (key, on) in [
         ("bold", inline.bold),
@@ -486,19 +490,23 @@ fn inline_to_lua(lua: &Lua, inline: &InlineStyle) -> LuaResult<Table> {
     Ok(tbl)
 }
 
-fn hex_color((r, g, b): (u8, u8, u8)) -> String {
-    format!("#{r:02x}{g:02x}{b:02x}")
+/// Plugins speak the same `#rrggbb | index | name | default` grammar as
+/// themes, so both directions go through [`SegmentColor`] and cannot drift.
+/// The orphan rule rules out `From`, both types are foreign here.
+fn parse_span_color(s: &str) -> Option<SpanColor> {
+    Some(match SegmentColor::parse(s)? {
+        SegmentColor::Rgb(rgb) => SpanColor::Rgb(rgb),
+        SegmentColor::Ansi(i) => SpanColor::Ansi(i),
+        SegmentColor::Default => SpanColor::Default(DefaultColor::Default),
+    })
 }
 
-fn parse_hex_color(s: &str) -> Option<(u8, u8, u8)> {
-    let s = s.strip_prefix('#')?;
-    if s.len() != 6 {
-        return None;
+fn segment_color_from_span(c: SpanColor) -> SegmentColor {
+    match c {
+        SpanColor::Rgb(rgb) => SegmentColor::Rgb(rgb),
+        SpanColor::Ansi(i) => SegmentColor::Ansi(i),
+        SpanColor::Default(_) => SegmentColor::Default,
     }
-    let r = u8::from_str_radix(&s[0..2], 16).ok()?;
-    let g = u8::from_str_radix(&s[2..4], 16).ok()?;
-    let b = u8::from_str_radix(&s[4..6], 16).ok()?;
-    Some((r, g, b))
 }
 
 #[cfg(test)]
@@ -570,7 +578,7 @@ mod tests {
     #[test_case("#ff000000", None               ; "too_long_8_digits")]
     #[test_case("",        None                 ; "empty_string")]
     fn hex_color_parsing(input: &str, expected: Option<(u8, u8, u8)>) {
-        assert_eq!(parse_hex_color(input), expected);
+        assert_eq!(parse_span_color(input), expected.map(SpanColor::Rgb));
     }
 
     fn test_lua() -> mlua::Lua {
@@ -645,7 +653,7 @@ mod tests {
         let style = parse_style(&LuaValue::Table(t)).unwrap();
         match style {
             SpanStyle::Inline(ref i) => {
-                assert_eq!(i.fg, Some((255, 128, 0)));
+                assert_eq!(i.fg, Some(SpanColor::Rgb((255, 128, 0))));
                 assert!(i.bold);
                 assert!(i.dim);
                 assert!(!i.italic);
@@ -744,7 +752,7 @@ mod tests {
         assert_eq!(snap.lines[0].spans[0].text, "ERROR");
         match &snap.lines[0].spans[0].style {
             SpanStyle::Inline(i) => {
-                assert_eq!(i.fg, Some((255, 0, 0)));
+                assert_eq!(i.fg, Some(SpanColor::Rgb((255, 0, 0))));
                 assert!(i.bold);
             }
             other => panic!("expected inline style, got {other:?}"),
@@ -845,8 +853,8 @@ mod tests {
         assert_eq!(
             lines[2].spans[0].style,
             SpanStyle::Inline(InlineStyle {
-                fg: Some((255, 128, 0)),
-                bg: Some((0, 17, 34)),
+                fg: Some(SpanColor::Rgb((255, 128, 0))),
+                bg: Some(SpanColor::Rgb((0, 17, 34))),
                 bold: true,
                 dim: true,
                 ..InlineStyle::default()
@@ -1051,5 +1059,35 @@ mod tests {
         // line + 2x lines + set_lines = 4; the recursive append was dropped.
         let changes: i64 = lua.globals().get("changes").unwrap();
         assert_eq!(changes, 4);
+    }
+}
+
+#[cfg(test)]
+mod palette_roundtrip {
+    use super::*;
+    use test_case::test_case;
+
+    #[test_case("light-blue", SpanColor::Ansi(12); "name")]
+    #[test_case("4", SpanColor::Ansi(4); "index")]
+    #[test_case("default", SpanColor::Default(DefaultColor::Default); "terminal default")]
+    #[test_case("#6fb3d2", SpanColor::Rgb((0x6f, 0xb3, 0xd2)); "hex")]
+    fn accepted_color_spellings(input: &str, expected: SpanColor) {
+        assert_eq!(parse_span_color(input), Some(expected));
+    }
+
+    #[test_case("lightgray"; "missing separator")]
+    #[test_case("LIGHT-GRAY"; "uppercase")]
+    #[test_case("+4"; "signed index")]
+    #[test_case("256"; "index out of range")]
+    fn rejected_color_spellings(name: &str) {
+        assert_eq!(parse_span_color(name), None);
+    }
+
+    #[test_case(SpanColor::Ansi(4); "palette index")]
+    #[test_case(SpanColor::Default(DefaultColor::Default); "terminal default")]
+    #[test_case(SpanColor::Rgb((0x6f, 0xb3, 0xd2)); "rgb")]
+    fn colors_survive_the_lua_round_trip(color: SpanColor) {
+        let text = segment_color_to_lua(segment_color_from_span(color));
+        assert_eq!(parse_span_color(&text), Some(color));
     }
 }

--- a/maki-lua/src/api/ui/mod.rs
+++ b/maki-lua/src/api/ui/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use humantime::format_duration;
+use maki_highlight::{DEFAULT_COLOR_NAME, SegmentColor};
 use maki_lua_macro::{lua_fn, lua_table};
 use mlua::{Lua, Result as LuaResult, Table};
 use strum::VariantNames;
@@ -93,7 +94,10 @@ fn buf(lua: &Lua) -> LuaResult<buf::BufHandle> {
 /// your plugin's colors consistent with the rest of the UI.
 ///
 /// @param name string Semantic color name, e.g. "accent" or "background".
-/// @return (string|nil) "#rrggbb" hex color, or nil if the name is unknown.
+/// @return (string|nil) "#rrggbb" for a truecolor theme, a palette index as a
+///   string like "4" when the theme names an ANSI color, or "default" for the
+///   terminal's own color. Nil only when the name is unknown. Every form can be
+///   passed straight to a span's `fg`/`bg`.
 /// @example
 /// local accent = maki.ui.theme_color("accent")
 /// if accent then
@@ -101,17 +105,22 @@ fn buf(lua: &Lua) -> LuaResult<buf::BufHandle> {
 /// end
 #[lua_fn]
 fn theme_color(lua: &Lua, name: String) -> LuaResult<mlua::Value> {
-    let Some((r, g, b)) = maki_highlight::theme_color(&name) else {
+    let Some(color) = maki_highlight::theme_color(&name) else {
         return Ok(mlua::Value::Nil);
     };
     Ok(mlua::Value::String(
-        lua.create_string(format!("#{r:02x}{g:02x}{b:02x}"))?,
+        lua.create_string(segment_color_to_lua(color))?,
     ))
 }
 
 /// Syntax-highlights a chunk of source code. Returns a table of styled
 /// lines that you can feed into a buffer. Each line is a list of
 /// `{text, style}` spans where style is a `{fg, bold?, italic?, underline?}` table.
+///
+/// `fg` is "#rrggbb" for a truecolor theme, a palette index as a string like
+/// "4" when the theme names an ANSI color, or "default" for the terminal's own
+/// color. Pass the span straight to `buf:line` and it resolves correctly in
+/// every case.
 ///
 /// @param code string Source text to highlight.
 /// @param lang string Language identifier, e.g. "rust", "python".
@@ -580,6 +589,17 @@ fn parse_title_pos(tbl: &Table) -> TitlePos {
         .unwrap_or_default()
 }
 
+/// Palette colors stay symbolic (`"4"`, `"12"`, `"default"`) so the terminal
+/// picks the actual shade; only true RGB is written as hex. Every spelling
+/// here round-trips back through a span's `fg`/`bg`.
+fn segment_color_to_lua(c: SegmentColor) -> String {
+    match c {
+        SegmentColor::Rgb((r, g, b)) => format!("#{r:02x}{g:02x}{b:02x}"),
+        SegmentColor::Ansi(i) => i.to_string(),
+        SegmentColor::Default => DEFAULT_COLOR_NAME.to_owned(),
+    }
+}
+
 fn segments_to_lua_lines(
     lua: &Lua,
     lines: &[Vec<maki_highlight::StyledSegment>],
@@ -591,8 +611,7 @@ fn segments_to_lua_lines(
             let span = lua.create_table_with_capacity(2, 0)?;
             span.raw_set(1, seg.text.as_str())?;
             let style = lua.create_table_with_capacity(0, 4)?;
-            let (r, g, b) = seg.fg;
-            style.raw_set("fg", format!("#{r:02x}{g:02x}{b:02x}"))?;
+            style.raw_set("fg", segment_color_to_lua(seg.fg))?;
             if seg.bold {
                 style.raw_set("bold", true)?;
             }
@@ -631,7 +650,7 @@ fn span_style_to_lua(lua: &Lua, span: &maki_markdown::render::Span) -> LuaResult
             underline,
         } => {
             let tbl = lua.create_table()?;
-            tbl.set("fg", format!("#{:02x}{:02x}{:02x}", fg.0, fg.1, fg.2))?;
+            tbl.set("fg", segment_color_to_lua(*fg))?;
             if *bold {
                 tbl.set("bold", true)?;
             }
@@ -875,7 +894,7 @@ mod tests {
     fn seg(text: &str, bold: bool) -> StyledSegment {
         StyledSegment {
             text: text.into(),
-            fg: (255, 128, 0),
+            fg: SegmentColor::Rgb((255, 128, 0)),
             bold,
             italic: false,
             underline: false,
@@ -1133,7 +1152,7 @@ mod tests {
     fn seg_full(text: &str, bold: bool, italic: bool, underline: bool) -> StyledSegment {
         StyledSegment {
             text: text.into(),
-            fg: (255, 128, 0),
+            fg: SegmentColor::Rgb((255, 128, 0)),
             bold,
             italic,
             underline,
@@ -1258,7 +1277,7 @@ mod tests {
             let span = maki_markdown::render::Span {
                 text: "tok".into(),
                 style: maki_markdown::render::StyleToken::Highlight {
-                    fg: (255, 128, 0),
+                    fg: SegmentColor::Rgb((255, 128, 0)),
                     bold,
                     italic,
                     underline,

--- a/maki-markdown/src/render.rs
+++ b/maki-markdown/src/render.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 use std::iter;
 use std::mem;
 
-use maki_highlight::{CodeHighlighter, StyledSegment};
+use maki_highlight::{CodeHighlighter, SegmentColor, StyledSegment};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::{
@@ -30,10 +30,10 @@ const LONG_LINE_SUFFIX: &str = "...";
 pub enum StyleToken {
     Text,
     InlineCode,
-    /// Syntax-highlighted token. Carries resolved rgb + modifiers so the
+    /// Syntax-highlighted token. Carries the resolved color + modifiers so the
     /// consumer doesn't need to know the language.
     Highlight {
-        fg: (u8, u8, u8),
+        fg: SegmentColor,
         bold: bool,
         italic: bool,
         underline: bool,

--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -19,7 +19,7 @@ use jiff::tz::TimeZone;
 
 use crate::markdown::{should_truncate, text_to_lines, truncate_output, truncation_notice};
 use maki_agent::{
-    BufferSnapshot, InstructionBlock, SnapshotSpan, SpanStyle, ToolInput, ToolOutput,
+    BufferSnapshot, InstructionBlock, SnapshotSpan, SpanColor, SpanStyle, ToolInput, ToolOutput,
 };
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
@@ -615,17 +615,21 @@ fn snapshot_to_lines_range(
     (lines, spinners)
 }
 
+fn span_color(c: SpanColor) -> Option<Color> {
+    theme::segment_slot(theme::segment_color_from_span(c))
+}
+
 pub(crate) fn resolve_span_style(style: &SpanStyle) -> Style {
     match style {
         SpanStyle::Default => theme::current().tool,
         SpanStyle::Named(name) => theme::style_by_name(name),
         SpanStyle::Inline(inline) => {
             let mut s = Style::default();
-            if let Some((r, g, b)) = inline.fg {
-                s = s.fg(Color::Rgb(r, g, b));
+            if let Some(fg) = inline.fg.and_then(span_color) {
+                s = s.fg(fg);
             }
-            if let Some((r, g, b)) = inline.bg {
-                s = s.bg(Color::Rgb(r, g, b));
+            if let Some(bg) = inline.bg.and_then(span_color) {
+                s = s.bg(bg);
             }
             if inline.bold {
                 s = s.bold();
@@ -802,6 +806,7 @@ mod tests {
     use crate::components::{DisplayRole, ToolRole};
     use crate::markdown::TRUNCATION_PREFIX;
     use maki_agent::tools::{BASH_TOOL_NAME, READ_TOOL_NAME, TASK_TOOL_NAME};
+    use maki_agent::types::{DefaultColor, InlineStyle};
     use maki_agent::{SnapshotLine, SnapshotSpan, TextOutput, ToolInput, ToolOutput};
     use test_case::test_case;
 
@@ -1718,10 +1723,9 @@ mod tests {
 
     #[test]
     fn resolve_span_style_inline_all_modifiers() {
-        use maki_agent::types::InlineStyle;
         let style = SpanStyle::Inline(InlineStyle {
-            fg: Some((10, 20, 30)),
-            bg: Some((40, 50, 60)),
+            fg: Some(SpanColor::Rgb((10, 20, 30))),
+            bg: Some(SpanColor::Rgb((40, 50, 60))),
             bold: true,
             italic: true,
             underline: true,
@@ -1739,6 +1743,21 @@ mod tests {
         assert!(resolved.add_modifier.contains(Modifier::DIM));
         assert!(resolved.add_modifier.contains(Modifier::CROSSED_OUT));
         assert!(resolved.add_modifier.contains(Modifier::REVERSED));
+    }
+
+    /// A span asking for the terminal default has to leave the slot empty.
+    /// Setting `Color::Reset` would win over the line style underneath it, and
+    /// the selected row of a plugin float would lose its highlight.
+    #[test_case(SpanColor::Ansi(4), Some(Color::Blue) ; "palette index")]
+    #[test_case(SpanColor::Default(DefaultColor::Default), None ; "terminal default")]
+    fn resolve_span_style_inline_colors(color: SpanColor, expected: Option<Color>) {
+        let style = SpanStyle::Inline(InlineStyle {
+            fg: Some(color),
+            bg: Some(color),
+            ..InlineStyle::default()
+        });
+        let resolved = resolve_span_style(&style);
+        assert_eq!((resolved.fg, resolved.bg), (expected, expected));
     }
 
     #[test]

--- a/maki-ui/src/highlight.rs
+++ b/maki-ui/src/highlight.rs
@@ -1,7 +1,7 @@
 use crate::theme;
 
 use maki_highlight::StyledSegment;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::Span;
 
 pub use maki_highlight::TAB_SPACES;
@@ -24,10 +24,7 @@ pub(crate) fn refresh_syntax_theme() {
             ("diff_new", theme.diff_new.bg),
         ]
         .into_iter()
-        .filter_map(|(name, color)| match color {
-            Some(Color::Rgb(r, g, b)) => Some((name.to_owned(), (r, g, b))),
-            _ => None,
-        })
+        .filter_map(|(name, color)| Some((name.to_owned(), theme::segment_color(color?))))
         .collect(),
     );
 }
@@ -52,15 +49,11 @@ pub fn fallback_span(text: &str) -> Span<'static> {
 pub fn highlight_ansi(lang: &str, code: &str) -> String {
     let theme = theme::current();
     maki_highlight::set_theme(theme.syntax.clone());
-    let bg = match theme.background {
-        Color::Rgb(r, g, b) => (r, g, b),
-        _ => (0, 0, 0),
-    };
-    maki_highlight::highlight_ansi(lang, code, bg)
+    maki_highlight::highlight_ansi(lang, code, theme::segment_color(theme.background))
 }
 
 fn convert_segment(seg: &StyledSegment) -> Style {
-    let mut style = Style::new().fg(Color::Rgb(seg.fg.0, seg.fg.1, seg.fg.2));
+    let mut style = theme::segment_style(seg.fg);
     if seg.bold {
         style = style.add_modifier(Modifier::BOLD);
     }
@@ -76,12 +69,14 @@ fn convert_segment(seg: &StyledSegment) -> Style {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use maki_highlight::SegmentColor;
+    use ratatui::style::Color;
 
     #[test]
     fn convert_segment_modifiers() {
         let all_mods = StyledSegment {
             text: "x".into(),
-            fg: (255, 0, 128),
+            fg: SegmentColor::Rgb((255, 0, 128)),
             bold: true,
             italic: true,
             underline: true,
@@ -94,7 +89,7 @@ mod tests {
 
         let no_mods = StyledSegment {
             text: "plain".into(),
-            fg: (100, 100, 100),
+            fg: SegmentColor::Rgb((100, 100, 100)),
             bold: false,
             italic: false,
             underline: false,

--- a/maki-ui/src/markdown.rs
+++ b/maki-ui/src/markdown.rs
@@ -74,7 +74,7 @@ fn style_for_token(
             italic,
             underline,
         } => {
-            let mut s = Style::default().fg(ratatui::style::Color::Rgb(fg.0, fg.1, fg.2));
+            let mut s = theme::segment_style(*fg);
             if *bold {
                 s = s.add_modifier(Modifier::BOLD);
             }

--- a/maki-ui/src/splash.rs
+++ b/maki-ui/src/splash.rs
@@ -49,6 +49,16 @@ const INTENSITY_SCALE: f32 = 0.3;
 const VIGNETTE_SCALE: f32 = 0.25;
 /// Base opacity for the dimmest field character (0.0–1.0). Higher = less contrast between chars.
 const FIELD_BASE_OPACITY: f32 = 0.5;
+/// How far accent-colored text is blended up from the background.
+const ACCENT_ALPHA: f32 = 0.75;
+/// The same, for secondary text that should recede.
+const MUTED_ALPHA: f32 = 0.5;
+const VERSION_ALPHA: f32 = 0.4;
+/// Peak brightness of the logo, which never reaches the full accent color.
+const LOGO_ALPHA: f32 = 0.85;
+/// The logo's blue channel is nudged up so it reads slightly cooler than the
+/// raw accent.
+const LOGO_BLUE_LIFT: u8 = 15;
 
 const INV_TAU: f32 = 1.0 / std::f32::consts::TAU;
 const TAU: f32 = std::f32::consts::TAU;
@@ -69,50 +79,52 @@ fn fast_sincos(x: f32) -> (f32, f32) {
     (fast_sin(x), fast_sin(x + FRAC_PI_2))
 }
 
+/// Crossfading needs numbers to interpolate, so a palette color has nowhere to
+/// go: it snaps and stays symbolic rather than being flattened to a guess at
+/// what the terminal would have drawn.
 pub struct ColorTransition {
-    from: (u8, u8, u8),
-    to: (u8, u8, u8),
+    from: Color,
+    to: Color,
     start: Instant,
 }
 
 impl ColorTransition {
     pub fn new(color: Color) -> Self {
-        let rgb = extract_rgb(color, (100, 140, 255));
         Self {
-            from: rgb,
-            to: rgb,
+            from: color,
+            to: color,
             start: Instant::now() - std::time::Duration::from_secs_f32(COLOR_TRANSITION_SECS),
         }
     }
 
     pub fn set(&mut self, color: Color) {
-        let rgb = extract_rgb(color, (100, 140, 255));
-        if rgb == self.to {
+        if color == self.to {
             return;
         }
         let now = Instant::now();
-        self.from = self.resolve_rgb(now);
-        self.to = rgb;
+        self.from = self.resolve_at(now);
+        self.to = color;
         self.start = now;
     }
 
+    /// A snapped transition has nothing left to draw, so it must not keep the
+    /// repaint loop awake for the rest of its window.
     pub fn is_animating(&self) -> bool {
-        Instant::now().duration_since(self.start).as_secs_f32() < COLOR_TRANSITION_SECS
+        matches!((self.from, self.to), (Color::Rgb(..), Color::Rgb(..)))
+            && Instant::now().duration_since(self.start).as_secs_f32() < COLOR_TRANSITION_SECS
     }
 
     pub fn resolve(&self) -> Color {
-        let (r, g, b) = self.resolve_rgb(Instant::now());
-        Color::Rgb(r, g, b)
+        self.resolve_at(Instant::now())
     }
 
-    fn resolve_rgb(&self, now: Instant) -> (u8, u8, u8) {
+    fn resolve_at(&self, now: Instant) -> Color {
+        let (Color::Rgb(fr, fg, fb), Color::Rgb(tr, tg, tb)) = (self.from, self.to) else {
+            return self.to;
+        };
         let t = (now.duration_since(self.start).as_secs_f32() / COLOR_TRANSITION_SECS).min(1.0);
         let p = ease_out_cubic(t);
-        (
-            lerp_u8(self.from.0, self.to.0, p),
-            lerp_u8(self.from.1, self.to.1, p),
-            lerp_u8(self.from.2, self.to.2, p),
-        )
+        Color::Rgb(lerp_u8(fr, tr, p), lerp_u8(fg, tg, p), lerp_u8(fb, tb, p))
     }
 }
 
@@ -194,10 +206,16 @@ impl Splash {
         render_version(area, buf, fade, area.y, self.latest_version);
     }
 
+    /// The field is a gradient of intensities between the background and the
+    /// accent, so it needs both as numbers. On a palette theme there is
+    /// nothing to interpolate and the splash simply draws without it.
     fn render_field(&self, area: Rect, buf: &mut Buffer, t: f32, fade: f32, accent: Color) {
         let theme = theme::current();
-        let (ac_r, ac_g, ac_b) = extract_rgb(accent, (100, 140, 255));
-        let (bg_r, bg_g, bg_b) = extract_rgb(theme.background, (15, 15, 25));
+        let (Color::Rgb(ac_r, ac_g, ac_b), Color::Rgb(bg_r, bg_g, bg_b)) =
+            (accent, theme.background)
+        else {
+            return;
+        };
 
         let w = area.width as usize;
         let h = area.height as usize;
@@ -340,19 +358,15 @@ impl Splash {
     ) {
         let theme = theme::current();
         let bg = theme.background;
-        let (ac_r, ac_g, ac_b) = extract_rgb(accent, (100, 140, 255));
-        let (bg_r, bg_g, bg_b) = extract_rgb(bg, (15, 15, 25));
 
         let logo_x = area.x + (area.width.saturating_sub(LOGO.len() as u16)) / 2;
-        let alpha = 0.85 * ease_out_cubic(((t - LOGO_DELAY) / LOGO_RAMP).clamp(0.0, 1.0)) * fade;
-        let style = Style::new()
-            .fg(Color::Rgb(
-                lerp_u8(bg_r, ac_r, alpha),
-                lerp_u8(bg_g, ac_g, alpha),
-                lerp_u8(bg_b, ac_b.saturating_add(15), alpha),
-            ))
-            .bg(bg)
-            .add_modifier(Modifier::BOLD);
+        let alpha =
+            LOGO_ALPHA * ease_out_cubic(((t - LOGO_DELAY) / LOGO_RAMP).clamp(0.0, 1.0)) * fade;
+        let lifted = match accent {
+            Color::Rgb(r, g, b) => Color::Rgb(r, g, b.saturating_add(LOGO_BLUE_LIFT)),
+            symbolic => symbolic,
+        };
+        let style = faded_style(lifted, bg, alpha).add_modifier(Modifier::BOLD);
 
         for (col, ch) in LOGO.chars().enumerate() {
             let x = logo_x + col as u16;
@@ -372,9 +386,6 @@ impl Splash {
 
         let theme = theme::current();
         let bg = theme.background;
-        let ac = extract_rgb(accent, (100, 140, 255));
-        let fg = extract_rgb(theme.foreground, (200, 200, 200));
-        let bg_rgb = extract_rgb(bg, (15, 15, 25));
 
         let total_width: u16 = HELP_SEGMENTS.iter().map(|(s, _)| s.len() as u16).sum();
         let x_start = area.x + area.width.saturating_sub(total_width) / 2;
@@ -382,8 +393,12 @@ impl Splash {
         let segments: Vec<_> = HELP_SEGMENTS
             .iter()
             .map(|&(text, highlighted)| {
-                let (target, alpha) = if highlighted { (ac, 0.75) } else { (fg, 0.5) };
-                (text, faded_style(bg_rgb, target, alpha * fade, bg))
+                let (target, alpha) = if highlighted {
+                    (accent, ACCENT_ALPHA)
+                } else {
+                    (theme.foreground, MUTED_ALPHA)
+                };
+                (text, faded_style(target, bg, alpha * fade))
             })
             .collect();
 
@@ -397,13 +412,7 @@ impl Splash {
 
         let theme = theme::current();
         let bg = theme.background;
-        let tip_rgb = extract_rgb(
-            theme.todo_in_progress.fg.unwrap_or(Color::Yellow),
-            (249, 226, 175),
-        );
-        let ac = extract_rgb(accent, (100, 140, 255));
-        let fg = extract_rgb(theme.foreground, (200, 200, 200));
-        let bg_rgb = extract_rgb(bg, (15, 15, 25));
+        let tip_fg = theme.todo_in_progress.fg.unwrap_or(Color::Yellow);
 
         let (label, desc) = TIPS[self.tip_idx];
         let total_width = (5 + label.len() + 1 + desc.len()) as u16;
@@ -412,11 +421,11 @@ impl Splash {
         let segments: &[(&str, Style)] = &[
             (
                 "tip: ",
-                faded_style(bg_rgb, tip_rgb, 0.75 * fade, bg).add_modifier(Modifier::BOLD),
+                faded_style(tip_fg, bg, ACCENT_ALPHA * fade).add_modifier(Modifier::BOLD),
             ),
-            (label, faded_style(bg_rgb, ac, 0.75 * fade, bg)),
+            (label, faded_style(accent, bg, ACCENT_ALPHA * fade)),
             (" ", Style::default()),
-            (desc, faded_style(bg_rgb, fg, 0.5 * fade, bg)),
+            (desc, faded_style(theme.foreground, bg, MUTED_ALPHA * fade)),
         ];
 
         render_segments(area, buf, tip_y, x_start, segments);
@@ -433,12 +442,7 @@ fn render_version(area: Rect, buf: &mut Buffer, fade: f32, y: u16, new_version: 
         Some(v) => format!("v{}{UPDATE_HINT}{v}", update::CURRENT),
         None => format!("v{}", update::CURRENT),
     };
-    let style = faded_style(
-        extract_rgb(bg, (15, 15, 25)),
-        extract_rgb(theme.foreground, (200, 200, 200)),
-        0.4 * fade,
-        bg,
-    );
+    let style = faded_style(theme.foreground, bg, VERSION_ALPHA * fade);
     let x_start = area.x + area.width.saturating_sub(text.chars().count() as u16 + 1);
     render_segments(area, buf, y, x_start, &[(&text, style)]);
 }
@@ -456,31 +460,24 @@ fn render_centered_faded(
     }
     let theme = theme::current();
     let bg = theme.background;
-    let style = faded_style(
-        extract_rgb(bg, (15, 15, 25)),
-        extract_rgb(theme.foreground, (200, 200, 200)),
-        intensity * fade,
-        bg,
-    );
+    let style = faded_style(theme.foreground, bg, intensity * fade);
     let x_start = area.x + area.width.saturating_sub(text.chars().count() as u16) / 2;
     render_segments(area, buf, y, x_start, &[(text, style)]);
 }
 
-fn extract_rgb(color: Color, fallback: (u8, u8, u8)) -> (u8, u8, u8) {
-    match color {
-        Color::Rgb(r, g, b) => (r, g, b),
-        _ => fallback,
+/// Fading means blending toward the background, which needs both ends as
+/// numbers. A palette color has no value to blend, so it is drawn flat instead
+/// of being resolved to a guess at what the terminal would have shown.
+fn faded_style(fg: Color, bg: Color, alpha: f32) -> Style {
+    let style = Style::new().bg(bg);
+    match (fg, bg) {
+        (Color::Rgb(fr, fg_, fb), Color::Rgb(br, bg_, bb)) => style.fg(Color::Rgb(
+            lerp_u8(br, fr, alpha),
+            lerp_u8(bg_, fg_, alpha),
+            lerp_u8(bb, fb, alpha),
+        )),
+        _ => style.fg(fg),
     }
-}
-
-fn faded_style(bg: (u8, u8, u8), fg: (u8, u8, u8), alpha: f32, bg_color: Color) -> Style {
-    Style::new()
-        .fg(Color::Rgb(
-            lerp_u8(bg.0, fg.0, alpha),
-            lerp_u8(bg.1, fg.1, alpha),
-            lerp_u8(bg.2, fg.2, alpha),
-        ))
-        .bg(bg_color)
 }
 
 fn render_segments(area: Rect, buf: &mut Buffer, y: u16, x_start: u16, segments: &[(&str, Style)]) {
@@ -512,26 +509,26 @@ mod tests {
     use std::time::Duration;
     use test_case::test_case;
 
-    fn transition_at(from: (u8, u8, u8), to: (u8, u8, u8), offset: Duration) -> (u8, u8, u8) {
+    fn transition_at(from: (u8, u8, u8), to: (u8, u8, u8), offset: Duration) -> Color {
         let mut ct = ColorTransition::new(Color::Rgb(from.0, from.1, from.2));
         ct.set(Color::Rgb(to.0, to.1, to.2));
-        ct.resolve_rgb(ct.start + offset)
+        ct.resolve_at(ct.start + offset)
     }
 
     #[test]
     fn interpolation_over_time() {
         let start = transition_at((0, 0, 0), (200, 200, 200), Duration::ZERO);
-        assert_eq!(start, (0, 0, 0));
+        assert_eq!(start, Color::Rgb(0, 0, 0));
 
-        let mid = transition_at((0, 0, 0), (200, 200, 200), Duration::from_millis(200));
-        assert!(
-            mid.0 > 0 && mid.0 < 200,
-            "expected interpolated, got {}",
-            mid.0
-        );
+        let Color::Rgb(mid, _, _) =
+            transition_at((0, 0, 0), (200, 200, 200), Duration::from_millis(200))
+        else {
+            panic!("an rgb transition stays rgb");
+        };
+        assert!(mid > 0 && mid < 200, "expected interpolated, got {mid}");
 
         let done = transition_at((0, 0, 0), (255, 255, 255), Duration::from_millis(500));
-        assert_eq!(done, (255, 255, 255));
+        assert_eq!(done, Color::Rgb(255, 255, 255));
     }
 
     #[test]
@@ -540,8 +537,8 @@ mod tests {
         ct.set(Color::Rgb(200, 100, 50));
         ct.set(Color::Rgb(10, 20, 30));
 
-        let done = ct.resolve_rgb(ct.start + Duration::from_secs(1));
-        assert_eq!(done, (10, 20, 30));
+        let done = ct.resolve_at(ct.start + Duration::from_secs(1));
+        assert_eq!(done, Color::Rgb(10, 20, 30));
     }
 
     const NEW_VERSION: &str = "99.9.9";
@@ -596,12 +593,53 @@ mod tests {
         assert!(ct.is_animating(), "animating after set");
     }
 
-    #[test]
-    fn non_rgb_color_uses_fallback() {
-        let ct = ColorTransition::new(Color::Blue);
-        assert_eq!(
-            ct.resolve_rgb(ct.start + Duration::from_secs(1)),
-            (100, 140, 255)
+    /// Resolving a palette color to rgb here would defeat the point of asking
+    /// for it, so it crosses the transition untouched.
+    #[test_case(Color::Blue, Color::Rgb(1, 2, 3); "into rgb")]
+    #[test_case(Color::Rgb(1, 2, 3), Color::Blue; "out of rgb")]
+    fn a_palette_color_snaps_instead_of_blending(from: Color, to: Color) {
+        let mut ct = ColorTransition::new(from);
+        ct.set(to);
+        assert_eq!(ct.resolve_at(ct.start), to);
+        assert!(
+            !ct.is_animating(),
+            "a snapped transition must not keep asking for frames"
         );
+    }
+
+    const ANSI_THEME_NAME: &str = "an all-ansi theme must parse";
+    const ANSI_THEME: &str = r#"
+[palette]
+background = "black"
+foreground = "white"
+
+[ui]
+background = { bg = "background" }
+foreground = { fg = "foreground" }
+todo_in_progress = { fg = "yellow" }
+"#;
+
+    /// The starfield needs numbers to build its gradient; on a palette theme
+    /// the splash draws flat rather than inventing truecolor for it. The theme
+    /// is installed here rather than inherited, because the default one is
+    /// truecolor and would make this pass or fail on test ordering.
+    #[test]
+    fn a_palette_accent_keeps_the_splash_free_of_truecolor() {
+        theme::set(theme::Theme::from_toml(ANSI_THEME).expect(ANSI_THEME_NAME));
+
+        let mut splash = Splash::new(true);
+        // At t=0 the entry fade has not started painting, so the assertion
+        // below would hold no matter what the field did.
+        splash.start -= Duration::from_secs_f32(FADE_DURATION);
+        let area = Rect::new(0, 0, 80, 20);
+        let mut buf = Buffer::empty(area);
+        splash.render(area, &mut buf, Color::Blue);
+
+        let rgb = buf
+            .content
+            .iter()
+            .filter_map(|c| c.style().fg)
+            .find(|fg| matches!(fg, Color::Rgb(..)));
+        assert_eq!(rgb, None, "a palette theme must not produce rgb cells");
     }
 }

--- a/maki-ui/src/theme.rs
+++ b/maki-ui/src/theme.rs
@@ -4,6 +4,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 
 use arc_swap::{ArcSwap, Guard};
+use maki_agent::SpanColor;
+use maki_highlight::SegmentColor;
 use maki_storage::StateDir;
 use ratatui::style::{Color, Modifier, Style};
 use serde::Deserialize;
@@ -491,38 +493,103 @@ fn helix_to_textmate_scope(key: &str) -> &str {
     key
 }
 
-fn parse_hex_rgb(s: &str) -> Option<(u8, u8, u8)> {
-    let hex = s.strip_prefix('#')?;
-    if hex.len() != 6 {
-        return None;
-    }
-    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
-    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
-    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
-    Some((r, g, b))
+fn parse_color(s: &str) -> Option<Color> {
+    SegmentColor::parse(s).map(to_color)
 }
 
-fn parse_hex(s: &str) -> Option<Color> {
-    let (r, g, b) = parse_hex_rgb(s)?;
-    Some(Color::Rgb(r, g, b))
+/// Named variants beat `Indexed(0..=7)` because terminals treat the bold
+/// attribute differently for the two, and ANSI themes expect named behaviour.
+fn indexed_to_color(i: u8) -> Color {
+    match i {
+        0 => Color::Black,
+        1 => Color::Red,
+        2 => Color::Green,
+        3 => Color::Yellow,
+        4 => Color::Blue,
+        5 => Color::Magenta,
+        6 => Color::Cyan,
+        7 => Color::Gray,
+        8 => Color::DarkGray,
+        9 => Color::LightRed,
+        10 => Color::LightGreen,
+        11 => Color::LightYellow,
+        12 => Color::LightBlue,
+        13 => Color::LightMagenta,
+        14 => Color::LightCyan,
+        15 => Color::White,
+        n => Color::Indexed(n),
+    }
 }
 
 fn parse_syn_color(s: &str, palette: &HashMap<String, String>) -> Option<SynColor> {
     let resolved = if s.starts_with('#') {
         s
     } else {
-        palette.get(s)?.as_str()
+        palette.get(s).map(String::as_str).unwrap_or(s)
     };
-    let (r, g, b) = parse_hex_rgb(resolved)?;
-    Some(SynColor { r, g, b, a: 0xFF })
+    SegmentColor::parse(resolved).map(SegmentColor::to_syntect)
+}
+
+/// The highlighter speaks [`SegmentColor`], ratatui speaks [`Color`]. Anything
+/// the terminal resolves itself (named, indexed, reset) crosses over as a
+/// palette index so it stays symbolic.
+pub(crate) fn segment_color(c: Color) -> SegmentColor {
+    match c {
+        Color::Rgb(r, g, b) => SegmentColor::Rgb((r, g, b)),
+        Color::Indexed(i) => SegmentColor::Ansi(i),
+        Color::Reset => SegmentColor::Default,
+        Color::Black => SegmentColor::Ansi(0),
+        Color::Red => SegmentColor::Ansi(1),
+        Color::Green => SegmentColor::Ansi(2),
+        Color::Yellow => SegmentColor::Ansi(3),
+        Color::Blue => SegmentColor::Ansi(4),
+        Color::Magenta => SegmentColor::Ansi(5),
+        Color::Cyan => SegmentColor::Ansi(6),
+        Color::Gray => SegmentColor::Ansi(7),
+        Color::DarkGray => SegmentColor::Ansi(8),
+        Color::LightRed => SegmentColor::Ansi(9),
+        Color::LightGreen => SegmentColor::Ansi(10),
+        Color::LightYellow => SegmentColor::Ansi(11),
+        Color::LightBlue => SegmentColor::Ansi(12),
+        Color::LightMagenta => SegmentColor::Ansi(13),
+        Color::LightCyan => SegmentColor::Ansi(14),
+        Color::White => SegmentColor::Ansi(15),
+    }
+}
+
+/// Inverse of [`segment_color`]. `Default` becomes [`Color::Reset`] rather
+/// than a guess, so the terminal keeps deciding.
+pub(crate) fn to_color(c: SegmentColor) -> Color {
+    match c {
+        SegmentColor::Rgb((r, g, b)) => Color::Rgb(r, g, b),
+        SegmentColor::Ansi(i) => indexed_to_color(i),
+        SegmentColor::Default => Color::Reset,
+    }
+}
+
+/// Plugin spans speak [`SpanColor`] because their crate is a wire format that
+/// must not pull in the highlighter. Both types are foreign here, so the
+/// orphan rule rules out a `From` impl.
+pub(crate) fn segment_color_from_span(c: SpanColor) -> SegmentColor {
+    match c {
+        SpanColor::Rgb(rgb) => SegmentColor::Rgb(rgb),
+        SpanColor::Ansi(i) => SegmentColor::Ansi(i),
+        SpanColor::Default(_) => SegmentColor::Default,
+    }
+}
+
+/// A segment asking for the terminal default leaves the slot unset so the
+/// enclosing style still shows through, which [`Color::Reset`] would override.
+pub(crate) fn segment_slot(c: SegmentColor) -> Option<Color> {
+    (c != SegmentColor::Default).then(|| to_color(c))
+}
+
+pub(crate) fn segment_style(c: SegmentColor) -> Style {
+    segment_slot(c).map_or(Style::new(), |c| Style::new().fg(c))
 }
 
 fn resolve_color(name: &str, palette: &HashMap<String, Color>) -> Option<Color> {
-    if name.starts_with('#') {
-        parse_hex(name)
-    } else {
-        palette.get(name).copied()
-    }
+    palette.get(name).copied().or_else(|| parse_color(name))
 }
 
 fn resolve_modifier(name: &str) -> Modifier {
@@ -554,15 +621,10 @@ fn resolve_style(def: &StyleDef, palette: &HashMap<String, Color>) -> Style {
 fn scope_fg(
     full_table: &toml::Table,
     palette: &HashMap<String, Color>,
-    raw_palette: &HashMap<String, String>,
     scope: &str,
 ) -> Option<Color> {
     let table = full_table.get(scope)?.as_table()?;
-    let fg_val = table.get("fg")?.as_str()?;
-    resolve_color(fg_val, palette).or_else(|| {
-        let resolved = raw_palette.get(fg_val)?;
-        parse_hex(resolved)
-    })
+    resolve_color(table.get("fg")?.as_str()?, palette)
 }
 
 fn resolve_font_style(modifiers: &[String]) -> FontStyle {
@@ -656,7 +718,7 @@ fn build_syntax_theme(
 }
 
 impl Theme {
-    fn from_toml(toml_str: &str) -> Result<Self, String> {
+    pub(crate) fn from_toml(toml_str: &str) -> Result<Self, String> {
         let full_table: toml::Table = toml::from_str(toml_str).map_err(|e| e.to_string())?;
 
         let raw_palette: HashMap<String, String> = full_table
@@ -671,7 +733,7 @@ impl Theme {
 
         let palette: HashMap<String, Color> = raw_palette
             .iter()
-            .filter_map(|(k, v)| parse_hex(v).map(|c| (k.clone(), c)))
+            .filter_map(|(k, v)| parse_color(v).map(|c| (k.clone(), c)))
             .collect();
 
         let ui: HashMap<String, StyleDef> = full_table
@@ -698,7 +760,7 @@ impl Theme {
                 return *c;
             }
             for scope in scopes {
-                if let Some(c) = scope_fg(&full_table, &palette, &raw_palette, scope) {
+                if let Some(c) = scope_fg(&full_table, &palette, scope) {
                     return c;
                 }
             }
@@ -710,7 +772,7 @@ impl Theme {
                 return resolve_style(d, &palette);
             }
             for scope in scopes {
-                if let Some(c) = scope_fg(&full_table, &palette, &raw_palette, scope) {
+                if let Some(c) = scope_fg(&full_table, &palette, scope) {
                     return Style::new().fg(c).add_modifier(mods);
                 }
             }
@@ -878,6 +940,8 @@ pub(crate) fn lerp_u8(a: u8, b: u8, t: f32) -> u8 {
     (a as f32 + (b as f32 - a as f32) * t.clamp(0.0, 1.0)) as u8
 }
 
+/// A palette color has no numeric value to blend toward the background, so
+/// those themes fall back to the terminal's own dim attribute.
 pub(crate) fn dim_style(style: Style, factor: f32) -> Style {
     match (style.fg, current().background) {
         (Some(Color::Rgb(fr, fg, fb)), Color::Rgb(br, bg, bb)) => style.fg(Color::Rgb(
@@ -885,7 +949,7 @@ pub(crate) fn dim_style(style: Style, factor: f32) -> Style {
             lerp_u8(fg, bg, factor),
             lerp_u8(fb, bb, factor),
         )),
-        _ => style,
+        _ => style.add_modifier(Modifier::DIM),
     }
 }
 
@@ -904,6 +968,21 @@ fn brighten_toward(style: Style, from: Color, to: Color, t: f32) -> Style {
 mod tests {
     use super::*;
     use test_case::test_case;
+
+    #[test_case(Color::Rgb(1, 2, 3), SegmentColor::Rgb((1, 2, 3)); "truecolor")]
+    #[test_case(Color::Indexed(200), SegmentColor::Ansi(200); "indexed")]
+    #[test_case(Color::Reset, SegmentColor::Default; "reset")]
+    #[test_case(Color::LightBlue, SegmentColor::Ansi(12); "named maps to its palette index")]
+    fn ratatui_colors_convert_to_segment_colors(color: Color, expected: SegmentColor) {
+        assert_eq!(segment_color(color), expected);
+    }
+
+    #[test]
+    fn dim_style_falls_back_to_the_dim_modifier_for_palette_colors() {
+        let dimmed = dim_style(Style::new().fg(Color::Blue), 0.4);
+        assert_eq!(dimmed.fg, Some(Color::Blue), "palette color stays symbolic");
+        assert!(dimmed.add_modifier.contains(Modifier::DIM));
+    }
 
     fn dracula_toml() -> &'static str {
         BUNDLED_THEMES
@@ -1243,6 +1322,101 @@ mode_build = "#112233"
         assert_eq!(
             maki_highlight::theme().settings.background,
             tokyonight().syntax.settings.background,
+        );
+    }
+
+    #[test_case("light-gray", Color::DarkGray; "name")]
+    #[test_case("4", Color::Blue; "low index prefers the named variant")]
+    #[test_case("42", Color::Indexed(42); "high index stays indexed")]
+    #[test_case("#fda331", Color::Rgb(0xfd, 0xa3, 0x31); "hex")]
+    fn theme_accepts_documented_spellings(input: &str, expected: Color) {
+        assert_eq!(parse_color(input), Some(expected));
+    }
+
+    #[test_case("lightgray"; "missing separator")]
+    #[test_case("256"; "index out of range")]
+    fn theme_rejects_sloppy_spellings(input: &str) {
+        assert_eq!(parse_color(input), None);
+    }
+
+    #[test]
+    fn ansi_syntax_scopes_encode_palette_markers() {
+        let toml = r##"
+"keyword" = { fg = "magenta" }
+"comment" = { fg = "default" }
+"type"    = { fg = "#fda331" }
+
+[palette]
+background = "black"
+foreground = "white"
+magenta    = "magenta"
+"##;
+        let t = Theme::from_toml(toml).unwrap();
+
+        let fg = t
+            .syntax
+            .settings
+            .foreground
+            .expect("foreground must resolve");
+        assert_eq!(
+            SegmentColor::from_syntect(fg),
+            SegmentColor::Ansi(15),
+            "white is palette 15"
+        );
+
+        let bg = t
+            .syntax
+            .settings
+            .background
+            .expect("background must resolve");
+        assert_eq!(
+            SegmentColor::from_syntect(bg),
+            SegmentColor::Ansi(0),
+            "black is palette 0"
+        );
+
+        let scope = |name: &str| {
+            let item = t
+                .syntax
+                .scopes
+                .iter()
+                .find(|i| format!("{:?}", i.scope).contains(name))
+                .unwrap_or_else(|| panic!("scope {name} must exist"));
+            item.style.foreground.expect("scope fg must resolve")
+        };
+
+        let kw = scope("keyword");
+        assert_eq!(SegmentColor::from_syntect(kw), SegmentColor::Ansi(5));
+
+        let comment = scope("comment");
+        assert_eq!(
+            SegmentColor::from_syntect(comment),
+            SegmentColor::Default,
+            "default means terminal default"
+        );
+
+        let ty = scope("type");
+        assert_eq!((ty.r, ty.g, ty.b, ty.a), (0xfd, 0xa3, 0x31, 0xFF));
+    }
+
+    #[test]
+    fn ui_entries_resolve_through_the_palette() {
+        let toml = r##"
+[palette]
+background = "black"
+orange = "light-red"
+
+[ui]
+accent = { fg = "orange" }
+error = { fg = "red" }
+"##;
+        let t = Theme::from_toml(toml).unwrap();
+        assert_eq!(t.background, Color::Black);
+        assert_eq!(t.accent.fg, Some(Color::LightRed), "via palette key");
+        assert_eq!(
+            t.error.fg,
+            Some(Color::Red),
+            "direct name, no palette entry"
         );
     }
 }

--- a/plugins/grep/init.lua
+++ b/plugins/grep/init.lua
@@ -71,11 +71,10 @@ local function dim_spans(spans)
   local result = {}
   for _, span in ipairs(spans) do
     local style = span[2]
-    if type(style) == "table" and style.fg then
-      result[#result + 1] = { span[1], { fg = color.dim(style.fg, DIM_FACTOR) } }
-    else
-      result[#result + 1] = { span[1], "dim" }
-    end
+    local fg = type(style) == "table" and style.fg or nil
+    local faded = fg and color.dim(fg, DIM_FACTOR)
+    -- A palette color has no value to blend, so the terminal dims it instead.
+    result[#result + 1] = faded and { span[1], { fg = faded } } or { span[1], { fg = fg, dim = true } }
   end
   return result
 end

--- a/plugins/lib/maki/color.lua
+++ b/plugins/lib/maki/color.lua
@@ -1,10 +1,10 @@
 local M = {}
 
 function M.lerp(from, to, t)
-  local fr, fg, fb = from:match("#(%x%x)(%x%x)(%x%x)")
-  local tr, tg, tb = to:match("#(%x%x)(%x%x)(%x%x)")
+  local fr, fg, fb = from:match("^#(%x%x)(%x%x)(%x%x)$")
+  local tr, tg, tb = to:match("^#(%x%x)(%x%x)(%x%x)$")
   if not fr or not tr then
-    return from
+    return nil
   end
   fr, fg, fb = tonumber(fr, 16), tonumber(fg, 16), tonumber(fb, 16)
   tr, tg, tb = tonumber(tr, 16), tonumber(tg, 16), tonumber(tb, 16)
@@ -15,8 +15,8 @@ function M.lerp(from, to, t)
 end
 
 function M.dim(color, factor)
-  local bg = maki.ui.theme_color("background") or "#000000"
-  return M.lerp(color, bg, factor)
+  local bg = maki.ui.theme_color("background")
+  return bg and M.lerp(color, bg, factor)
 end
 
 return M

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -87,7 +87,11 @@ Available themes: `ayu_dark`, `ayu_light`, `ayu_mirage`, `carbonfox`, `catppucci
 
 You can add your own themes too. Drop a `<name>.toml` file into `themes/` inside your Maki config directory, for example `~/.config/maki/themes/`. If it reuses a built-in name, yours wins.
 
-Themes use 24-bit colors, but not every terminal can show them. Maki checks the environment, terminfo, and the terminal itself, and when truecolor is missing it quietly falls back to the closest of the 256 classic terminal colors. If detection gets it wrong, set `MAKI_TRUECOLOR=1` to force truecolor or `MAKI_TRUECOLOR=0` to force the fallback.
+Themes use 24-bit colors by default, but not every terminal can show them. Maki checks the environment, terminfo, and the terminal itself, and when truecolor is missing it quietly falls back to the closest of the 256 classic terminal colors. If detection gets it wrong, set `MAKI_TRUECOLOR=1` to force truecolor or `MAKI_TRUECOLOR=0` to force the fallback.
+
+Theme files can also name terminal colors instead of giving hex values, using the same names as Helix: `default`, `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `gray`, `light-red`, `light-green`, `light-yellow`, `light-blue`, `light-magenta`, `light-cyan`, `light-gray`, and `white`. Write them exactly as listed. `lightgray`, `light_gray` and `LIGHT-GRAY` are all rejected. `default` means the terminal default. Maki also takes a number from `0` to `255` to pick a palette entry by index, which Helix does not.
+
+These work everywhere a hex value does, including syntax highlighting scopes, so a theme can be written entirely against the palette your terminal already defines. Maki passes them through as palette references rather than resolving them to RGB, so the colors stay correct in terminals that mangle truecolor, such as nested tmux over ssh.
 
 ### `ui.tool_output_lines`
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -4742,7 +4742,10 @@ your plugin's colors consistent with the rest of the UI.
 
 - `{name}` (`string`) Semantic color name, e.g. "accent" or "background".
 
-**Returns:** (`string|nil`) "#rrggbb" hex color, or nil if the name is unknown.
+**Returns:** (`string|nil`) "#rrggbb" for a truecolor theme, a palette index as a
+  string like "4" when the theme names an ANSI color, or "default" for the
+  terminal's own color. Nil only when the name is unknown. Every form can be
+  passed straight to a span's `fg`/`bg`.
 
 **Example:**
 
@@ -4764,6 +4767,11 @@ maki.ui.highlight({code}, {lang}, {opts?})
 Syntax-highlights a chunk of source code. Returns a table of styled
 lines that you can feed into a buffer. Each line is a list of
 `{text, style}` spans where style is a `{fg, bold?, italic?, underline?}` table.
+
+`fg` is "#rrggbb" for a truecolor theme, a palette index as a string like
+"4" when the theme names an ANSI color, or "default" for the terminal's own
+color. Pass the span straight to `buf:line` and it resolves correctly in
+every case.
 
 **Parameters:**
 
@@ -5310,8 +5318,11 @@ Buf:line({line})
 Appends a single line to the end of the buffer. You can pass a
 plain string for unstyled text, or a table of `{text, style?}` spans
 for rich content. Style can be a named string like "bold" or
-"keyword", or an inline table `{fg?, bg?, bold?, italic?, underline?, dim?, strikethrough?, reversed?}`
-with "#rrggbb" color strings.
+"keyword", or an inline table `{fg?, bg?, bold?, italic?, underline?, dim?, strikethrough?, reversed?}`.
+Colors accept "#rrggbb", a terminal color name like "blue" or "light-gray",
+or a palette index as a string like "4". Names must be spelled exactly,
+hyphens included. Named and indexed colors are left for the terminal to
+resolve, so they follow the user's palette.
 
 **Parameters:**
 
@@ -5665,10 +5676,10 @@ shown as full source, larger ones as their public interface.
 local M = {}
 
 function M.lerp(from, to, t)
-  local fr, fg, fb = from:match("#(%x%x)(%x%x)(%x%x)")
-  local tr, tg, tb = to:match("#(%x%x)(%x%x)(%x%x)")
+  local fr, fg, fb = from:match("^#(%x%x)(%x%x)(%x%x)$")
+  local tr, tg, tb = to:match("^#(%x%x)(%x%x)(%x%x)$")
   if not fr or not tr then
-    return from
+    return nil
   end
   fr, fg, fb = tonumber(fr, 16), tonumber(fg, 16), tonumber(fb, 16)
   tr, tg, tb = tonumber(tr, 16), tonumber(tg, 16), tonumber(tb, 16)
@@ -5679,8 +5690,8 @@ function M.lerp(from, to, t)
 end
 
 function M.dim(color, factor)
-  local bg = maki.ui.theme_color("background") or "#000000"
-  return M.lerp(color, bg, factor)
+  local bg = maki.ui.theme_color("background")
+  return bg and M.lerp(color, bg, factor)
 end
 
 return M


### PR DESCRIPTION
Themes could only give hex values, so on terminals that mangle truecolor the whole UI drifted to the wrong colors. Nested tmux over ssh is the usual way to hit it.

A theme can now name a palette color and maki passes it through as a reference, so the terminal decides how it looks.

```toml
[palette]
background = "black"
orange     = "light-red"

[ui]
accent = { fg = "orange" }
error  = { fg = "red" }
```

## Names

The names are Helix's, so its themes load unchanged alongside the scope mapping that was already there: `default`, `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `gray`, `light-red`, `light-green`, `light-yellow`, `light-blue`, `light-magenta`, `light-cyan`, `light-gray`, `white`.

Spelling is exact. `lightgray`, `light_gray` and `LIGHT-GRAY` are all rejected, because ratatui's `FromStr` strips every space, dash and underscore and would otherwise accept `d-a-r-kgray`. An index from `0` to `255` also works, which Helix has no equivalent for.

## Syntax highlighting

Named colors work anywhere hex does, scopes included. syntect has no ANSI variant, but it carries its RGBA struct through untouched, so the palette index rides in the alpha byte using bat's convention: `a=0` means `r` holds an index, `a=1` means the terminal default. `maki-highlight` decodes that into a `SegmentColor`, and the ratatui, SGR and Lua consumers each render it in their own terms.

Without this, an all-ANSI theme parsed fine but produced an empty syntect theme, and every markdown body rendered unstyled.

## No RGB guessing

Nothing resolves a palette color to concrete RGB. An earlier iteration had a hardcoded xterm table, which turned ANSI blue into `#0000ff` and was visible in any plugin-rendered output such as the highlighted command in bash tool calls. Guessing what index 4 looks like defeats the point of asking for ANSI.

Plugin spans carry a `SpanColor` for the same reason. It is `#[serde(untagged)]`, so sessions written before it still deserialize.

Fixes #892


## AI use

Written by an agent (Claude Opus 4.6 via maki), directed interactively by @untitaker. The work started from a real bug: maki's UI rendered orange in a nested tmux session.

The agent did the code, tests and docs. The human caught the substantive problems, and most of the review cycles came from that rather than from the initial implementation:

- The first version made `[palette]` accept color names but left `parse_syn_color` hex-only, so an all-ANSI theme parsed cleanly and then rendered every markdown body unstyled. Reported as "i reloaded and now everything is white".
- The agent then added a hardcoded xterm table to flatten palette colors to RGB. The human rejected it outright ("we cannot hardcode such a mapping"), which was correct and is why the PR now keeps palette colors symbolic end to end. The bug was visible as ANSI blue rendering as `#0000ff` in bash tool calls.
- Name parsing initially inherited ratatui's `FromStr`, which accepts `d-a-r-kgray`. Flagged as too sloppy.
- `ansi_color_index` was first written as a scan over a static array. Flagged, now a `match`.
- The color names were the agent's own invention until the human asked whether Helix themes were supported. They were not, and the vocabulary now follows Helix.

Prompts were short and corrective, in the style of the ones in CONTRIBUTING.md. A subagent review pass with the goal "make the diff smaller" cut it by roughly 50 lines, though two of its eight suggestions were wrong and were rejected.
