### PR TITLE
feat(config): let you allow private hosts through the SSRF guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2858,6 +2858,7 @@ dependencies = [
  "tree-sitter-yaml",
  "tree-sitter-zig",
  "unicode-width",
+ "url",
 ]
 
 [[package]]

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -239,6 +239,7 @@ pub struct RawConfig {
     pub agent: AgentFileConfig,
     pub provider: ProviderFileConfig,
     pub storage: StorageFileConfig,
+    pub net: NetFileConfig,
     pub telemetry: TelemetryConfig,
     pub plugins: HashMap<String, PluginFileConfig>,
     /// Renamed to `plugins`; kept so old configs fail with a pointer to the
@@ -260,6 +261,7 @@ impl RawConfig {
         self.agent.merge(overlay.agent);
         self.provider.merge(overlay.provider);
         self.storage.merge(overlay.storage);
+        self.net.merge(overlay.net);
         self.telemetry.merge(overlay.telemetry);
         for (name, plugin) in overlay.plugins {
             let entry = self.plugins.entry(name).or_default();
@@ -298,6 +300,7 @@ impl RawConfig {
             agent: AgentConfig::from_file(self.agent, disabled_tools),
             provider: ProviderConfig::from_file(self.provider)?,
             storage: StorageConfig::from_file(self.storage),
+            net: NetConfig::from_file(self.net),
             telemetry: self.telemetry,
             permissions: PermissionsConfig::default(),
             plugins: PluginsConfig::from_plugins_and_packages(self.plugins, packages),
@@ -547,6 +550,18 @@ impl ProviderFileConfig {
             low_speed_timeout_secs,
             stream_timeout_secs
         );
+    }
+}
+
+#[derive(Deserialize, Default, Debug)]
+#[serde(default, deny_unknown_fields)]
+pub struct NetFileConfig {
+    pub allowed_private_hosts: Option<Vec<String>>,
+}
+
+impl NetFileConfig {
+    fn merge(&mut self, overlay: NetFileConfig) {
+        merge_option!(self, overlay, allowed_private_hosts);
     }
 }
 
@@ -851,6 +866,7 @@ pub struct Config {
     pub agent: AgentConfig,
     pub provider: ProviderConfig,
     pub storage: StorageConfig,
+    pub net: NetConfig,
     pub telemetry: TelemetryConfig,
     pub permissions: PermissionsConfig,
     pub plugins: PluginsConfig,
@@ -1287,6 +1303,29 @@ impl StorageConfig {
             max_log_bytes: f.max_log_bytes_mb.unwrap_or(DEFAULT_MAX_LOG_BYTES_MB) * 1024 * 1024,
             max_log_files: f.max_log_files.unwrap_or(DEFAULT_MAX_LOG_FILES),
             input_history_size: f.input_history_size.unwrap_or(DEFAULT_INPUT_HISTORY_SIZE),
+        }
+    }
+}
+
+/// Escape hatches for the SSRF guard in `maki.net`, which every HTTP tool
+/// goes through. The model picks the URL, so private and metadata addresses
+/// are refused unless the user named the host here.
+#[derive(Debug, Clone, ConfigSection)]
+#[config(section = "net")]
+pub struct NetConfig {
+    #[config(
+        ty = "string[]",
+        default = "Vec::new()",
+        default_doc = "[]",
+        desc = "Hosts allowed to resolve to a private or loopback address, as `host`, `host:port`, or a CIDR range. Plain `http://` is kept for them instead of being upgraded to `https://`"
+    )]
+    pub allowed_private_hosts: Vec<String>,
+}
+
+impl NetConfig {
+    fn from_file(f: NetFileConfig) -> Self {
+        Self {
+            allowed_private_hosts: f.allowed_private_hosts.unwrap_or_default(),
         }
     }
 }
