### PR TITLE
fix(config): let a disabled plugin hand its tool name over

### DIFF
--- a/maki-agent/src/permissions.rs
+++ b/maki-agent/src/permissions.rs
@@ -26,6 +26,9 @@ pub const DECISION_SOURCE_USER_SESSION: &str = "user_session";
 pub const DECISION_SOURCE_USER_ALWAYS: &str = "user_always";
 pub const DECISION_SOURCE_USER_ABORT: &str = "user_abort";
 
+const TASK_TOOL: &str = "task";
+const BASH_TOOL: &str = "bash";
+
 fn builtin_rules(cwd: &Path) -> Vec<PermissionRule> {
     let cwd_glob = format!(
         "{}/**",
@@ -40,11 +43,20 @@ fn builtin_rules(cwd: &Path) -> Vec<PermissionRule> {
         .iter()
         .map(|tool| allow(tool, &cwd_glob))
         .collect();
-    rules.push(allow("task", "*"));
+    rules.push(allow(TASK_TOOL, "*"));
     rules
 }
 
 pub const BOUNDARY_UNVERIFIABLE_PREFIX: &str = "Cannot verify project boundary for";
+
+/// Whether the builtin defaults treat `tool` specially. File write tools get
+/// the cwd allow and the plan mode allow, `task` gets a blanket allow, and an
+/// "allow always" for `bash` is stored under the first word of the command.
+/// Rules are keyed by name alone, so a plugin taking one of these names
+/// inherits all of it.
+pub fn carries_builtin_defaults(tool: &str) -> bool {
+    FILE_WRITE_TOOLS.contains(&tool) || matches!(tool, TASK_TOOL | BASH_TOOL)
+}
 
 #[derive(Debug)]
 pub enum PermissionCheck {
@@ -729,7 +741,7 @@ pub fn generalized_scopes(tool: &ToolKey, scopes: &[String]) -> Vec<String> {
 
 fn generalize_scope(tool: &ToolKey, scope: &str) -> String {
     match tool {
-        ToolKey::Native(name) if name.as_ref() == "bash" => generalize_bash_segment(scope),
+        ToolKey::Native(name) if name.as_ref() == BASH_TOOL => generalize_bash_segment(scope),
         ToolKey::Native(name) if FILE_WRITE_TOOLS.contains(&name.as_ref()) => {
             let p = Path::new(scope);
             match p.parent() {

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -279,15 +279,6 @@ impl RawConfig {
     /// merge between two of them.
     pub fn into_config(self, packages: &[String]) -> Result<Config, ConfigError> {
         self.validate_plugin_tables(packages)?;
-        // Only bundled names, because a builtin's name is also its tool name
-        // while a package's is not. Copying a package name here would hide an
-        // unrelated tool that happened to share it.
-        let disabled_tools: Vec<String> = self
-            .plugins
-            .iter()
-            .filter(|(name, cfg)| cfg.enabled == Some(false) && !packages.contains(name))
-            .map(|(name, _)| name.clone())
-            .collect();
         Ok(Config {
             always_yolo: self.always_yolo.unwrap_or(false),
             always_fast: self.always_fast.unwrap_or(false),
@@ -297,7 +288,7 @@ impl RawConfig {
                 .map(AlwaysThinking::resolve)
                 .transpose()?,
             ui: UiConfig::from_file(self.ui),
-            agent: AgentConfig::from_file(self.agent, disabled_tools),
+            agent: AgentConfig::from_file(self.agent),
             provider: ProviderConfig::from_file(self.provider)?,
             storage: StorageConfig::from_file(self.storage),
             net: NetConfig::from_file(self.net),
@@ -1108,12 +1099,14 @@ pub struct AgentConfig {
     #[config(skip, default = "Vec::new()")]
     pub allowed_tools: Vec<String>,
 
+    /// Only from the CLI's `--disallowed-tools`. A disabled plugin never
+    /// registers its tool, so its name stays free for another plugin to claim.
     #[config(skip, default = "Vec::new()")]
     pub disabled_tools: Vec<String>,
 }
 
 impl AgentConfig {
-    fn from_file(file: AgentFileConfig, disabled_tools: Vec<String>) -> Self {
+    fn from_file(file: AgentFileConfig) -> Self {
         Self {
             max_output_bytes: file.max_output_bytes.unwrap_or(DEFAULT_MAX_OUTPUT_BYTES),
             max_output_lines: file.max_output_lines.unwrap_or(DEFAULT_MAX_OUTPUT_LINES),
@@ -1127,7 +1120,7 @@ impl AgentConfig {
             rtk: file.rtk.unwrap_or(true),
             max_turns: None,
             allowed_tools: Vec::new(),
-            disabled_tools,
+            disabled_tools: Vec::new(),
         }
     }
 }
@@ -3257,18 +3250,16 @@ mod tests {
         );
     }
 
-    #[test]
-    fn disabling_a_package_does_not_disable_a_tool() {
-        let raw: RawConfig = toml::from_str("[plugins.my_pack]\nenabled = false\n").unwrap();
-        let config = raw.into_config(&["my_pack".to_owned()]).unwrap();
-        assert!(!config.agent.disabled_tools.contains(&"my_pack".to_owned()));
-    }
-
-    #[test]
-    fn disabling_a_builtin_still_disables_its_tool() {
-        let raw: RawConfig = toml::from_str("[plugins.grep]\nenabled = false\n").unwrap();
-        let config = raw.into_config(&[]).unwrap();
-        assert!(config.agent.disabled_tools.contains(&"grep".to_owned()));
+    #[test_case("grep", &[] ; "builtin")]
+    #[test_case("my_pack", &["my_pack".to_owned()] ; "package")]
+    fn disabling_a_plugin_leaves_its_tool_name_free(name: &str, packages: &[String]) {
+        let raw: RawConfig =
+            toml::from_str(&format!("[plugins.{name}]\nenabled = false\n")).unwrap();
+        let config = raw.into_config(packages).unwrap();
+        assert!(
+            config.agent.disabled_tools.is_empty(),
+            "a disabled plugin never registers, so nothing may filter its name away"
+        );
     }
 
     #[test]

--- a/maki-docgen/src/gen_config.rs
+++ b/maki-docgen/src/gen_config.rs
@@ -285,6 +285,12 @@ All fields are optional. Typos in field names cause an error right away.
         "The `plugins` table turns plugins on or off and passes options to \
          them. All bundled plugins are on by default. Set \
          `enabled = false` to turn one off.\n\n\
+         A plugin that is off never loads, so its tool name is free for one \
+         of your own plugins to take. Permission rules are keyed by the tool \
+         name alone, and names such as `bash`, `write`, and `task` already \
+         have rules in maki. A plugin that takes one of them inherits those \
+         rules, together with any \"always allow\" you saved. Maki warns you \
+         at load when this happens.\n\n\
          Each plugin checks its own options at startup. A typo, a wrong \
          type, or an unknown plugin name gives you a clear error right \
          away.\n\n\

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -19,7 +19,7 @@ pub use api::util::command::{
 };
 pub use docs::{DocKind, FnDoc, ModuleDoc, ParamDoc, api_docs};
 pub use error::PluginError;
-pub use loader::{EventHandle, PluginHost, SKIPPED_PLUGIN_WARNING};
+pub use loader::{EventHandle, PERMISSION_NAME_WARNING, PluginHost, SKIPPED_PLUGIN_WARNING};
 pub use pack::{
     DiscoveredPackage, Discovery, InstallReport, Interaction, MANAGED_GROUP, Origin, discover,
     discover_installed, install_declared, lockfile_path, sanitize_message, site_dir,

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -6,8 +6,8 @@ use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 use include_dir::{Dir, include_dir};
-use maki_agent::permissions::PluginRuleStore;
-use maki_agent::tools::ToolRegistry;
+use maki_agent::permissions::{PluginRuleStore, carries_builtin_defaults};
+use maki_agent::tools::{ToolRegistry, ToolSource};
 use maki_config::{PluginsConfig, RawConfig};
 
 use crate::api::keymap::KeymapReader;
@@ -26,6 +26,9 @@ use maki_agent::prompt::ResolvedSlots;
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 const USER_PLUGIN: &str = "user";
 pub const SKIPPED_PLUGIN_WARNING: &str = "skipping plugin lua";
+/// Tests assert on this exact text, so a wording tweak here updates them too.
+pub const PERMISSION_NAME_WARNING: &str = "inherits maki's permission rules for the builtin \
+     tool of the same name, together with any \"always allow\" you saved";
 
 struct BundledPlugin {
     name: &'static str,
@@ -188,6 +191,7 @@ fn package_entrypoints(root: &Path) -> Result<Vec<PathBuf>, PluginError> {
 pub struct PluginHost {
     inner: LuaThread,
     plugin_rules: Arc<PluginRuleStore>,
+    registry: Arc<ToolRegistry>,
 }
 
 impl Drop for PluginHost {
@@ -220,10 +224,16 @@ impl PluginHost {
     /// every chunk gets it, init.lua files included.
     pub fn with_jit(registry: Arc<ToolRegistry>, jit: bool) -> Result<Self, PluginError> {
         let plugin_rules = Arc::new(PluginRuleStore::default());
-        let lua = runtime::spawn(registry, *BUNDLED_DIRS, jit, Arc::clone(&plugin_rules))?;
+        let lua = runtime::spawn(
+            Arc::clone(&registry),
+            *BUNDLED_DIRS,
+            jit,
+            Arc::clone(&plugin_rules),
+        )?;
         Ok(Self {
             inner: lua,
             plugin_rules,
+            registry,
         })
     }
 
@@ -321,12 +331,14 @@ impl PluginHost {
             warnings.push(format!("{SKIPPED_PLUGIN_WARNING}: {e}"));
             return Ok(());
         }
+        let owner = scope.label().to_owned();
         if let Some(raw) = self.send_config_lua(source, scope, plugin_dir)? {
             match merged {
                 Some(existing) => existing.merge(raw),
                 None => *merged = Some(raw),
             }
         }
+        warnings.extend(self.permission_name_warning(&owner));
         Ok(())
     }
 
@@ -688,6 +700,28 @@ impl PluginHost {
         self.load_declared_packages(packages, &[], config)
     }
 
+    /// The names the plugin registered that maki's own permission defaults are
+    /// keyed on. Taking such a name is allowed, and a drop-in replacement may
+    /// want the builtin's rules, but the user has to be told which rules the
+    /// plugin just inherited. One warning lists them all, because the TUI
+    /// flashes a single warning and a per-tool one would drop the rest.
+    fn permission_name_warning(&self, plugin: &str) -> Option<String> {
+        let snapshot = self.registry.iter();
+        let names: Vec<String> = snapshot
+            .iter()
+            .filter(|t| matches!(&t.source, ToolSource::Lua { plugin: p } if p.as_ref() == plugin))
+            .filter(|t| carries_builtin_defaults(t.name()))
+            .map(|t| format!("`{}`", t.name()))
+            .collect();
+        if names.is_empty() {
+            return None;
+        }
+        Some(format!(
+            "{plugin}: registered {}, so it {PERMISSION_NAME_WARNING}",
+            names.join(", ")
+        ))
+    }
+
     /// As `load_packages`, with the declarations that may carry a custom
     /// loader. A package with no matching declaration loads its `plugin/*.lua`.
     pub fn load_declared_packages(
@@ -696,7 +730,7 @@ impl PluginHost {
         declared: &[crate::api::pack::Declared],
         config: &PluginsConfig,
     ) -> Vec<String> {
-        let mut failures = Vec::new();
+        let mut warnings = Vec::new();
         let mut loaded: Vec<&str> = Vec::new();
         let mut round: Vec<&DiscoveredPackage> = packages
             .iter()
@@ -739,31 +773,33 @@ impl PluginHost {
                         pkg.revision_guard.clone(),
                     ),
                 };
-                if let Err(e) = result {
-                    if e.is_version_floor() {
+                match result {
+                    Ok(()) => warnings.extend(self.permission_name_warning(&pkg.name)),
+                    Err(e) if e.is_version_floor() => {
                         tracing::warn!(
                             package = %pkg.name,
                             path = %pkg.dir.display(),
                             error = %e,
                             "{SKIPPED_PLUGIN_WARNING}"
                         );
-                        failures.push(format!("{SKIPPED_PLUGIN_WARNING}: {e}"));
-                        continue;
+                        warnings.push(format!("{SKIPPED_PLUGIN_WARNING}: {e}"));
                     }
-                    tracing::error!(
-                        package = %pkg.name,
-                        path = %pkg.dir.display(),
-                        error = %e,
-                        "failed to load package"
-                    );
-                    failures.push(format!("{}: failed to load: {e}", pkg.name));
+                    Err(e) => {
+                        tracing::error!(
+                            package = %pkg.name,
+                            path = %pkg.dir.display(),
+                            error = %e,
+                            "failed to load package"
+                        );
+                        warnings.push(format!("{}: failed to load: {e}", pkg.name));
+                    }
                 }
             }
 
             let ops = match self.take_pending_pack_ops() {
                 Ok(ops) => ops,
                 Err(e) => {
-                    failures.push(format!("could not read package activations: {e}"));
+                    warnings.push(format!("could not read package activations: {e}"));
                     break;
                 }
             };
@@ -780,7 +816,7 @@ impl PluginHost {
                     .find(|pkg| pkg.name == name && config.packages.iter().any(|n| n == &pkg.name));
                 match found {
                     Some(pkg) => round.push(pkg),
-                    None => failures.push(format!(
+                    None => warnings.push(format!(
                         "packadd {name:?}: no package with that name is installed"
                     )),
                 }
@@ -797,7 +833,7 @@ impl PluginHost {
             Ok(leftover) => {
                 for op in leftover {
                     let crate::api::pack::PackOp::Activate { name } = op;
-                    failures.push(format!(
+                    warnings.push(format!(
                         "packadd {name:?}: arrived after the packages had loaded"
                     ));
                 }
@@ -806,7 +842,7 @@ impl PluginHost {
                 tracing::warn!(error = %e, "could not close the package activation queue");
             }
         }
-        failures
+        warnings
     }
 
     pub fn event_handle(&self) -> EventHandle {

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -5,12 +5,17 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use maki_agent::ToolOutput;
+use maki_agent::template::Vars;
 use maki_agent::tools::{
-    DescriptionContext, ExecFuture, HeaderFuture, HeaderResult, ParseError, Tool, ToolContext,
-    ToolExecResult, ToolInvocation, ToolLive, ToolRegistry, ToolSource, timeout_annotation,
+    DescriptionContext, ExecFuture, HeaderFuture, HeaderResult, ParseError, Tool, ToolAudience,
+    ToolContext, ToolExecResult, ToolFilter, ToolInvocation, ToolLive, ToolRegistry, ToolSource,
+    timeout_annotation,
 };
 use maki_config::{AlwaysThinking, Effect, PluginsConfig, ToolKey, ToolOutputLines};
-use maki_lua::{PluginError, PluginHost, SKIPPED_PLUGIN_WARNING, WARM_TOOL_CAP};
+use maki_lua::{
+    PERMISSION_NAME_WARNING, PluginError, PluginHost, SKIPPED_PLUGIN_WARNING, WARM_TOOL_CAP,
+};
+use maki_providers::Model;
 use maki_storage::id::SessionRef;
 #[cfg(unix)]
 use rustix::process::{Pid, test_kill_process_group};
@@ -25,6 +30,12 @@ const USAGE_OUTPUT: &str = "usage_done";
 const FLOORED_PACKAGE: &str = "future_pack";
 const SIBLING_PACKAGE: &str = "sibling_pack";
 const MALFORMED_FLOOR: &str = "min_maki_version = 12\n";
+const SHADOWED_TOOL: &str = "skill";
+const REPLACEMENT_PLUGIN: &str = "my_skill";
+const REPLACEMENT_DESC: &str = "took the builtin name over";
+const PERMISSION_KEYED_TOOL: &str = "task";
+const OTHER_PERMISSION_KEYED_TOOL: &str = "write";
+const PLAIN_TOOL: &str = "plain_helper";
 
 /// Lua tools cannot publish `ToolLive::Usage` (only the subagent relay does), so
 /// a native stub stands in for one.
@@ -1083,6 +1094,45 @@ fn incompatible_plugin_warns_instead_of_aborting_startup() {
         .find(|w| w.contains(SKIPPED_PLUGIN_WARNING))
         .unwrap_or_else(|| panic!("no skip warning in {warnings:?}"));
     assert!(warning.contains(&required), "{warning}");
+}
+
+/// An `init.lua` registers tools on the same name-keyed permission model a
+/// package does, and it is the path a plugin under the lua directory is loaded
+/// from, so a name carrying maki's builtin defaults has to be reported here too.
+#[test_case::test_case(PERMISSION_KEYED_TOOL, 1 ; "permission_keyed_name_warns")]
+#[test_case::test_case(PLAIN_TOOL, 0 ; "ordinary_name_is_quiet")]
+fn init_file_taking_a_permission_keyed_tool_name_warns(tool: &str, expected: usize) {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let maki_dir = tmp.path().join(".maki");
+    std::fs::create_dir_all(&maki_dir).unwrap();
+    std::fs::write(
+        maki_dir.join("init.lua"),
+        format!(
+            r#"maki.api.register_tool({{
+            name = "{tool}",
+            description = "{REPLACEMENT_DESC}",
+            schema = {MINIMAL_SCHEMA},
+            handler = function() return "" end
+        }})"#
+        ),
+    )
+    .unwrap();
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let mut warnings = Vec::new();
+    host.load_init_files_or_skip(false, tmp.path(), &mut warnings)
+        .expect("init.lua must load");
+
+    assert!(reg.has(tool));
+    assert_eq!(
+        warnings
+            .iter()
+            .filter(|w| w.contains(PERMISSION_NAME_WARNING) && w.contains(tool))
+            .count(),
+        expected,
+        "got: {warnings:?}"
+    );
 }
 
 #[test]
@@ -2737,6 +2787,69 @@ fn unknown_plugin_name_fails_load_builtins() {
     );
 }
 
+fn shadow_src() -> String {
+    format!(
+        r#"maki.api.register_tool({{
+            name = "{SHADOWED_TOOL}",
+            description = "{REPLACEMENT_DESC}",
+            schema = {MINIMAL_SCHEMA},
+            handler = function() return "replaced" end
+        }})"#
+    )
+}
+
+/// Turning a builtin off used to copy its name into `agent.disabled_tools`,
+/// the name filter every request runs over the tool array, so a replacement
+/// could load and still stay invisible to the model. That is why this walks
+/// the whole path: init.lua, config, builtins, then the definitions a request
+/// is built from.
+#[test]
+fn disabled_builtin_hands_its_tool_name_to_a_user_plugin() {
+    let reg = fresh_registry();
+    let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let raw = host
+        .send_run_init_lua(
+            format!("maki.setup({{ plugins = {{ {SHADOWED_TOOL} = {{ enabled = false }} }} }})"),
+            "test_init.lua".to_owned(),
+            None,
+        )
+        .unwrap()
+        .expect("setup returns a config");
+    let config = raw.into_config(&[]).unwrap();
+    host.load_builtins(&config.plugins).unwrap();
+    host.load_source(REPLACEMENT_PLUGIN, &shadow_src())
+        .expect("a disabled builtin leaves its tool name free");
+
+    let model = Model::from_spec("anthropic/claude-opus-4-8").unwrap();
+    let filter = ToolFilter::from_config(&config.agent, &model, &[]);
+    let ctx = DescriptionContext {
+        filter: &filter,
+        audience: ToolAudience::MAIN,
+        workflow: false,
+        mcp: false,
+    };
+    let defs = reg.definitions(&Vars::new(), &ctx, false);
+    let shadowed = defs
+        .as_array()
+        .expect("definitions returns an array")
+        .iter()
+        .find(|def| def["name"] == SHADOWED_TOOL)
+        .expect("the replacement must reach the model, not just `maki prompt --tools`");
+    assert_eq!(shadowed["description"], REPLACEMENT_DESC);
+}
+
+#[test]
+fn enabled_builtin_still_rejects_a_shadowing_plugin() {
+    let (_reg, host) = builtins_host();
+    let err = host
+        .load_source(REPLACEMENT_PLUGIN, &shadow_src())
+        .expect_err("an enabled builtin owns its tool name");
+    assert!(
+        matches!(err, PluginError::NameConflict { .. }),
+        "got: {err}"
+    );
+}
+
 #[test]
 fn disabled_plugin_opts_are_ignored_not_rejected() {
     let reg = fresh_registry();
@@ -3180,6 +3293,45 @@ fn site_with_package(sub: &str, name: &str, files: &[(&str, &str)]) -> tempfile:
         std::fs::write(dir.join("plugin").join(file), source).unwrap();
     }
     tmp
+}
+
+/// Permission decisions are keyed by tool name alone, so a package that takes
+/// a name maki's builtin defaults are written for inherits those defaults, and
+/// any "always allow" the user stored for the builtin. The load is allowed, the
+/// user is told, once for the package however many names it took.
+#[test_case::test_case(&[PERMISSION_KEYED_TOOL], 1 ; "permission_keyed_name_warns")]
+#[test_case::test_case(&[PERMISSION_KEYED_TOOL, OTHER_PERMISSION_KEYED_TOOL], 1 ; "two_names_warn_once")]
+#[test_case::test_case(&[PLAIN_TOOL], 0 ; "ordinary_name_is_quiet")]
+fn package_taking_a_permission_keyed_tool_name_warns(tools: &[&str], expected: usize) {
+    let source = tools
+        .iter()
+        .map(|tool| {
+            format!(
+                r#"maki.api.register_tool({{
+            name = "{tool}",
+            description = "{REPLACEMENT_DESC}",
+            schema = {MINIMAL_SCHEMA},
+            handler = function() return "" end
+        }})"#
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let site = site_with_package("start", "perm_pack", &[("init.lua", &source)]);
+    let found = maki_lua::discover(site.path());
+    let (_, config) = discovered_config(&found);
+    let host = PluginHost::new(fresh_registry()).unwrap();
+
+    let warnings = host.load_packages(&found.packages, &config);
+
+    assert_eq!(
+        warnings
+            .iter()
+            .filter(|w| w.contains(PERMISSION_NAME_WARNING))
+            .count(),
+        expected,
+        "got: {warnings:?}"
+    );
 }
 
 /// The whole layer-1 path: find a package on disk, then load it.

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -196,6 +196,8 @@ Every field also has an environment variable, shown in the Env column, and the v
 
 The `plugins` table turns plugins on or off and passes options to them. All bundled plugins are on by default. Set `enabled = false` to turn one off.
 
+A plugin that is off never loads, so its tool name is free for one of your own plugins to take. Permission rules are keyed by the tool name alone, and names such as `bash`, `write`, and `task` already have rules in maki. A plugin that takes one of them inherits those rules, together with any "always allow" you saved. Maki warns you at load when this happens.
+
 Each plugin checks its own options at startup. A typo, a wrong type, or an unknown plugin name gives you a clear error right away.
 
 The edit plugin's extra tools are options too: `plugins.edit = { multiedit = false, insert_lines = true }`. The old `tools` table is gone. If your config still uses it, Maki stops at startup and shows you the new form.


### PR DESCRIPTION
Turning a bundled plugin off with `plugins.skill = { enabled = false }` already stopped it from loading, but `into_config` also copied every disabled name into `agent.disabled_tools`, which is a plain name filter applied to the model's tool array on every request.

So a plugin of your own could register `skill` and show up in `maki prompt --tools`, and the live agent still never saw it.

The list of names it built is dead weight now that off means never registered, so it is gone and `agent.disabled_tools` carries only what `--disallowed-tools` puts there.

Leaving the builtin on still fails the load with `NameConflict`, since the tool is really there.

Permission rules are keyed by tool name, so a package or an `init.lua` taking one maki has rules for, like `bash`, `task`, or `write`, now warns at load that it inherits them together with any stored "always allow".

Closes #779.