### PR TITLE
fix(providers): retry Codex overloads instead of failing the run

### DIFF
--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -33,6 +33,7 @@ pub(crate) mod xai;
 pub(crate) mod zai;
 
 const LOW_SPEED_BYTES_PER_SEC: u32 = 1;
+const UNMAPPED_SSE_ERROR_STATUS: u16 = 400;
 
 pub(crate) fn user_agent() -> &'static str {
     concat!(
@@ -121,22 +122,34 @@ pub(crate) struct SseErrorPayload {
 pub(crate) struct SseErrorDetail {
     #[serde(default)]
     pub r#type: String,
+    /// Nullable in the OpenAI error object, and providers do send an explicit `null` on rate
+    /// limits, which a plain `String` rejects outright.
+    pub code: Option<String>,
     pub message: String,
+}
+
+/// A streamed error rides inside a plain 200 response, so this tag is the only clue we get about
+/// what went wrong and whether waiting will help.
+pub(crate) fn sse_error_status(tag: &str) -> Option<u16> {
+    Some(match tag {
+        "overloaded_error" | "server_is_overloaded" => 529,
+        "service_unavailable_error" => 503,
+        "api_error" | "server_error" => 500,
+        "rate_limit_error" | "rate_limit_exceeded" | "tokens" => 429,
+        "request_too_large" => 413,
+        "not_found_error" => 404,
+        "permission_error" => 403,
+        "billing_error" | "insufficient_quota" => 402,
+        "authentication_error" | "invalid_api_key" => 401,
+        _ => return None,
+    })
 }
 
 impl SseErrorPayload {
     pub fn into_agent_error(self) -> AgentError {
-        let status = match self.error.r#type.as_str() {
-            "overloaded_error" => 529,
-            "api_error" | "server_error" => 500,
-            "rate_limit_error" | "rate_limit_exceeded" | "tokens" => 429,
-            "request_too_large" => 413,
-            "not_found_error" => 404,
-            "permission_error" => 403,
-            "billing_error" | "insufficient_quota" => 402,
-            "authentication_error" | "invalid_api_key" => 401,
-            _ => 400,
-        };
+        let status = sse_error_status(self.error.code.as_deref().unwrap_or_default())
+            .or_else(|| sse_error_status(&self.error.r#type))
+            .unwrap_or(UNMAPPED_SSE_ERROR_STATUS);
         AgentError::Api {
             status,
             message: self.error.message,
@@ -289,6 +302,29 @@ mod tests {
     use super::*;
     use futures_lite::io::AsyncBufReadExt;
     use test_case::test_case;
+
+    const ERROR_MESSAGE: &str = "Our servers are currently overloaded. Please try again later.";
+    const PARSE_FAILED: &str = "SSE error payload should deserialize";
+
+    // Codex only admits the overload in `code`, and anything we cannot place has to stay a plain
+    // 400 so a user mistake is not retried forever: https://github.com/tontinton/maki/issues/777
+    #[test_case(r#""type":"service_unavailable_error","code":"server_is_overloaded""#, 529, true  ; "code_beats_type")]
+    #[test_case(r#""type":"service_unavailable_error""#,                               503, true  ; "absent_code")]
+    #[test_case(r#""type":"service_unavailable_error","code":null"#,                   503, true  ; "null_code")]
+    #[test_case(r#""type":"invalid_request_error","code":"invalid_value""#,            400, false ; "unknown_tags")]
+    fn sse_error_payload_status(tags: &str, status: u16, retryable: bool) {
+        let payload: SseErrorPayload = serde_json::from_str(&format!(
+            r#"{{"error":{{{tags},"message":"{ERROR_MESSAGE}"}}}}"#
+        ))
+        .expect(PARSE_FAILED);
+        let err = payload.into_agent_error();
+
+        assert_eq!(
+            err.to_string(),
+            format!("API error ({status}): {ERROR_MESSAGE}")
+        );
+        assert_eq!(err.is_retryable(), retryable);
+    }
 
     #[test_case("a b", "a%20b" ; "space")]
     #[test_case("a:b", "a%3Ab" ; "colon")]

--- a/maki-providers/src/providers/openai/responses.rs
+++ b/maki-providers/src/providers/openai/responses.rs
@@ -8,7 +8,7 @@ use serde_json::{Value, json};
 use tracing::{debug, warn};
 
 use crate::model::Model;
-use crate::providers::ResolvedAuth;
+use crate::providers::{ResolvedAuth, sse_error_status};
 use crate::types::EffortDialect;
 use crate::{
     AgentError, ContentBlock, Message, ProviderEvent, Role, StopReason, StreamResponse,
@@ -16,6 +16,7 @@ use crate::{
 };
 
 const RESPONSES_PATH: &str = "/responses";
+const FAILED_RESPONSE_STATUS: u16 = 500;
 
 pub(crate) fn build_body(
     model: &Model,
@@ -478,18 +479,15 @@ pub(crate) async fn parse_sse(
                     Ok(v) => v,
                     Err(_) => continue,
                 };
-                let resp = &parsed["response"];
-                let error = &resp["error"];
+                let error = &parsed["response"]["error"];
                 let message = error["message"]
                     .as_str()
                     .unwrap_or("response generation failed")
                     .to_string();
-                let code = error["code"].as_str().unwrap_or("server_error");
-                let status = match code {
-                    "rate_limit_exceeded" => 429,
-                    "server_error" => 500,
-                    _ => 500,
-                };
+                let status = error["code"]
+                    .as_str()
+                    .and_then(sse_error_status)
+                    .unwrap_or(FAILED_RESPONSE_STATUS);
                 return Err(AgentError::Api { status, message });
             }
 
@@ -556,8 +554,12 @@ mod tests {
     use super::*;
     use futures_lite::io::Cursor;
     use serde_json::json;
+    use test_case::test_case;
 
     const TEST_STREAM_TIMEOUT: Duration = Duration::from_secs(300);
+    const OVERLOAD_MESSAGE: &str = "Our servers are currently overloaded. Please try again later.";
+    const BAD_REQUEST_MESSAGE: &str = "Invalid value for 'model'";
+    const RATE_LIMIT_MESSAGE: &str = "Rate limit hit";
 
     async fn run_sse(sse: &str) -> (Result<StreamResponse, AgentError>, Vec<ProviderEvent>) {
         let (tx, rx) = flume::unbounded();
@@ -643,41 +645,43 @@ data: {\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":5,\"ou
         })
     }
 
-    #[test]
-    fn parse_sse_error_event() {
+    // Codex hides an overload in `code` on an otherwise healthy 200 stream, so these tags are what
+    // decide between backing off and giving up: https://github.com/tontinton/maki/issues/777
+    #[test_case("service_unavailable_error", "server_is_overloaded", OVERLOAD_MESSAGE, 529, true ; "codex_overload")]
+    #[test_case("overloaded_error", "", OVERLOAD_MESSAGE, 529, true                              ; "overload_without_code")]
+    #[test_case("invalid_request_error", "invalid_value", BAD_REQUEST_MESSAGE, 400, false        ; "bad_request")]
+    fn parse_sse_error_event(
+        error_type: &str,
+        code: &str,
+        message: &str,
+        status: u16,
+        retryable: bool,
+    ) {
         smol::block_on(async {
-            let sse = "\
-event: error\n\
-data: {\"error\":{\"message\":\"Server overloaded\",\"type\":\"overloaded_error\"}}\n\
-\n";
+            let data = json!({
+                "type": "error",
+                "error": { "type": error_type, "code": code, "message": message },
+            });
 
-            let (err, _) = run_sse(sse).await;
-            match err.unwrap_err() {
-                AgentError::Api { status, message } => {
-                    assert_eq!(status, 529);
-                    assert_eq!(message, "Server overloaded");
-                }
-                other => panic!("expected Api error, got: {other:?}"),
-            }
+            let (result, _) = run_sse(&format!("event: error\ndata: {data}\n\n")).await;
+            let err = result.unwrap_err();
+            assert_eq!(err.to_string(), format!("API error ({status}): {message}"));
+            assert_eq!(err.is_retryable(), retryable);
         })
     }
 
-    #[test]
-    fn parse_sse_response_failed() {
+    #[test_case("rate_limit_exceeded", RATE_LIMIT_MESSAGE, 429 ; "rate_limit")]
+    #[test_case("server_is_overloaded", OVERLOAD_MESSAGE, 529  ; "overload")]
+    fn parse_sse_response_failed(code: &str, message: &str, status: u16) {
         smol::block_on(async {
-            let sse = "\
-event: response.failed\n\
-data: {\"response\":{\"error\":{\"code\":\"rate_limit_exceeded\",\"message\":\"Rate limit hit\"}}}\n\
-\n";
+            let data = json!({
+                "response": { "error": { "code": code, "message": message } },
+            });
 
-            let (err, _) = run_sse(sse).await;
-            match err.unwrap_err() {
-                AgentError::Api { status, message } => {
-                    assert_eq!(status, 429);
-                    assert_eq!(message, "Rate limit hit");
-                }
-                other => panic!("expected Api error, got: {other:?}"),
-            }
+            let (result, _) = run_sse(&format!("event: response.failed\ndata: {data}\n\n")).await;
+            let err = result.unwrap_err();
+            assert_eq!(err.to_string(), format!("API error ({status}): {message}"));
+            assert!(err.is_retryable());
         })
     }
 


### PR DESCRIPTION
Codex reports an overload inside a normal 200 stream, as an SSE error event with `type` `service_unavailable_error` and `code` `server_is_overloaded`, never as a 429 or a 5xx.

Our tag table only looked at `type` and fell back to `400` for anything it did not know, so a run died with `API error (400): Our servers are currently overloaded. Please try again later.` and the backoff never got a chance.

It now reads `code` first and then `type`, both landing on `529`, so the main thread and sub agents wait and retry like they already do for any other overload.

The table stays in the shared SSE code because these are structured tags and not message text, and `response.failed` now reuses it instead of keeping its own smaller copy.

Closes #777.