@@ -2231,6 +2270,9 @@ mod tests {
     use tempfile::TempDir;
     use test_case::test_case;
 
+    const GLOBAL_ALLOWED_HOST: &str = "ollama.lan";
+    const PROJECT_ALLOWED_HOST: &str = "searx.lan:8888";
+
     fn plugin_enabled(enabled: bool) -> PluginFileConfig {
         PluginFileConfig {
             enabled: Some(enabled),
@@ -2370,6 +2412,24 @@ mod tests {
             "overlay wins"
         );
         assert_eq!(base.ui.flash_duration_ms, Some(2000), "base preserved");
+    }
+
+    #[test]
+    fn net_allowlist_is_empty_by_default_and_project_replaces_global() {
+        let raw_with = |host: &str| RawConfig {
+            net: NetFileConfig {
+                allowed_private_hosts: Some(vec![host.into()]),
+            },
+            ..Default::default()
+        };
+        let defaults = RawConfig::default().into_config(&[]).unwrap();
+        assert!(defaults.net.allowed_private_hosts.is_empty());
+
+        let mut global = raw_with(GLOBAL_ALLOWED_HOST);
+        global.merge(raw_with(PROJECT_ALLOWED_HOST));
+
+        let net = global.into_config(&[]).unwrap().net;
+        assert_eq!(net.allowed_private_hosts, [PROJECT_ALLOWED_HOST]);
     }
 
     #[test]
@@ -2572,6 +2632,7 @@ mod tests {
             agent: AgentConfig::default(),
             provider: ProviderConfig::default(),
             storage: StorageConfig::default(),
+            net: NetConfig::default(),
             telemetry: TelemetryConfig::default(),
             permissions: PermissionsConfig::default(),
             plugins: PluginsConfig::default(),

--- a/maki-docgen/src/gen_config.rs
+++ b/maki-docgen/src/gen_config.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use maki_agent::tools::ToolRegistry;
 use maki_config::{
     AgentConfig, ConfigField, DEFAULT_MAX_LOG_FILES, DEFAULT_MAX_OUTPUT_LINES,
-    DEFAULT_MOUSE_SCROLL_LINES, MIN_TOOL_OUTPUT_LINES, ProviderConfig, StorageConfig,
+    DEFAULT_MOUSE_SCROLL_LINES, MIN_TOOL_OUTPUT_LINES, NetConfig, ProviderConfig, StorageConfig,
     TOP_LEVEL_FIELDS, TelemetryConfig, ToolOutputLines, UiConfig,
 };
 use maki_lua::{PluginHost, PluginOptionSpecs};
@@ -134,6 +134,39 @@ fn write_theme_section(out: &mut String) {
     .unwrap();
 }
 
+fn write_net_section(out: &mut String) {
+    write_section(out, "[net]", NetConfig::FIELDS);
+    writeln!(
+        out,
+        "`maki.net` refuses private, loopback and metadata addresses, because \
+         the model picks the URLs. List a host here to let it through:\n"
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "\
+```lua
+maki.setup({{
+    net = {{
+        allowed_private_hosts = {{ \"localhost:8080\", \"nas.lan\", \"10.0.0.0/8\" }},
+    }},
+}})
+```\n"
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "An entry with no port covers every port. A name you list is allowed \
+         whatever it resolves to. A name you did not list stays blocked when \
+         DNS lands it on a private address, unless that address falls in a \
+         range you allowed, so keep ranges as small as the service needs. \
+         Every redirect hop is checked against the same list. \
+         [Permissions](/docs/permissions/#network-addresses) covers what the \
+         guard protects.\n"
+    )
+    .unwrap();
+}
+
 fn write_telemetry_section(out: &mut String) {
     write_section(out, "[telemetry]", TelemetryConfig::FIELDS);
     writeln!(
@@ -243,6 +276,7 @@ All fields are optional. Typos in field names cause an error right away.
     write_section(&mut out, "[agent]", AgentConfig::FIELDS);
     write_section(&mut out, "[provider]", ProviderConfig::FIELDS);
     write_section(&mut out, "[storage]", StorageConfig::FIELDS);
+    write_net_section(&mut out);
     write_telemetry_section(&mut out);
 
     writeln!(out, "## Plugins\n").unwrap();

--- a/maki-lua/Cargo.toml
+++ b/maki-lua/Cargo.toml
@@ -37,6 +37,7 @@ futures-lite = { workspace = true }
 pin-project-lite = { workspace = true }
 tree-sitter = { workspace = true }
 unicode-width = { workspace = true }
+url = { workspace = true }
 regex = { workspace = true }
 include_dir = { workspace = true }
 maki-storage = { workspace = true }

--- a/maki-lua/src/api/net.rs
+++ b/maki-lua/src/api/net.rs
@@ -1,11 +1,14 @@
 use std::net::{IpAddr, ToSocketAddrs};
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
+use arc_swap::ArcSwap;
 use futures_lite::io::AsyncReadExt;
 use isahc::config::{Configurable, RedirectPolicy, VersionNegotiation};
-use isahc::{AsyncBody, HttpClient, Request};
+use isahc::{AsyncBody, HttpClient, Request, Response};
 use maki_lua_macro::{lua_fn, lua_table};
 use mlua::{Lua, Result as LuaResult, Table};
+use url::Url;
 
 use crate::api::util::pair::{Pair, try_pair};
 
@@ -15,10 +18,146 @@ const DEFAULT_TIMEOUT_SECS: u64 = 30;
 const MAX_TIMEOUT_SECS: u64 = 120;
 const DEFAULT_MAX_BYTES: usize = 5 * 1024 * 1024;
 const MAX_RETRIES: u32 = 3;
+const MAX_REDIRECTS: u32 = 10;
 const USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
 const CF_MITIGATED: &str = "cf-mitigated";
 const CF_CHALLENGE: &str = "challenge";
 const FALLBACK_USER_AGENT: &str = "maki";
+const HTTP_SCHEME: &str = "http://";
+const HTTPS_SCHEME: &str = "https://";
+const HTTP_PORT: u16 = 80;
+const HTTPS_PORT: u16 = 443;
+const ALLOWLIST_HINT: &str = "add it to `net.allowed_private_hosts` in your init.lua to allow it";
+/// Credentials handed to one authority are not for whoever it redirects us to.
+/// The same set isahc scrubbed before redirects were followed by hand.
+const CROSS_AUTHORITY_HEADERS: [&str; 5] = [
+    "authorization",
+    "cookie",
+    "cookie2",
+    "proxy-authorization",
+    "www-authenticate",
+];
+
+/// Hosts the user marked as safe to reach on a private address, from
+/// `net.allowed_private_hosts`. Process-wide because the guard sits far below
+/// the config: every `maki.net` call, in any plugin, on any Lua thread, reads
+/// the same list, and `/reload` swaps it.
+static ALLOWED_PRIVATE_HOSTS: LazyLock<ArcSwap<HostAllowlist>> = LazyLock::new(ArcSwap::default);
+
+/// Applies `net.allowed_private_hosts`. Entries that parse as neither a host,
+/// a `host:port`, nor a CIDR range are dropped with a warning.
+pub fn set_allowed_private_hosts(entries: &[String]) {
+    ALLOWED_PRIVATE_HOSTS.store(Arc::new(HostAllowlist::parse(entries)));
+}
+
+/// Split by how far a rule may be trusted: a name only ever answers for the
+/// host written in the URL, a range answers for resolved addresses too.
+#[derive(Debug, Default)]
+struct HostAllowlist {
+    /// Name and the port it is pinned to, `None` for any port.
+    names: Vec<(String, Option<u16>)>,
+    /// Network address, prefix length, and port as above.
+    nets: Vec<(IpAddr, u8, Option<u16>)>,
+}
+
+impl HostAllowlist {
+    fn parse(entries: &[String]) -> Self {
+        let mut list = Self::default();
+        for entry in entries {
+            if list.add(entry.trim()).is_none() {
+                tracing::warn!(
+                    entry,
+                    "ignoring unparseable net.allowed_private_hosts entry"
+                );
+            }
+        }
+        list
+    }
+
+    fn add(&mut self, entry: &str) -> Option<()> {
+        if let Some((addr, prefix)) = entry.split_once('/') {
+            let addr: IpAddr = addr.parse().ok()?;
+            let prefix = prefix.parse().ok().filter(|p| *p <= address_bits(addr))?;
+            self.nets.push((addr, prefix, None));
+            return Some(());
+        }
+        let (host, port) = split_host_port(entry);
+        if host.is_empty() {
+            return None;
+        }
+        match host.parse::<IpAddr>() {
+            Ok(addr) => self.nets.push((addr, address_bits(addr), port)),
+            Err(_) => self.names.push((host.to_string(), port)),
+        }
+        Some(())
+    }
+
+    /// Answers for the host in the URL, before any DNS lookup: a name the user
+    /// wrote is trusted whatever it resolves to.
+    fn allows_host(&self, host: &str, port: u16) -> bool {
+        self.names
+            .iter()
+            .any(|(name, allowed)| port_matches(*allowed, port) && name.eq_ignore_ascii_case(host))
+            || host.parse().is_ok_and(|ip| self.allows_ip(ip, port))
+    }
+
+    /// Once DNS has spoken only the ranges count, so a name the user did not
+    /// write cannot borrow another name's exemption, though it is let through
+    /// when it resolves into a range the user opened.
+    fn allows_ip(&self, ip: IpAddr, port: u16) -> bool {
+        self.nets.iter().any(|(net, prefix, allowed)| {
+            port_matches(*allowed, port) && ip_in_net(ip, *net, *prefix)
+        })
+    }
+}
+
+fn port_matches(allowed: Option<u16>, port: u16) -> bool {
+    allowed.is_none_or(|allowed| allowed == port)
+}
+
+/// Width of the address, which is also the prefix of a rule naming one host.
+fn address_bits(ip: IpAddr) -> u8 {
+    if ip.is_ipv4() { 32 } else { 128 }
+}
+
+/// An IPv4 range also covers the `::ffff:` spelling of an address in it, while
+/// an IPv6 range never covers IPv4.
+fn ip_in_net(ip: IpAddr, net: IpAddr, prefix: u8) -> bool {
+    match (ip, net) {
+        (IpAddr::V4(ip), IpAddr::V4(net)) => {
+            leading_bits_match(ip.to_bits().into(), net.to_bits().into(), prefix, u32::BITS)
+        }
+        (IpAddr::V6(ip), IpAddr::V6(net)) => {
+            leading_bits_match(ip.to_bits(), net.to_bits(), prefix, u128::BITS)
+        }
+        (IpAddr::V6(ip), IpAddr::V4(_)) => ip
+            .to_ipv4_mapped()
+            .is_some_and(|ip| ip_in_net(ip.into(), net, prefix)),
+        (IpAddr::V4(_), IpAddr::V6(_)) => false,
+    }
+}
+
+/// `add` refuses a prefix longer than the address, so the shift stays in
+/// range, and a `/0` gets its own answer because shifting by the full width
+/// would panic.
+fn leading_bits_match(ip: u128, net: u128, prefix: u8, width: u32) -> bool {
+    prefix == 0 || (ip ^ net) >> (width - u32::from(prefix)) == 0
+}
+
+/// Splits an authority into host and port, leaving a bare IPv6 literal like
+/// `::1` (more than one colon, no brackets) whole.
+fn split_host_port(authority: &str) -> (&str, Option<u16>) {
+    if let Some(rest) = authority.strip_prefix('[') {
+        let (host, tail) = rest.split_once(']').unwrap_or((rest, ""));
+        return (host, tail.strip_prefix(':').and_then(|p| p.parse().ok()));
+    }
+    match authority.rsplit_once(':') {
+        Some((host, port)) if !host.contains(':') => {
+            port.parse().map_or((authority, None), |p| (host, Some(p)))
+        }
+        _ => (authority, None),
+    }
+}
 
 struct RequestParams {
     url: String,
@@ -38,7 +177,8 @@ struct ResponseData {
 
 /// Make an HTTP request and return the response body. Plain `http://`
 /// URLs are automatically upgraded to `https://`. Requests to private
-/// or metadata IP addresses are blocked for safety.
+/// or metadata IP addresses are blocked for safety, unless the host is
+/// listed in `net.allowed_private_hosts`.
 ///
 /// {opts} fields:
 ///   `method` (string) HTTP verb (default `"GET"`).
@@ -75,8 +215,9 @@ async fn request(lua: Lua, url: String, opts: Option<Table>) -> LuaResult<Pair<T
 lua_table! {
     /// HTTP client for fetching web content. All traffic goes over HTTPS
     /// (plain HTTP is upgraded). Private and metadata IP addresses are
-    /// blocked to prevent SSRF. Failed requests (5xx) are retried
-    /// automatically.
+    /// blocked to prevent SSRF, including after a redirect. Hosts listed in
+    /// the `net.allowed_private_hosts` config option are exempt.
+    /// Failed requests (5xx) are retried automatically.
     ///
     /// ```lua
     /// local res, err = maki.net.request("https://example.com")
@@ -88,8 +229,9 @@ lua_table! {
 }
 
 fn extract_request_params(url: &str, opts: Option<&Table>) -> Result<RequestParams, String> {
-    let url = validate_and_upgrade_url(url)?;
-    check_ssrf(&url)?;
+    let allowed = ALLOWED_PRIVATE_HOSTS.load_full();
+    let url = validate_and_upgrade_url(url, &allowed)?;
+    check_ssrf(&url, &allowed)?;
 
     let method = opts
         .and_then(|o| o.get::<String>("method").ok())
@@ -157,21 +299,14 @@ fn build_request(
         .map_err(|e| format!("request build error: {e}"))
 }
 
-async fn do_request(params: RequestParams) -> Result<ResponseData, String> {
-    let client = HttpClient::builder()
-        .timeout(params.timeout)
-        .redirect_policy(RedirectPolicy::Follow)
-        // The workspace enables curl's http2 feature for OTLP over gRPC. This
-        // client fetches arbitrary user URLs, so keep it on HTTP/1.1 rather
-        // than change how every one of them is negotiated.
-        .version_negotiation(VersionNegotiation::http11())
-        .build()
-        .map_err(|e| format!("client error: {e}"))?;
-
+async fn send_with_retries(
+    client: &HttpClient,
+    params: &RequestParams,
+) -> Result<Response<AsyncBody>, String> {
     let is_get = params.method.eq_ignore_ascii_case("GET");
     let mut last_err = String::new();
 
-    let mut response = 'retry: {
+    'retry: {
         for attempt in 0..=params.retries {
             let req = build_request(
                 &params.url,
@@ -199,21 +334,71 @@ async fn do_request(params: RequestParams) -> Result<ResponseData, String> {
                             params.body.clone(),
                         )?;
                         match client.send_async(req).await {
-                            Ok(resp) => break 'retry resp,
+                            Ok(resp) => break 'retry Ok(resp),
                             Err(e) => last_err = format!("request failed: {e}"),
                         }
                     } else if status >= 500 && attempt < params.retries {
                         last_err = format!("HTTP {status}");
                         continue;
                     } else {
-                        break 'retry resp;
+                        break 'retry Ok(resp);
                     }
                 }
                 Err(e) => last_err = format!("request failed: {e}"),
             }
         }
-        return Err(last_err);
-    };
+        Err(last_err)
+    }
+}
+
+fn redirect_location(response: &Response<AsyncBody>) -> Option<String> {
+    if !response.status().is_redirection() {
+        return None;
+    }
+    let location = response.headers().get("location")?;
+    if let Ok(location) = location.to_str() {
+        return Some(location.to_string());
+    }
+    // Misconfigured servers put raw bytes in `Location` and browsers recover
+    // from it, so encode them rather than drop the hop and return an empty body
+    // as if the redirect had never been sent.
+    let mut encoded = String::new();
+    for &byte in location.as_bytes() {
+        match byte {
+            0x21..=0x7E => encoded.push(char::from(byte)),
+            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    Some(encoded)
+}
+
+async fn do_request(mut params: RequestParams) -> Result<ResponseData, String> {
+    let client = HttpClient::builder()
+        .timeout(params.timeout)
+        // Redirects are followed by hand below, so every hop goes through the
+        // SSRF check. Left to curl, a URL that passed the check could still
+        // bounce us into 169.254.169.254.
+        .redirect_policy(RedirectPolicy::None)
+        // The workspace enables curl's http2 feature for OTLP over gRPC. This
+        // client fetches arbitrary user URLs, so keep it on HTTP/1.1 rather
+        // than change how every one of them is negotiated.
+        .version_negotiation(VersionNegotiation::http11())
+        .build()
+        .map_err(|e| format!("client error: {e}"))?;
+
+    let allowed = ALLOWED_PRIVATE_HOSTS.load_full();
+    let mut response = send_with_retries(&client, &params).await?;
+
+    for _ in 0..MAX_REDIRECTS {
+        let Some(location) = redirect_location(&response) else {
+            break;
+        };
+        params.follow_redirect(response.status().as_u16(), &location, &allowed)?;
+        response = send_with_retries(&client, &params).await?;
+    }
+    if redirect_location(&response).is_some() {
+        return Err(format!("gave up after {MAX_REDIRECTS} redirects"));
+    }
 
     let status = response.status().as_u16();
 
@@ -254,37 +439,93 @@ async fn do_request(params: RequestParams) -> Result<ResponseData, String> {
     })
 }
 
-fn extract_host(url: &str) -> Option<&str> {
-    let rest = url
-        .strip_prefix("https://")
-        .or_else(|| url.strip_prefix("http://"))?;
-    let host_port = rest.split('/').next()?;
-    if let Some(bracketed) = host_port.strip_prefix('[') {
-        bracketed.split(']').next()
-    } else {
-        host_port.split(':').next()
+impl RequestParams {
+    /// Points the request at a redirect target after putting it through the
+    /// same scheme and SSRF rules as the URL the caller asked for.
+    fn follow_redirect(
+        &mut self,
+        status: u16,
+        location: &str,
+        allowed: &HostAllowlist,
+    ) -> Result<(), String> {
+        let base = Url::parse(&self.url).map_err(|e| format!("invalid URL {}: {e}", self.url))?;
+        let target = base
+            .join(location)
+            .map_err(|e| format!("invalid redirect to {location}: {e}"))?;
+        let target = validate_and_upgrade_url(target.as_str(), allowed)?;
+        check_ssrf(&target, allowed)?;
+
+        let landed =
+            Url::parse(&target).map_err(|e| format!("invalid redirect to {location}: {e}"))?;
+        if authority(&base) != authority(&landed) {
+            self.headers.retain(|(name, _)| {
+                !CROSS_AUTHORITY_HEADERS
+                    .iter()
+                    .any(|sensitive| name.eq_ignore_ascii_case(sensitive))
+            });
+        }
+
+        // 301, 302 and 303 turn anything that is not a read into a `GET`, the
+        // way browsers and curl do it. 307 and 308 keep method and body.
+        let is_read =
+            self.method.eq_ignore_ascii_case("GET") || self.method.eq_ignore_ascii_case("HEAD");
+        if matches!(status, 301..=303) && !is_read {
+            self.method = "GET".to_string();
+            self.body.clear();
+        }
+        self.url = target;
+        Ok(())
     }
 }
 
-fn check_ssrf(url: &str) -> Result<(), String> {
-    let host = extract_host(url).ok_or("cannot extract host from URL")?;
+/// What decides whether a redirect stays within the same authority, the same
+/// triple isahc compared before dropping credentials.
+fn authority(url: &Url) -> (&str, Option<&str>, Option<u16>) {
+    (url.scheme(), url.host_str(), url.port_or_known_default())
+}
+
+/// Host and port of an `http(s)` URL. Any userinfo is dropped, so
+/// `https://example.com@127.0.0.1/` is seen for the loopback address it is.
+fn extract_host_port(url: &str) -> Option<(&str, u16)> {
+    let (rest, default_port) = url
+        .strip_prefix(HTTPS_SCHEME)
+        .map(|rest| (rest, HTTPS_PORT))
+        .or_else(|| url.strip_prefix(HTTP_SCHEME).map(|rest| (rest, HTTP_PORT)))?;
+    let authority = rest.split(['/', '?', '#']).next()?;
+    let authority = authority.rsplit_once('@').map_or(authority, |(_, h)| h);
+    if authority.is_empty() {
+        return None;
+    }
+    let (host, port) = split_host_port(authority);
+    Some((host, port.unwrap_or(default_port)))
+}
+
+fn check_ssrf(url: &str, allowed: &HostAllowlist) -> Result<(), String> {
+    let (host, port) = extract_host_port(url).ok_or("cannot extract host from URL")?;
+    if allowed.allows_host(host, port) {
+        return Ok(());
+    }
 
     if let Ok(ip) = host.parse::<IpAddr>() {
         if is_private_ip(&ip) {
-            return Err(format!("blocked: {ip} is a private/metadata address"));
+            return Err(format!(
+                "blocked: {ip} is a private/metadata address ({ALLOWLIST_HINT})"
+            ));
         }
         return Ok(());
     }
 
-    let addr = format!("{host}:443");
-    if let Ok(addrs) = addr.to_socket_addrs() {
-        for sa in addrs {
-            if is_private_ip(&sa.ip()) {
-                return Err(format!(
-                    "blocked: {host} resolves to private address {}",
-                    sa.ip()
-                ));
-            }
+    // A host we cannot resolve is a host we cannot vouch for, and that covers
+    // being offline: the answer the guard would have judged never arrives.
+    let addrs = (host, port)
+        .to_socket_addrs()
+        .map_err(|e| format!("blocked: cannot resolve {host}: {e} ({ALLOWLIST_HINT})"))?;
+    for sa in addrs {
+        if is_private_ip(&sa.ip()) && !allowed.allows_ip(sa.ip(), port) {
+            return Err(format!(
+                "blocked: {host} resolves to private address {} ({ALLOWLIST_HINT})",
+                sa.ip()
+            ));
         }
     }
     Ok(())
@@ -317,11 +558,22 @@ fn is_private_ip(ip: &IpAddr) -> bool {
     }
 }
 
-fn validate_and_upgrade_url(url: &str) -> Result<String, String> {
-    if let Some(rest) = url.strip_prefix("http://") {
-        return Ok(format!("https://{rest}"));
+/// An allowlisted host keeps plain `http://`, because the local services
+/// people put on that list rarely have a certificate.
+///
+/// Normalising through the WHATWG parser first is what makes the guard read the
+/// host curl will dial: a trailing dot, an empty port and a percent encoded
+/// zone id all survive a hand split of the authority but not this.
+fn validate_and_upgrade_url(url: &str, allowed: &HostAllowlist) -> Result<String, String> {
+    let parsed = Url::parse(url).map_err(|e| format!("invalid URL {url}: {e}"))?;
+    let url = parsed.as_str();
+    if let Some(rest) = url.strip_prefix(HTTP_SCHEME) {
+        if extract_host_port(url).is_some_and(|(host, port)| allowed.allows_host(host, port)) {
+            return Ok(url.to_string());
+        }
+        return Ok(format!("{HTTPS_SCHEME}{rest}"));
     }
-    if url.starts_with("https://") {
+    if url.starts_with(HTTPS_SCHEME) {
         return Ok(url.to_string());
     }
     Err(format!(
@@ -336,33 +588,163 @@ mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
     use test_case::test_case;
 
-    #[test_case("https://example.com", "https://example.com" ; "https_passthrough")]
-    #[test_case("http://example.com", "https://example.com" ; "http_upgraded_to_https")]
-    fn validate_and_upgrade_url_valid(input: &str, expected: &str) {
-        assert_eq!(validate_and_upgrade_url(input).unwrap(), expected);
+    const SEARX_HOST: &str = "searx.lan";
+    const SEARX_URL: &str = "http://searx.lan:8888/search";
+    const LOOPBACK_PORT_ENTRY: &str = "127.0.0.1:8888";
+    const LOOPBACK_PORT_URL: &str = "http://127.0.0.1:8888/search";
+    const LOOPBACK_URL: &str = "https://127.0.0.1";
+    const LOCALHOST_ENTRY: &str = "localhost";
+    const LOCALHOST_URL: &str = "http://localhost:8888";
+    const PRIVATE_CIDR_ENTRY: &str = "10.0.0.0/8";
+    const IN_CIDR_URL: &str = "https://10.1.2.3";
+    const OUT_OF_CIDR_URL: &str = "https://192.168.1.1";
+    const METADATA_URL: &str = "http://169.254.169.254/latest/meta-data";
+    /// An address rather than a name, so no test needs a DNS answer.
+    const PUBLIC_URL: &str = "https://8.8.8.8/";
+    const PUBLIC_HTTP_URL: &str = "http://8.8.8.8/";
+    const OTHER_PUBLIC_URL: &str = "https://1.1.1.1/";
+    const PUBLIC_URL_OTHER_PORT: &str = "https://8.8.8.8:8443/";
+    const BLOCKED_PREFIX: &str = "blocked:";
+    const PAYLOAD: &str = "payload";
+    const AUTH_HEADER: &str = "Authorization";
+    const AUTH_VALUE: &str = "Bearer tok";
+    const ACCEPT_HEADER: &str = "Accept";
+    const ACCEPT_VALUE: &str = "text/html";
+
+    fn allowlist(entries: &[&str]) -> HostAllowlist {
+        HostAllowlist::parse(&entries.iter().map(|e| (*e).to_string()).collect::<Vec<_>>())
+    }
+
+    #[test_case(&[], "https://example.com/", "https://example.com/" ; "https_passthrough")]
+    #[test_case(&[], "http://example.com", "https://example.com/" ; "http_upgraded_to_https")]
+    #[test_case(&[SEARX_HOST], SEARX_URL, SEARX_URL ; "allowlisted_host_keeps_plain_http")]
+    fn validate_and_upgrade_url_valid(entries: &[&str], input: &str, expected: &str) {
+        assert_eq!(
+            validate_and_upgrade_url(input, &allowlist(entries)).unwrap(),
+            expected
+        );
     }
 
     #[test_case("ftp://example.com" ; "unsupported_scheme")]
     #[test_case("example.com" ; "bare_domain")]
     fn validate_and_upgrade_url_invalid(input: &str) {
-        assert!(validate_and_upgrade_url(input).is_err());
+        assert!(validate_and_upgrade_url(input, &HostAllowlist::default()).is_err());
     }
 
-    #[test_case("https://8.8.8.8", Ok(()) ; "public_ip_allowed")]
-    #[test_case("https://127.0.0.1", Err(()) ; "loopback_blocked")]
-    #[test_case("https://192.168.1.1", Err(()) ; "private_blocked")]
-    #[test_case("https://10.0.0.1", Err(()) ; "rfc1918_10_blocked")]
-    #[test_case("https://172.16.0.1", Err(()) ; "rfc1918_172_blocked")]
-    #[test_case("https://169.254.169.254", Err(()) ; "aws_metadata_blocked")]
-    #[test_case("https://[::1]", Err(()) ; "ipv6_loopback_blocked")]
-    #[test_case("https://[::ffff:127.0.0.1]", Err(()) ; "ipv4_mapped_loopback_blocked")]
-    #[test_case("https://0.0.0.0", Err(()) ; "unspecified_blocked")]
-    #[test_case("https://[::ffff:169.254.169.254]", Err(()) ; "ipv4_mapped_metadata_blocked")]
-    fn check_ssrf_cases(url: &str, expected: Result<(), ()>) {
-        match expected {
-            Ok(()) => assert!(check_ssrf(url).is_ok(), "{url} should be allowed"),
-            Err(()) => assert!(check_ssrf(url).is_err(), "{url} should be blocked"),
+    #[test_case(&[], PUBLIC_URL, true ; "public_ip_allowed")]
+    #[test_case(&[], LOOPBACK_URL, false ; "loopback_blocked")]
+    #[test_case(&[], "https://192.168.1.1", false ; "private_blocked")]
+    #[test_case(&[], "https://10.0.0.1", false ; "rfc1918_10_blocked")]
+    #[test_case(&[], "https://172.16.0.1", false ; "rfc1918_172_blocked")]
+    #[test_case(&[], "https://169.254.169.254", false ; "aws_metadata_blocked")]
+    #[test_case(&[], "https://[::1]", false ; "ipv6_loopback_blocked")]
+    #[test_case(&[], "https://[::ffff:127.0.0.1]", false ; "ipv4_mapped_loopback_blocked")]
+    #[test_case(&[], "https://0.0.0.0", false ; "unspecified_blocked")]
+    #[test_case(&[], "https://[::ffff:169.254.169.254]", false ; "ipv4_mapped_metadata_blocked")]
+    #[test_case(&[], "https://example.com@127.0.0.1/", false ; "userinfo_hiding_loopback_blocked")]
+    #[test_case(&[], LOCALHOST_URL, false ; "name_resolving_to_loopback_blocked")]
+    #[test_case(&[LOOPBACK_PORT_ENTRY], LOOPBACK_PORT_URL, true ; "ip_with_port_allowed")]
+    #[test_case(&[LOOPBACK_PORT_ENTRY], LOOPBACK_URL, false ; "same_ip_other_port_still_blocked")]
+    #[test_case(&[LOCALHOST_ENTRY], LOCALHOST_URL, true ; "name_allowed_whatever_it_resolves_to")]
+    #[test_case(&[LOCALHOST_ENTRY], LOOPBACK_PORT_URL, false ; "other_private_host_still_blocked")]
+    #[test_case(&[PRIVATE_CIDR_ENTRY], IN_CIDR_URL, true ; "cidr_range_allowed")]
+    #[test_case(&[PRIVATE_CIDR_ENTRY], OUT_OF_CIDR_URL, false ; "outside_cidr_still_blocked")]
+    #[test_case(&[PRIVATE_CIDR_ENTRY], METADATA_URL, false ; "metadata_never_allowed_by_a_range")]
+    fn check_ssrf_cases(entries: &[&str], url: &str, allowed: bool) {
+        let result = check_ssrf(url, &allowlist(entries));
+        assert_eq!(
+            result.is_ok(),
+            allowed,
+            "{url} with {entries:?}: {result:?}"
+        );
+    }
+
+    /// Spellings glibc rejects but curl normalises, so the guard has to read
+    /// them the way the WHATWG parser does or never see the real host.
+    #[test_case("https://192.168.1.1./" ; "trailing_dot_on_a_private_address")]
+    #[test_case("https://127.0.0.1.:11434/" ; "trailing_dot_with_a_port")]
+    #[test_case("https://127.0.0.1:/" ; "empty_port")]
+    #[test_case("https://[fe80::1%25eth0]/" ; "percent_encoded_zone_id")]
+    fn normalised_bypass_is_refused(url: &str) {
+        let allowed = HostAllowlist::default();
+        let result = validate_and_upgrade_url(url, &allowed).and_then(|u| check_ssrf(&u, &allowed));
+        assert!(result.is_err(), "{url}");
+    }
+
+    #[test_case(LOOPBACK_URL ; "private_address")]
+    fn blocked_message_points_at_the_config_option(url: &str) {
+        let err = check_ssrf(url, &HostAllowlist::default()).unwrap_err();
+        assert!(err.starts_with(BLOCKED_PREFIX), "{err}");
+        assert!(err.contains(ALLOWLIST_HINT), "{err}");
+    }
+
+    fn redirect_params(url: &str) -> RequestParams {
+        RequestParams {
+            url: url.to_string(),
+            method: "GET".to_string(),
+            headers: Vec::new(),
+            body: Vec::new(),
+            timeout: Duration::from_secs(DEFAULT_TIMEOUT_SECS),
+            max_bytes: DEFAULT_MAX_BYTES,
+            retries: 0,
         }
+    }
+
+    #[test]
+    fn redirect_hop_into_a_private_address_is_refused() {
+        let mut params = redirect_params(LOOPBACK_PORT_URL);
+        let err = params
+            .follow_redirect(302, METADATA_URL, &allowlist(&[LOOPBACK_PORT_ENTRY]))
+            .unwrap_err();
+        assert!(err.starts_with(BLOCKED_PREFIX), "{err}");
+        assert_eq!(
+            params.url, LOOPBACK_PORT_URL,
+            "refused hop moved the request"
+        );
+    }
+
+    #[test]
+    fn relative_redirect_on_an_allowlisted_host_is_followed() {
+        let mut params = redirect_params(LOOPBACK_PORT_URL);
+        params
+            .follow_redirect(302, "/results", &allowlist(&[LOOPBACK_PORT_ENTRY]))
+            .unwrap();
+        assert_eq!(params.url, "http://127.0.0.1:8888/results");
+    }
+
+    #[test_case(PUBLIC_URL, true ; "same_authority_keeps_credentials")]
+    #[test_case(OTHER_PUBLIC_URL, false ; "other_host_drops_credentials")]
+    #[test_case(PUBLIC_HTTP_URL, true ; "same_host_upgraded_back_to_https_keeps_credentials")]
+    #[test_case(PUBLIC_URL_OTHER_PORT, false ; "other_port_drops_credentials")]
+    fn redirect_scrubs_credentials_across_authorities(location: &str, kept: bool) {
+        let mut params = redirect_params(PUBLIC_URL);
+        params.headers = vec![
+            (AUTH_HEADER.to_string(), AUTH_VALUE.to_string()),
+            (ACCEPT_HEADER.to_string(), ACCEPT_VALUE.to_string()),
+        ];
+        params
+            .follow_redirect(302, location, &HostAllowlist::default())
+            .unwrap();
+        assert_eq!(
+            params.headers.iter().any(|(k, _)| k == AUTH_HEADER),
+            kept,
+            "{location}: {:?}",
+            params.headers
+        );
+        assert!(params.headers.iter().any(|(k, _)| k == ACCEPT_HEADER));
+    }
+
+    #[test_case(303, "GET", "" ; "303_rewrites_a_post_into_a_get")]
+    #[test_case(308, "POST", PAYLOAD ; "308_keeps_method_and_body")]
+    fn redirect_rewrites_the_method_per_status(status: u16, method: &str, body: &str) {
+        let mut params = redirect_params(PUBLIC_URL);
+        params.method = "POST".to_string();
+        params.body = PAYLOAD.into();
+        params
+            .follow_redirect(status, PUBLIC_URL, &HostAllowlist::default())
+            .unwrap();
+        assert_eq!(params.method, method);
+        assert_eq!(params.body, body.as_bytes());
     }
 
     #[test_case(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), true ; "v4_unspecified")]
@@ -380,14 +762,25 @@ mod tests {
         assert_eq!(is_private_ip(&ip), expected);
     }
 
-    #[test_case("https://example.com", Some("example.com") ; "simple_domain")]
-    #[test_case("https://example.com:8080/path", Some("example.com") ; "domain_with_port")]
-    #[test_case("https://[::1]/path", Some("::1") ; "bracketed_ipv6")]
-    #[test_case("https://[::1]:8080/path", Some("::1") ; "bracketed_ipv6_with_port")]
-    #[test_case("https://192.168.1.1:443", Some("192.168.1.1") ; "ipv4_with_port")]
+    #[test_case("https://example.com", Some(("example.com", HTTPS_PORT)) ; "simple_domain")]
+    #[test_case("http://example.com", Some(("example.com", HTTP_PORT)) ; "http_default_port")]
+    #[test_case("https://example.com:8080/path", Some(("example.com", 8080)) ; "domain_with_port")]
+    #[test_case("https://[::1]/path", Some(("::1", HTTPS_PORT)) ; "bracketed_ipv6")]
+    #[test_case("https://[::1]:8080/path", Some(("::1", 8080)) ; "bracketed_ipv6_with_port")]
+    #[test_case("https://192.168.1.1:443", Some(("192.168.1.1", HTTPS_PORT)) ; "ipv4_with_port")]
+    #[test_case("https://user:pw@10.0.0.1/", Some(("10.0.0.1", HTTPS_PORT)) ; "userinfo_stripped")]
+    #[test_case("https://example.com?a=/b", Some(("example.com", HTTPS_PORT)) ; "query_before_path")]
     #[test_case("not-a-url", None ; "no_scheme")]
-    fn extract_host_cases(url: &str, expected: Option<&str>) {
-        assert_eq!(extract_host(url), expected);
+    fn extract_host_port_cases(url: &str, expected: Option<(&str, u16)>) {
+        assert_eq!(extract_host_port(url), expected);
+    }
+
+    #[test_case("10.0.0.0/33" ; "prefix_too_long")]
+    #[test_case("10.0.0.0/x" ; "prefix_not_a_number")]
+    #[test_case("" ; "empty_entry")]
+    fn unparseable_allowlist_entries_are_dropped(entry: &str) {
+        let list = allowlist(&[entry]);
+        assert!(list.names.is_empty() && list.nets.is_empty(), "{list:?}");
     }
 
     #[test]
@@ -449,8 +842,8 @@ mod tests {
 
     #[test]
     fn extract_params_defaults_no_opts() {
-        let params = extract_request_params("https://example.com", None).unwrap();
-        assert_eq!(params.url, "https://example.com");
+        let params = extract_request_params(PUBLIC_URL, None).unwrap();
+        assert_eq!(params.url, PUBLIC_URL);
         assert_eq!(params.method, "GET");
         assert!(params.headers.is_empty());
         assert!(params.body.is_empty());
@@ -464,7 +857,7 @@ mod tests {
         let lua = Lua::new();
         let opts = lua.create_table().unwrap();
         opts.set("timeout", MAX_TIMEOUT_SECS + 100).unwrap();
-        let params = extract_request_params("https://example.com", Some(&opts)).unwrap();
+        let params = extract_request_params(PUBLIC_URL, Some(&opts)).unwrap();
         assert_eq!(params.timeout, Duration::from_secs(MAX_TIMEOUT_SECS));
     }
 
@@ -474,38 +867,38 @@ mod tests {
         let opts = lua.create_table().unwrap();
         opts.set("method", "POST").unwrap();
         opts.set("body", r#"{"key":"val"}"#).unwrap();
-        let params = extract_request_params("https://example.com", Some(&opts)).unwrap();
+        let params = extract_request_params(PUBLIC_URL, Some(&opts)).unwrap();
         assert_eq!(params.method, "POST");
         assert_eq!(params.body, br#"{"key":"val"}"#);
     }
 
     #[test]
     fn extract_params_http_upgraded_to_https() {
-        let params = extract_request_params("http://example.com", None).unwrap();
-        assert_eq!(params.url, "https://example.com");
+        let params = extract_request_params(PUBLIC_HTTP_URL, None).unwrap();
+        assert_eq!(params.url, PUBLIC_URL);
     }
 
     #[test]
     fn extract_params_headers_collected() {
         let lua = Lua::new();
         let headers = lua.create_table().unwrap();
-        headers.set("Authorization", "Bearer tok").unwrap();
-        headers.set("Accept", "text/html").unwrap();
+        headers.set(AUTH_HEADER, AUTH_VALUE).unwrap();
+        headers.set(ACCEPT_HEADER, ACCEPT_VALUE).unwrap();
         let opts = lua.create_table().unwrap();
         opts.set("headers", headers).unwrap();
-        let params = extract_request_params("https://example.com", Some(&opts)).unwrap();
+        let params = extract_request_params(PUBLIC_URL, Some(&opts)).unwrap();
         assert_eq!(params.headers.len(), 2);
         assert!(
             params
                 .headers
                 .iter()
-                .any(|(k, v)| k == "Authorization" && v == "Bearer tok")
+                .any(|(k, v)| k == AUTH_HEADER && v == AUTH_VALUE)
         );
         assert!(
             params
                 .headers
                 .iter()
-                .any(|(k, v)| k == "Accept" && v == "text/html")
+                .any(|(k, v)| k == ACCEPT_HEADER && v == ACCEPT_VALUE)
         );
     }
 }

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -9,6 +9,7 @@ pub(crate) mod plugin_permissions;
 mod runtime;
 
 pub use api::keymap::{KeymapEntry, KeymapReader, KeymapSnapshot};
+pub use api::net::set_allowed_private_hosts;
 pub use api::options::{OptionSpec, OptionType, PluginOptionSpecs};
 pub use api::pack::{Declared, PackOp};
 pub use api::util::command::{

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -137,6 +137,24 @@ How many lines of output to show per tool in the UI. All values are `usize` with
 | `max_log_files` | u32 | `10` | 1 | Max number of log files to keep |
 | `input_history_size` | usize | `100` | 10 | Number of input history entries to retain |
 
+### `net`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `allowed_private_hosts` | string[] | `[]` | Hosts allowed to resolve to a private or loopback address, as `host`, `host:port`, or a CIDR range. Plain `http://` is kept for them instead of being upgraded to `https://` |
+
+`maki.net` refuses private, loopback and metadata addresses, because the model picks the URLs. List a host here to let it through:
+
+```lua
+maki.setup({
+    net = {
+        allowed_private_hosts = { "localhost:8080", "nas.lan", "10.0.0.0/8" },
+    },
+})
+```
+
+An entry with no port covers every port. A name you list is allowed whatever it resolves to. A name you did not list stays blocked when DNS lands it on a private address, unless that address falls in a range you allowed, so keep ranges as small as the service needs. Every redirect hop is checked against the same list. [Permissions](/docs/permissions/#network-addresses) covers what the guard protects.
+
 ### `telemetry`
 
 | Field | Type | Default | Env | Description |

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -2837,8 +2837,9 @@ maki.keymap.set("n", "<M-t>", function() maki.model.set({ thinking = "" }) end)
 
 HTTP client for fetching web content. All traffic goes over HTTPS
 (plain HTTP is upgraded). Private and metadata IP addresses are
-blocked to prevent SSRF. Failed requests (5xx) are retried
-automatically.
+blocked to prevent SSRF, including after a redirect. Hosts listed in
+the `net.allowed_private_hosts` config option are exempt.
+Failed requests (5xx) are retried automatically.
 
 ```lua
 local res, err = maki.net.request("https://example.com")
@@ -2855,7 +2856,8 @@ maki.net.request({url}, {opts?})
 
 Make an HTTP request and return the response body. Plain `http://`
 URLs are automatically upgraded to `https://`. Requests to private
-or metadata IP addresses are blocked for safety.
+or metadata IP addresses are blocked for safety, unless the host is
+listed in `net.allowed_private_hosts`.
 
 {opts} fields:
   `method` (string) HTTP verb (default `"GET"`).

--- a/site/docs/content/permissions/_index.md
+++ b/site/docs/content/permissions/_index.md
@@ -199,6 +199,12 @@ Brace groups `{ ... }` and control flow (`if`, `for`, …) are segmented when po
 
 Lua plugins have a separate, unrelated gate. A `plugin.toml` manifest next to the Lua file controls which gated `maki.*` APIs it may call. No manifest means every gated call is denied, including for your own `init.lua`. The [Lua API reference](/lua-api/#plugin-permissions) documents the manifest and lists every permission.
 
+## Network Addresses
+
+`webfetch`, `websearch` and every plugin that calls `maki.net` go through one guard. A request to a private, loopback or link-local address is refused, and so is a redirect that lands on one. The model picks these URLs, so a page it reads could otherwise talk it into fetching `http://169.254.169.254/` or an admin panel on your LAN.
+
+To reach a service on your own machine or network, list it in [`net.allowed_private_hosts`](/docs/configuration/#net). An allowed host also keeps plain `http://` instead of being upgraded to `https://`, since a service on your LAN rarely has a certificate.
+
 ## Session Persistence
 
 When you save a session, its permission rules are saved too. Loading the session restores them.

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -82,6 +82,10 @@ fn load_plugins(
         &mut warnings,
     )?;
 
+    // Before any plugin can call `maki.net`, so the first request already sees
+    // the hosts the user exempted from the private-address block.
+    maki_lua::set_allowed_private_hosts(&config.net.allowed_private_hosts);
+
     if let Err(e) = host.load_builtins(&config.plugins) {
         let e = color_eyre::eyre::Report::from(e).wrap_err("load builtin plugins");
         match on_builtin_failure {


### PR DESCRIPTION
People running their own SearxNG or Ollama could not reach it: `maki.net` refuses private and loopback addresses, so `webfetch` and any plugin built on it got blocked.

The new `net.allowed_private_hosts` names the boxes you trust, as `host`, `host:port` or a CIDR range, and those hosts also keep plain `http://` instead of being upgraded.

It stays opt in and empty by default, because the model picks the URL and a poisoned page would otherwise walk it into `169.254.169.254` or your admin panel.

A name you allow covers that name alone whatever it resolves to, while a range also covers any other name that resolves into it, so keep ranges as small as the service needs.

Redirects are now followed by hand rather than by curl, so every hop goes through the same check, and credentials are dropped when a hop changes scheme, host or port.

Closes #417.