### PR TITLE
feat(lua): building blocks for long-running tools (sleep, run opts, background task)

### DIFF
--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -1023,6 +1023,7 @@ mod tests {
                     prompt: None,
                     model: None,
                     answer_tx: None,
+                    detached: false,
                 }),
                 run_id: 0,
             })

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -37,11 +37,11 @@ pub use maki_providers::AgentError;
 use maki_providers::Message;
 pub use maki_providers::{EMPTY_RESPONSE_MARKER, ImageMediaType, ImageSource, ThinkingConfig};
 pub use types::{
-    AgentEvent, BufferSnapshot, DoneReason, Envelope, EventSender, EventStreamGuard, GrepFileEntry,
-    GrepLine, GrepMatchGroup, InstructionBlock, NO_FILES_FOUND, RunLedger, RunTotals,
-    SessionEndReason, SessionEvents, SharedBuf, SnapshotLine, SnapshotSpan, SpanColor, SpanStyle,
-    SubagentInfo, TextOutput, ToolDoneEvent, ToolInput, ToolOutput, ToolStartEvent,
-    TurnCompleteEvent, event_stream,
+    AgentEvent, BufferSnapshot, DETACHED_RUN_ID, DoneReason, Envelope, EventSender,
+    EventStreamGuard, GrepFileEntry, GrepLine, GrepMatchGroup, InstructionBlock, NO_FILES_FOUND,
+    RunLedger, RunTotals, SessionEndReason, SessionEvents, SharedBuf, SnapshotLine, SnapshotSpan,
+    SpanColor, SpanStyle, SubagentInfo, TextOutput, ToolDoneEvent, ToolInput, ToolOutput,
+    ToolStartEvent, TurnCompleteEvent, event_stream,
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -1002,7 +1002,16 @@ pub struct SubagentInfo {
     pub model: Option<String>,
     #[serde(skip)]
     pub answer_tx: Option<flume::Sender<String>>,
+    /// Outlives the run that spawned it. The UI keeps the chat cancellable
+    /// and does not drop its events when `run_id` bumps.
+    #[serde(skip)]
+    pub detached: bool,
 }
+
+/// Events from a subagent that outlives the run that spawned it. The UI
+/// does not drop these when `run_id` bumps. Distinct from restore
+/// snapshots, which use `u64::MAX`.
+pub const DETACHED_RUN_ID: u64 = u64::MAX - 1;
 
 #[derive(Debug, Clone)]
 pub struct EventSender {

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use async_lock::Mutex as AsyncMutex;
 use futures::future::{Either, select};
 use maki_agent::agent::tool_dispatch;
-use maki_agent::cancel::{CancelMap, CancelSlot};
+use maki_agent::cancel::{CancelMap, CancelSlot, CancelToken};
 use maki_agent::tools::interpreter_bridge;
 use maki_agent::tools::registry::ToolRegistry;
 use maki_agent::tools::schema::sanitize_tool_input_schema;
@@ -26,7 +26,7 @@ use maki_lua_macro::{lua_class, lua_fn, lua_table};
 use maki_providers::model::ModelTier;
 use maki_providers::provider;
 use maki_providers::{ContentBlock, Model, ModelError, Role, ThinkingConfig, TokenUsage, add_cost};
-use maki_storage::id::MakiId;
+use maki_storage::id::{MakiId, SessionRef};
 use maki_storage::sessions::StoredThinking;
 use mlua::{Function, IntoLuaMulti, Lua, Result as LuaResult, Table, Value as LuaValue};
 use serde_json::Value as JsonValue;
@@ -41,6 +41,8 @@ use crate::runtime::CANCELLED_MSG;
 
 const SESSION_CLOSED_ERR: &str = "session closed";
 const DEFAULT_SESSION_AUDIENCE: ToolAudience = ToolAudience::GENERAL_SUB;
+const SCOPE_TABLE_ERR: &str = "scope must be { session = \"<id>\" }";
+const SCOPE_SESSION_MISMATCH_ERR: &str = "scope.session must be the caller's own session id";
 
 fn resolve_model_from_ctx(ctx: &AgentContext, tier: Option<&str>) -> Result<Model, String> {
     let Some(tier_str) = tier else {
@@ -430,6 +432,13 @@ async fn call_tool(
 ///     `"max"`), or a budget integer (token count). Inherits parent setting
 ///     if omitted.
 ///   `fast` (boolean?) - use fast mode. Inherits parent setting if omitted.
+///   `scope` (table?) - `{ session = "<id>" }` detaches the session from the
+///     call that spawned it: it survives the call returning and the turn
+///     ending, instead of being cancelled the moment either does. `<id>`
+///     must be the caller's own session (`ctx:session_id()`). Only cancel-all
+///     and a targeted cancel of this session's tool call id can stop it from
+///     here on; keep the returned handle (or its id) if you need to reach it
+///     later. Omit for the default: tied to the call that spawned it.
 /// @return (Session?, string?) Session handle, or `(nil, err)` on failure.
 /// @example
 /// local tools = maki.agent.tools(ctx, { audience = "general_sub" })
@@ -452,6 +461,24 @@ async fn session(
 ) -> LuaResult<Pair<mlua::AnyUserData>> {
     let agent_ctx = try_pair!(dispatch_ctx(&ctx, "session")).clone();
     drop(ctx);
+    let detached: bool = match opts.get::<LuaValue>("scope")? {
+        LuaValue::Nil => false,
+        LuaValue::Table(scope) => {
+            let Ok(LuaValue::String(raw)) = scope.get::<LuaValue>("session") else {
+                return Ok(err_pair(SCOPE_TABLE_ERR));
+            };
+            let session: MakiId = try_pair!(
+                raw.to_str()?
+                    .parse()
+                    .map_err(|e: maki_storage::id::MakiIdParseError| e.to_string())
+            );
+            if agent_ctx.session_id.as_ref().map(SessionRef::id) != Some(session) {
+                return Ok(err_pair(SCOPE_SESSION_MISMATCH_ERR));
+            }
+            true
+        }
+        _ => return Ok(err_pair(SCOPE_TABLE_ERR)),
+    };
     let model_spec: Option<String> = opts.get("model_spec")?;
     let system: Option<String> = opts.get("system")?;
     let tools_val: Option<LuaValue> = opts.get("tools")?;
@@ -574,8 +601,15 @@ async fn session(
         .clone()
         .unwrap_or_else(|| format!("session-{}", MakiId::generate()));
     // Registered before the session runs so the child token does not fire
-    // on drop and kill the subagent at birth.
-    let (child_trigger, child_cancel) = agent_ctx.cancel.child();
+    // on drop and kill the subagent at birth. A detached child stands on
+    // its own token instead of the caller's: it must outlive the call (and
+    // the turn) that spawned it, only stopped by a targeted cancel or
+    // cancel-all from here on.
+    let (child_trigger, child_cancel) = if detached {
+        CancelToken::new()
+    } else {
+        agent_ctx.cancel.child()
+    };
     // Several sessions can share one `ui_id`, so keep the slot and retire
     // only ours on close instead of clearing the whole key.
     let cancel_slot = agent_ctx

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -18,15 +18,15 @@ use maki_agent::tools::{
     ToolContext, ToolFilter, ToolLive,
 };
 use maki_agent::{
-    Agent, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams, DoneReason,
-    EMPTY_RESPONSE_MARKER, EventSender, EventStreamGuard, History, McpSession, RunLedger,
-    SessionEvents, SubagentInfo, ToolDoneEvent, event_stream,
+    Agent, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams, DETACHED_RUN_ID,
+    DoneReason, EMPTY_RESPONSE_MARKER, EventSender, EventStreamGuard, History, McpSession,
+    RunLedger, SessionEvents, SubagentInfo, ToolDoneEvent, event_stream,
 };
 use maki_lua_macro::{lua_class, lua_fn, lua_table};
 use maki_providers::model::ModelTier;
 use maki_providers::provider;
 use maki_providers::{ContentBlock, Model, ModelError, Role, ThinkingConfig, TokenUsage, add_cost};
-use maki_storage::id::{MakiId, SessionRef};
+use maki_storage::id::MakiId;
 use maki_storage::sessions::StoredThinking;
 use mlua::{Function, IntoLuaMulti, Lua, Result as LuaResult, Table, Value as LuaValue};
 use serde_json::Value as JsonValue;
@@ -41,8 +41,8 @@ use crate::runtime::CANCELLED_MSG;
 
 const SESSION_CLOSED_ERR: &str = "session closed";
 const DEFAULT_SESSION_AUDIENCE: ToolAudience = ToolAudience::GENERAL_SUB;
-const SCOPE_TABLE_ERR: &str = "scope must be { session = \"<id>\" }";
-const SCOPE_SESSION_MISMATCH_ERR: &str = "scope.session must be the caller's own session id";
+const SCOPE_ERR: &str = "scope must be \"session\"";
+const SCOPE_NESTED_ERR: &str = "scope = \"session\" is only valid on the main session";
 
 fn resolve_model_from_ctx(ctx: &AgentContext, tier: Option<&str>) -> Result<Model, String> {
     let Some(tier_str) = tier else {
@@ -432,13 +432,12 @@ async fn call_tool(
 ///     `"max"`), or a budget integer (token count). Inherits parent setting
 ///     if omitted.
 ///   `fast` (boolean?) - use fast mode. Inherits parent setting if omitted.
-///   `scope` (table?) - `{ session = "<id>" }` detaches the session from the
-///     call that spawned it: it survives the call returning and the turn
-///     ending, instead of being cancelled the moment either does. `<id>`
-///     must be the caller's own session (`ctx:session_id()`). Only cancel-all
-///     and a targeted cancel of this session's tool call id can stop it from
-///     here on; keep the returned handle (or its id) if you need to reach it
-///     later. Omit for the default: tied to the call that spawned it.
+///   `scope` (string?) - `"session"` detaches the session from the call that
+///     spawned it: it survives the call returning and the turn ending,
+///     instead of being cancelled the moment either does. Esc on its chat
+///     still cancels it. Keep the returned handle to `prompt` and `close`.
+///     Omit for the default: tied to the call that spawned it. Invalid
+///     inside a subagent.
 /// @return (Session?, string?) Session handle, or `(nil, err)` on failure.
 /// @example
 /// local tools = maki.agent.tools(ctx, { audience = "general_sub" })
@@ -463,22 +462,12 @@ async fn session(
     drop(ctx);
     let detached: bool = match opts.get::<LuaValue>("scope")? {
         LuaValue::Nil => false,
-        LuaValue::Table(scope) => {
-            let Ok(LuaValue::String(raw)) = scope.get::<LuaValue>("session") else {
-                return Ok(err_pair(SCOPE_TABLE_ERR));
-            };
-            let session: MakiId = try_pair!(
-                raw.to_str()?
-                    .parse()
-                    .map_err(|e: maki_storage::id::MakiIdParseError| e.to_string())
-            );
-            if agent_ctx.session_id.as_ref().map(SessionRef::id) != Some(session) {
-                return Ok(err_pair(SCOPE_SESSION_MISMATCH_ERR));
-            }
-            true
-        }
-        _ => return Ok(err_pair(SCOPE_TABLE_ERR)),
+        LuaValue::String(s) if s.to_str()?.as_ref() == "session" => true,
+        _ => return Ok(err_pair(SCOPE_ERR)),
     };
+    if detached && agent_ctx.task_id.is_some() {
+        return Ok(err_pair(SCOPE_NESTED_ERR));
+    }
     let model_spec: Option<String> = opts.get("model_spec")?;
     let system: Option<String> = opts.get("system")?;
     let tools_val: Option<LuaValue> = opts.get("tools")?;
@@ -577,8 +566,12 @@ async fn session(
     };
 
     let (stream_guard, sub_events) = event_stream();
-    let sub_event_tx = stream_guard.sender(agent_ctx.event_tx.run_id());
-    let parent_tx = agent_ctx.event_tx.clone();
+    let parent_tx = if detached {
+        agent_ctx.event_tx.with_run_id(DETACHED_RUN_ID)
+    } else {
+        agent_ctx.event_tx.clone()
+    };
+    let sub_event_tx = stream_guard.sender(parent_tx.run_id());
     let (answer_tx, answer_rx) = flume::unbounded::<String>();
 
     let subagent_info: Arc<OnceLock<SubagentInfo>> = Arc::new(OnceLock::new());
@@ -673,6 +666,7 @@ async fn session(
         usage_rx,
         start: Instant::now(),
         closed: false,
+        detached,
     };
 
     let sess = lua.create_userdata(LuaSession {
@@ -798,6 +792,7 @@ struct SessionState {
     usage_rx: flume::Receiver<TokenUsage>,
     start: Instant,
     closed: bool,
+    detached: bool,
 }
 
 impl SessionState {
@@ -879,6 +874,7 @@ async fn prompt(
             prompt: Some(message.clone()),
             model: Some(s.params.model.spec()),
             answer_tx: s.answer_tx.take(),
+            detached: s.detached,
         });
     }
 
@@ -1084,6 +1080,7 @@ mod tests {
             prompt: None,
             model: None,
             answer_tx: None,
+            detached: false,
         })
         .unwrap();
         info

--- a/maki-lua/src/api/async.rs
+++ b/maki-lua/src/api/async.rs
@@ -12,6 +12,7 @@ use crate::runtime::{TaskHandle, enqueue_async_task, lock_cell, register_cancel_
 
 const AWAIT_MIN_ARGS: usize = 2;
 const PERMIT_RELEASED_ERR: &str = "permit already released";
+const SLEEP_NEGATIVE_ERR: &str = "maki.async.sleep: ms must be >= 0";
 
 /// Cancel-aware counting semaphore. Permits release on `:release()` or gc.
 struct LuaSemaphore {
@@ -84,6 +85,9 @@ lua_class! {
 /// Fire off a function as a new async task. It runs in the background and
 /// you do not wait for it. If you need the result, pass an {on_finish}
 /// callback.
+///
+/// The task must finish within 60 seconds; waiting minutes for a build or a
+/// subagent inside one dies partway through.
 ///
 /// @param fn function Zero-argument function to execute.
 /// @param on_finish function? Optional callback `function(err, result)`. Called once {fn} completes.
@@ -196,26 +200,6 @@ async fn gather(lua: Lua, fns: Table) -> LuaResult<Table> {
     Ok(out)
 }
 
-/// Suspend the calling task for {ms} milliseconds. The plugin thread is
-/// never blocked, so other tasks and the UI keep running, and a cancel
-/// still lands while you sleep.
-///
-/// For a timer that has to outlive the tool call that started it, such
-/// as a toast dismissing itself, use `maki.defer_fn`.
-///
-/// @param ms integer Milliseconds to sleep.
-/// @return
-/// @example
-/// maki.async.run(function()
-///   maki.async.sleep(4000)
-///   win:close()
-/// end)
-#[lua_fn]
-async fn sleep(_lua: Lua, ms: u64) -> LuaResult<()> {
-    smol::Timer::after(Duration::from_millis(ms)).await;
-    Ok(())
-}
-
 /// Create a counting semaphore that allows at most {n} concurrent permits.
 /// Use this to limit how many tasks hit a resource at the same time.
 ///
@@ -232,6 +216,35 @@ fn semaphore(_lua: &Lua, n: usize) -> LuaResult<LuaSemaphore> {
     Ok(LuaSemaphore {
         sem: Arc::new(Semaphore::new(n.max(1))),
     })
+}
+
+/// Suspend the current coroutine for {ms} milliseconds. The timer runs on
+/// the async executor, so nothing spins and other tasks keep running.
+/// Cancelling the owning task interrupts the sleep with the cancel error.
+///
+/// For a timer that has to outlive the tool call that started it, such
+/// as a toast dismissing itself, use `maki.defer_fn`.
+///
+/// @param ms integer Milliseconds to wait. Must be >= 0.
+/// @example
+/// maki.async.run(function()
+///   maki.async.sleep(250)
+///   retry()
+/// end)
+#[lua_fn]
+async fn sleep(lua: Lua, ms: i64) -> LuaResult<()> {
+    if ms < 0 {
+        return Err(mlua::Error::runtime(SLEEP_NEGATIVE_ERR));
+    }
+    let cancel = lua
+        .app_data_ref::<TaskHandle>()
+        .map(|h| lock_cell(&h).cancel.clone())
+        .unwrap_or_else(CancelToken::none);
+    cancel
+        .race(smol::Timer::after(Duration::from_millis(ms as u64)))
+        .await
+        .map_err(mlua::Error::runtime)?;
+    Ok(())
 }
 
 /// `await`, `wrap`, and `join` are registered by hand below: `await`
@@ -440,6 +453,7 @@ mod tests {
     const ERR_ARGC_GE_1: &str = "argc must be >= 1";
     const ERR_ARGC_INTEGER: &str = "argc must be an integer";
     const ERR_SECOND_ARG_FN: &str = "second argument must be a function";
+    const ERR_SLEEP_NEGATIVE: &str = "ms must be >= 0";
 
     fn setup() -> (Lua, Table) {
         let lua = Lua::new();
@@ -460,6 +474,60 @@ mod tests {
             assert!(
                 msg.contains(expected_err),
                 "expected error containing {expected_err:?}, got: {msg}"
+            );
+        });
+    }
+
+    #[test_case(r#"return async_tbl.sleep(-1)"#, ERR_SLEEP_NEGATIVE ; "negative_ms")]
+    fn sleep_validation(code: &str, expected_err: &str) {
+        smol::block_on(async {
+            let (lua, _tbl) = setup();
+            let err = lua.load(code).eval_async::<Value>().await.unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains(expected_err),
+                "expected error containing {expected_err:?}, got: {msg}"
+            );
+        });
+    }
+
+    #[test]
+    fn sleep_suspends_for_the_requested_duration() {
+        smol::block_on(async {
+            let (lua, _tbl) = setup();
+            let began = std::time::Instant::now();
+            lua.load("async_tbl.sleep(30)").exec_async().await.unwrap();
+            assert!(
+                began.elapsed() >= Duration::from_millis(30),
+                "sleep(30) returned early after {:?}",
+                began.elapsed()
+            );
+        });
+    }
+
+    #[test]
+    fn sleep_observes_caller_cancel() {
+        smol::block_on(async {
+            let (lua, _tbl) = setup();
+            lua.set_app_data::<TaskHandle>(cancelled_task_handle());
+            let code = r#"
+                local ok, err = pcall(async_tbl.sleep, 60_000)
+                return ok, tostring(err)
+            "#;
+            let vals: Vec<Value> = lua
+                .load(code)
+                .eval_async::<MultiValue>()
+                .await
+                .unwrap()
+                .into_vec();
+            assert!(!vals[0].as_boolean().unwrap());
+            assert!(
+                vals[1]
+                    .as_string()
+                    .unwrap()
+                    .to_string_lossy()
+                    .contains(CANCELLED_MSG),
+                "sleep should observe the caller's cancel token"
             );
         });
     }

--- a/maki-lua/src/api/util/command.rs
+++ b/maki-lua/src/api/util/command.rs
@@ -537,6 +537,10 @@ pub struct UiAttachment(Arc<AtomicBool>);
 impl Default for UiAttachment {
     /// Attached until a loop says otherwise. Headless runs and ACP hand Lua no
     /// sender at all, so the bit only ever describes a loop that went away.
+    /// A test harness (or other embedder) that drains `ui_action_rx` itself
+    /// without ever building an `EventLoop` relies on this default too, so it
+    /// stays `true`; real cold-start plugin load closes its own gap instead
+    /// by detaching explicitly before `EventLoop::new` reattaches.
     fn default() -> Self {
         Self(Arc::new(AtomicBool::new(true)))
     }

--- a/maki-lua/src/api/util/command.rs
+++ b/maki-lua/src/api/util/command.rs
@@ -535,14 +535,15 @@ pub enum UiAction {
 pub struct UiAttachment(Arc<AtomicBool>);
 
 impl Default for UiAttachment {
-    /// Attached until a loop says otherwise. Headless runs and ACP hand Lua no
-    /// sender at all, so the bit only ever describes a loop that went away.
-    /// A test harness (or other embedder) that drains `ui_action_rx` itself
-    /// without ever building an `EventLoop` relies on this default too, so it
-    /// stays `true`; real cold-start plugin load closes its own gap instead
-    /// by detaching explicitly before `EventLoop::new` reattaches.
+    /// Detached until `EventLoop::new` calls `attach()`. Plugin load in the
+    /// TUI, ACP, and subcommands all happen before any loop drains
+    /// `UiAction`, so a roundtrip at load must fail fast. A thread that
+    /// never installed a handle still reads as attached (`ui_attached` uses
+    /// `is_none_or`), so unit tests that do not go through `PluginHost`
+    /// keep working. Tests that drain `ui_action_rx` themselves call
+    /// `attach()`.
     fn default() -> Self {
-        Self(Arc::new(AtomicBool::new(true)))
+        Self(Arc::new(AtomicBool::new(false)))
     }
 }
 

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -5926,6 +5926,13 @@ fn session_close_idempotent_and_prompt_after_close_errors() {
 #[test_case::test_case("{ audience = 'wurkflow' }", "unknown audience: wurkflow" ; "unknown_audience")]
 #[test_case::test_case("{ local_tools = { foo = { handler = function() return '' end } } }", "local_tools.foo: 'description' is required" ; "local_tool_missing_description")]
 #[test_case::test_case("{ local_tools = { foo = { description = 'd' } } }", "local_tools.foo: 'handler' is required" ; "local_tool_missing_handler")]
+#[test_case::test_case("{ scope = 'session' }", "scope must be" ; "scope_wrong_type")]
+#[test_case::test_case("{ scope = {} }", "scope must be" ; "scope_table_missing_session")]
+#[test_case::test_case(
+    "{ scope = { session = '01965087-4c71-7f00-8000-000000000000' } }",
+    "scope.session must be the caller's own session id"
+    ; "scope_session_mismatch"
+)]
 fn session_opts_validation_rejects(opts: &str, expected: &str) {
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
@@ -5945,6 +5952,35 @@ fn session_opts_validation_rejects(opts: &str, expected: &str) {
     host.load_source("session_opts_plugin", &src).unwrap();
     let out = exec_tool(&reg, "session_opts_probe", serde_json::json!({})).unwrap();
     assert!(out.contains(expected), "got: {out}");
+}
+
+#[test]
+fn session_scope_accepts_the_callers_own_session() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "detach_probe",
+            description = "test",
+            schema = {MINIMAL_SCHEMA},
+            audiences = {{ "main" }},
+            handler = function(input, ctx)
+                local id = ctx:session_id()
+                local sess, err = maki.agent.session(ctx, {{ scope = {{ session = id }} }})
+                if err ~= nil then return "err:" .. err end
+                sess:close()
+                return "ok"
+            end
+        }})"#
+    );
+    host.load_source("detach_plugin", &src).unwrap();
+    let session: SessionRef = "01965087-4c71-7f00-8000-000000000000"
+        .parse()
+        .expect("valid session id");
+    let mut ctx = maki_agent::tools::test_support::stub_ctx(&maki_agent::AgentMode::Build);
+    ctx.session_id = Some(session);
+    let out = exec_with_ctx(&reg, "detach_probe", json!({}), &ctx).unwrap();
+    assert_eq!(out, "ok");
 }
 
 fn load_img_tool(host: &PluginHost) {

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -3928,6 +3928,7 @@ fn register_command_nargs_values(nargs_field: &str) -> usize {
 #[test_case::test_case("", "|" ; "empty_args")]
 fn command_handler_receives_args_and_fargs(args: &str, expected_flash: &str) {
     let host = PluginHost::new(fresh_registry()).unwrap();
+    host.ui_attachment().attach();
     host.load_source(
         "p",
         r#"
@@ -3961,6 +3962,7 @@ const RUN_COMMAND_NO_ACTION: &str = "run_command did not reach the UI";
 #[test_case::test_case(Err("unknown command".into()), "nil|unknown command" ; "rejected")]
 fn run_command_round_trips_through_ui(reply: Result<(), String>, expected_flash: &str) {
     let host = PluginHost::new(fresh_registry()).unwrap();
+    host.ui_attachment().attach();
     host.load_source(
         "p",
         r#"
@@ -5926,12 +5928,12 @@ fn session_close_idempotent_and_prompt_after_close_errors() {
 #[test_case::test_case("{ audience = 'wurkflow' }", "unknown audience: wurkflow" ; "unknown_audience")]
 #[test_case::test_case("{ local_tools = { foo = { handler = function() return '' end } } }", "local_tools.foo: 'description' is required" ; "local_tool_missing_description")]
 #[test_case::test_case("{ local_tools = { foo = { description = 'd' } } }", "local_tools.foo: 'handler' is required" ; "local_tool_missing_handler")]
-#[test_case::test_case("{ scope = 'session' }", "scope must be" ; "scope_wrong_type")]
-#[test_case::test_case("{ scope = {} }", "scope must be" ; "scope_table_missing_session")]
+#[test_case::test_case("{ scope = 'plugin' }", "scope must be" ; "scope_wrong_string")]
+#[test_case::test_case("{ scope = {} }", "scope must be" ; "scope_table")]
 #[test_case::test_case(
     "{ scope = { session = '01965087-4c71-7f00-8000-000000000000' } }",
-    "scope.session must be the caller's own session id"
-    ; "scope_session_mismatch"
+    "scope must be"
+    ; "scope_table_session_id"
 )]
 fn session_opts_validation_rejects(opts: &str, expected: &str) {
     let reg = fresh_registry();
@@ -5966,7 +5968,7 @@ fn session_scope_accepts_the_callers_own_session() {
             audiences = {{ "main" }},
             handler = function(input, ctx)
                 local id = ctx:session_id()
-                local sess, err = maki.agent.session(ctx, {{ scope = {{ session = id }} }})
+                local sess, err = maki.agent.session(ctx, {{ scope = "session" }})
                 if err ~= nil then return "err:" .. err end
                 sess:close()
                 return "ok"
@@ -5981,6 +5983,30 @@ fn session_scope_accepts_the_callers_own_session() {
     ctx.session_id = Some(session);
     let out = exec_with_ctx(&reg, "detach_probe", json!({}), &ctx).unwrap();
     assert_eq!(out, "ok");
+}
+
+#[test]
+fn session_scope_rejected_from_inside_a_subagent() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "nested_detach_probe",
+            description = "test",
+            schema = {MINIMAL_SCHEMA},
+            audiences = {{ "main" }},
+            handler = function(input, ctx)
+                local sess, err = maki.agent.session(ctx, {{ scope = "session" }})
+                if sess ~= nil then return "unexpected session" end
+                return err or "no error"
+            end
+        }})"#
+    );
+    host.load_source("nested_detach_plugin", &src).unwrap();
+    let mut ctx = maki_agent::tools::test_support::stub_ctx(&maki_agent::AgentMode::Build);
+    ctx.task_id = Some(Arc::from("child"));
+    let out = exec_with_ctx(&reg, "nested_detach_probe", json!({}), &ctx).unwrap();
+    assert!(out.contains("only valid on the main session"), "got: {out}");
 }
 
 fn load_img_tool(host: &PluginHost) {
@@ -6227,6 +6253,7 @@ fn interpreter_bridge_flattens_image_with_visibility_note() {
 #[test]
 fn async_run_from_parked_command_handler_runs_promptly() {
     let host = PluginHost::new(fresh_registry()).unwrap();
+    host.ui_attachment().attach();
     host.load_source(
         "p",
         r#"
@@ -6258,6 +6285,7 @@ fn async_run_from_parked_command_handler_runs_promptly() {
 #[test]
 fn job_callbacks_fire_while_command_handler_parked() {
     let host = PluginHost::new(fresh_registry()).unwrap();
+    host.ui_attachment().attach();
     host.load_source(
         "p",
         r#"

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -17,7 +17,7 @@ pub(crate) mod tasks;
 pub(crate) mod tests;
 pub(crate) mod view;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -199,6 +199,10 @@ pub struct App {
     pub(super) chats: Vec<Chat>,
     pub(super) active_chat: usize,
     pub(super) chat_index: HashMap<String, usize>,
+    /// Subagent chats that outlive the run that spawned them. Esc on the
+    /// main chat must not finish or drop these; Esc on the chat itself
+    /// still sends `CancelSubagent`.
+    detached_subagents: HashSet<String>,
     pub(crate) input_box: InputBox,
     pub(super) command_palette: CommandPalette,
     pub(super) theme_picker: ThemePicker,
@@ -294,6 +298,7 @@ impl App {
             )],
             active_chat: 0,
             chat_index: HashMap::new(),
+            detached_subagents: HashSet::new(),
             input_box,
             command_palette: CommandPalette::new(
                 custom_commands,
@@ -1049,11 +1054,15 @@ impl App {
         self.close_all_overlays();
         self.pending_input = PendingInput::None;
         self.finish_subagents(TaskOutcome::Error, CANCELLED_TEXT);
-        self.subagent_answers.clear();
+        self.subagent_answers
+            .retain(|id, _| self.detached_subagents.contains(id));
         self.shell.cancel_all();
-        for chat in &mut self.chats {
+        let detached_chats = self.detached_chat_indices();
+        for (i, chat) in self.chats.iter_mut().enumerate() {
             chat.flush();
-            chat.cancel_in_progress();
+            if i == 0 || !detached_chats.contains(&i) {
+                chat.cancel_in_progress();
+            }
         }
         self.main_chat()
             .push(DisplayMessage::new(DisplayRole::Error, CANCEL_MSG.into()));
@@ -1108,7 +1117,7 @@ impl App {
             }
             return vec![];
         }
-        if envelope.run_id != self.run_id {
+        if envelope.run_id != self.run_id && envelope.run_id != maki_agent::DETACHED_RUN_ID {
             // A snapshot dropped here degrades the tool body to llm_output.
             if let AgentEvent::ToolSnapshot { id, .. }
             | AgentEvent::ToolHeaderSnapshot { id, .. }
@@ -1136,6 +1145,7 @@ impl App {
             if let Some(&sub_idx) = self.chat_index.get(tool_use_id.as_str()) {
                 self.chats[sub_idx].mark_finished(TaskOutcome::Unknown, DONE_TEXT);
             }
+            self.detached_subagents.remove(&tool_use_id);
             self.state
                 .session_mut()
                 .set_subagent_messages(tool_use_id, messages);
@@ -1168,7 +1178,9 @@ impl App {
             self.state
                 .session_mut()
                 .insert_tool_output(e.id.clone(), e.output.clone());
-            if let Some(&sub_idx) = self.chat_index.get(&e.id) {
+            if let Some(&sub_idx) = self.chat_index.get(&e.id)
+                && !self.detached_subagents.contains(&e.id)
+            {
                 let (outcome, text) = if e.is_error {
                     (TaskOutcome::Error, ERROR_TEXT)
                 } else {
@@ -1256,8 +1268,9 @@ impl App {
                 ChatEventResult::Done => {
                     self.status_bar.clear_flash();
                     self.terminalize_turn(MISSING_TOOL_COMPLETION);
-                    self.chat_index.clear();
-                    self.subagent_answers.clear();
+                    self.drop_attached_subagents();
+                    self.subagent_answers
+                        .retain(|id, _| self.detached_subagents.contains(id));
                     self.status = Status::Idle;
                     if self.exit_on_done {
                         self.exit_request = ExitRequest::Success;
@@ -1266,11 +1279,12 @@ impl App {
                 ChatEventResult::Error(message) => {
                     self.status = Status::error(message.clone());
                     self.status_bar.clear_flash();
-                    self.subagent_answers.clear();
+                    self.subagent_answers
+                        .retain(|id, _| self.detached_subagents.contains(id));
                     self.terminalize_turn(&message);
                     self.recoverable_queue = self.queue.text_messages();
                     self.queue.clear();
-                    self.chat_index.clear();
+                    self.drop_attached_subagents();
                     if self.exit_on_done {
                         self.exit_request = ExitRequest::Error;
                     }
@@ -1286,6 +1300,9 @@ impl App {
 
     fn resolve_or_create_chat(&mut self, subagent: &SubagentInfo) -> usize {
         let id = &subagent.parent_tool_use_id;
+        if subagent.detached {
+            self.detached_subagents.insert(id.clone());
+        }
         if let Some(&idx) = self.chat_index.get(id.as_str()) {
             return idx;
         }
@@ -1730,7 +1747,20 @@ impl App {
 
     fn finish_subagents(&mut self, outcome: TaskOutcome, text: &str) {
         self.retain_resolved_subagents(outcome, text);
-        self.chat_index.clear();
+        self.drop_attached_subagents();
+    }
+
+    fn detached_chat_indices(&self) -> HashSet<usize> {
+        self.detached_subagents
+            .iter()
+            .filter_map(|id| self.chat_index.get(id).copied())
+            .collect()
+    }
+
+    fn drop_attached_subagents(&mut self) {
+        self.chat_index
+            .retain(|id, _| self.detached_subagents.contains(id));
+        self.sync_subagents();
     }
 
     /// Terminalizes every tool left in progress when a turn ends, sparing
@@ -1738,16 +1768,22 @@ impl App {
     fn terminalize_turn(&mut self, message: &str) {
         self.retain_resolved_subagents(TaskOutcome::Error, ERROR_TEXT);
         self.chats[0].fail_in_progress_except(message.into(), self.shell.active_ids());
-        for chat in self.chats.iter_mut().skip(1) {
+        let detached = self.detached_chat_indices();
+        for (i, chat) in self.chats.iter_mut().enumerate().skip(1) {
+            if detached.contains(&i) {
+                continue;
+            }
             chat.fail_in_progress_with_message(message.into());
         }
     }
 
-    /// Marks unfinished subagent chats as ended and drops them from
-    /// `chat_index`, so the session records only the children that really
-    /// completed.
+    /// Marks unfinished attached subagent chats as ended. Detached chats
+    /// stay in `chat_index` so Esc on them can still cancel.
     fn retain_resolved_subagents(&mut self, outcome: TaskOutcome, text: &str) {
-        self.chat_index.retain(|_, &mut sub_idx| {
+        self.chat_index.retain(|id, &mut sub_idx| {
+            if self.detached_subagents.contains(id) {
+                return true;
+            }
             if self.chats[sub_idx].is_finished() {
                 true
             } else {

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -1758,9 +1758,11 @@ impl App {
     }
 
     fn drop_attached_subagents(&mut self) {
+        // Do not sync: `retain_resolved_subagents` already persisted the
+        // finished attached children. Re-syncing from the pruned index
+        // would wipe them.
         self.chat_index
             .retain(|id, _| self.detached_subagents.contains(id));
-        self.sync_subagents();
     }
 
     /// Terminalizes every tool left in progress when a turn ends, sparing

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -177,6 +177,7 @@ impl App {
         self.chats.push(main);
         self.active_chat = 0;
         self.chat_index.clear();
+        self.detached_subagents.clear();
         self.status = super::Status::Idle;
         self.clear_exit_request();
         self.queue.clear();

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -252,6 +252,7 @@ fn subagent_info_with_tx(
         prompt: None,
         model: None,
         answer_tx,
+        detached: false,
     }
 }
 
@@ -4785,6 +4786,47 @@ fn app_with_active_subagent() -> App {
     app.run_builtin(BuiltinAction::NextChat);
     assert_eq!(app.active_chat, 1);
     app
+}
+
+#[test]
+fn detached_subagent_survives_main_cancel_and_stays_cancellable() {
+    let mut app = streaming_app();
+    let mut info = subagent_info(TASK_ID, RESEARCH_NAME);
+    info.detached = true;
+    app.update(Msg::Agent(Box::new(Envelope {
+        event: AgentEvent::TextDelta { text: "x".into() },
+        subagent: Some(info.clone()),
+        run_id: maki_agent::DETACHED_RUN_ID,
+    })));
+    assert!(!app.chats[1].is_finished());
+
+    finish_subagent_task(&mut app, false);
+    assert!(
+        !app.chats[1].is_finished(),
+        "the spawning tool returning must not finish a detached chat"
+    );
+
+    app.last_esc = Some(Instant::now());
+    let actions = app.update(Msg::Key(key(KeyCode::Esc)));
+    assert!(matches!(&actions[0], Action::CancelAgent { .. }));
+    assert!(!app.chats[1].is_finished());
+    assert!(app.chat_index.contains_key(TASK_ID));
+
+    app.update(Msg::Agent(Box::new(Envelope {
+        event: AgentEvent::TextDelta { text: "y".into() },
+        subagent: Some(info),
+        run_id: maki_agent::DETACHED_RUN_ID,
+    })));
+    assert_eq!(app.chats.len(), 2);
+
+    app.active_chat = 1;
+    app.last_esc = Some(Instant::now());
+    let actions = app.update(Msg::Key(key(KeyCode::Esc)));
+    assert!(matches!(
+        &actions[0],
+        Action::CancelSubagent { tool_use_id } if tool_use_id == TASK_ID
+    ));
+    assert!(app.chats[1].is_finished());
 }
 
 #[test]

--- a/site/docs/content/_index.md
+++ b/site/docs/content/_index.md
@@ -28,6 +28,7 @@ The docs are sorted by what you came here to do:
   <div class="card-grid">
     <a class="card" href="/docs/skills/"><span class="card-title">Skills</span><span class="card-desc">Write Markdown playbooks the agent loads on demand.</span></a>
     <a class="card" href="/docs/plugins/"><span class="card-title">Plugins</span><span class="card-desc">Add your own tools and commands in Lua, or let the agent write them.</span></a>
+    <a class="card" href="/docs/long-running-tools/"><span class="card-title">Long-Running Tools</span><span class="card-desc">Write tools that supervise builds, servers, and subagents without parking the session.</span></a>
     <a class="card" href="/docs/headless/"><span class="card-title">Headless Mode</span><span class="card-desc">--print for scripts and CI. Drop-in Claude Code compatible.</span></a>
     <a class="card" href="/docs/acp/"><span class="card-title">ACP</span><span class="card-desc">Drive Maki from your editor, like Zed, over the Agent Client Protocol.</span></a>
   </div>

--- a/site/docs/content/long-running-tools/_index.md
+++ b/site/docs/content/long-running-tools/_index.md
@@ -1,0 +1,139 @@
++++
+title = "Long-Running Tools"
+weight = 24
+[extra]
+group = "Guides"
++++
+
+# Long-Running Tools
+
+Some work takes longer than a tool call should: a test suite, a build, a
+server, a subagent. A tool call must return before the agent can do anything
+else, and the provider APIs require one result for every call the model makes.
+A call that parks for minutes parks the whole session, and you cannot reach the
+agent while it parks.
+
+The pattern that works: return a small receipt at once, and deliver the outcome
+later as an observation in the session mailbox.
+
+```
+model              host                        session
+ |  call the tool    |
+ |<-- receipt: id, log paths
+ |                   | turn ends, session idle
+ |               job exits
+ |                   |-- observation + wake -->|
+ |                   | next turn reads the observation
+```
+
+## Receipt and delivery
+
+Start the job, hand back the id and the log paths, and let the `on_exit`
+callback carry the outcome:
+
+```lua
+maki.api.register_tool({
+  name = "watch",
+  kind = "execute",
+  permission = "run",
+  schema = {
+    type = "object",
+    properties = {
+      command = { type = "string", description = "The command to watch", required = true },
+    },
+  },
+  handler = function(input, ctx)
+    local session = ctx:session_id()
+    local dir = maki.fs.joinpath(maki.env.logs_dir(), session, "watch")
+    maki.fs.mkdir(dir, { parents = true })
+    local ok, id = pcall(maki.fn.jobstart, input.command, {
+      scope = { session = session },
+      stdout = maki.fs.joinpath(dir, "stdout.log"),
+      stderr = maki.fs.joinpath(dir, "stderr.log"),
+      on_exit = function(job_id, code)
+        maki.session.notify(
+          string.format("[watch %d] %s exited with code %d", job_id, input.command, code),
+          { session = session, wake = true }
+        )
+      end,
+    })
+    if not ok then
+      return { llm_output = tostring(id), is_error = true }
+    end
+    return "watch "
+      .. id
+      .. " started. You will be notified when it exits. Keep working meanwhile."
+  end,
+})
+```
+
+`wake = true` starts a new turn when the session is idle, so the agent sees the
+observation without the user doing anything. `ctx:session_id()` is captured in
+the handler because the callback runs after the handler returned.
+
+`jobstart` without `scope` defaults to `"task"`, which ends the job the moment
+the handler returns — exactly when you need it to keep running. `scope = {
+session = session }` ties the job to the session instead, so it survives past
+this call.
+
+## Why the receipt cannot arrive late
+
+A provider request must carry a result for every tool call the model made, and
+later turns build on that request. A result that arrives after newer turns
+exist has no place to go in the API. The mailbox observation is how maki
+represents an outcome that lands after its call ended: it joins the history and
+the next turn reads it.
+
+## Staying correct across reloads
+
+A `/reload` drops the Lua callbacks of running jobs, the jobs keep running.
+When the plugin loads again, find its jobs and re-arm each one:
+
+```lua
+for _, job in ipairs(maki.fn.joblist(nil) or {}) do
+  if job.status == "running" then
+    maki.fn.jobattach(job.id, { on_exit = my_on_exit(job) })
+  end
+end
+```
+
+`joblist(nil)` lists the jobs of your plugin across sessions, and each entry
+carries its own `session`. Calling it at load time is fine. `maki.session.current()`
+answers over the UI event loop instead, so a call made before the loop starts
+draining (cold startup, not a `/reload`) returns `(nil, err)` rather than the
+focused session.
+
+This only finds jobs started with a session `scope`: `can_access` matches a
+`"task"`-scoped job only while the same task call is still on the stack, so
+`joblist` at load time never returns them, and `jobattach` has nothing to
+re-arm.
+
+Keep the outcome on disk when it matters (a meta file next to the logs). A job
+that exits while the plugin was unloaded has no callback to deliver it, so the
+next load compares disk state against `joblist` and reports what was missed.
+
+## Waiting
+
+Ending the turn and taking the wake is usually enough. When you truly need to
+block, `jobwait` parks the caller until the job exits or the timeout passes:
+
+- A timeout returns nil and leaves the job usable. You can wait again, and the
+  `on_exit` callback still fires.
+- While parked it delivers `on_stdout`, `on_stderr`, and `on_exit` as events
+  arrive, like Neovim.
+- An already-exited job answers from its snapshot without waiting.
+- It parks the caller, so a slot chain cannot call it.
+
+For bounded polling, `maki.async.sleep(ms)` suspends the coroutine on the async
+executor without spinning, and other tasks keep running:
+
+```lua
+maki.async.run(function()
+  for _ = 1, 40 do
+    maki.async.sleep(250)
+    if done_yet() then
+      return
+    end
+  end
+end)
+```

--- a/site/docs/content/long-running-tools/_index.md
+++ b/site/docs/content/long-running-tools/_index.md
@@ -99,9 +99,8 @@ end
 
 `joblist(nil)` lists the jobs of your plugin across sessions, and each entry
 carries its own `session`. Calling it at load time is fine. `maki.session.current()`
-answers over the UI event loop instead, so a call made before the loop starts
-draining (cold startup, not a `/reload`) returns `(nil, err)` rather than the
-focused session.
+answers over the UI event loop instead, so a call made at plugin load
+returns `(nil, err)` rather than the focused session.
 
 This only finds jobs started with a session `scope`: `can_access` matches a
 `"task"`-scoped job only while the same task call is still on the stack, so

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -1270,13 +1270,12 @@ and tool set.
     `"max"`), or a budget integer (token count). Inherits parent setting
     if omitted.
   - `fast` (`boolean?`) use fast mode. Inherits parent setting if omitted.
-  - `scope` (`table?`) `{ session = "<id>" }` detaches the session from the
-    call that spawned it: it survives the call returning and the turn
-    ending, instead of being cancelled the moment either does. `<id>`
-    must be the caller's own session (`ctx:session_id()`). Only cancel-all
-    and a targeted cancel of this session's tool call id can stop it from
-    here on; keep the returned handle (or its id) if you need to reach it
-    later. Omit for the default: tied to the call that spawned it.
+  - `scope` (`string?`) `"session"` detaches the session from the call that
+    spawned it: it survives the call returning and the turn ending,
+    instead of being cancelled the moment either does. Esc on its chat
+    still cancels it. Keep the returned handle to `prompt` and `close`.
+    Omit for the default: tied to the call that spawned it. Invalid
+    inside a subagent.
 
 **Returns:** ([`Session?`](#maki-agent-Session), `string?`) Session handle, or `(nil, err)` on failure.
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -1270,6 +1270,13 @@ and tool set.
     `"max"`), or a budget integer (token count). Inherits parent setting
     if omitted.
   - `fast` (`boolean?`) use fast mode. Inherits parent setting if omitted.
+  - `scope` (`table?`) `{ session = "<id>" }` detaches the session from the
+    call that spawned it: it survives the call returning and the turn
+    ending, instead of being cancelled the moment either does. `<id>`
+    must be the caller's own session (`ctx:session_id()`). Only cancel-all
+    and a targeted cancel of this session's tool call id can stop it from
+    here on; keep the returned handle (or its id) if you need to reach it
+    later. Omit for the default: tied to the call that spawned it.
 
 **Returns:** ([`Session?`](#maki-agent-Session), `string?`) Session handle, or `(nil, err)` on failure.
 
@@ -1381,6 +1388,9 @@ Fire off a function as a new async task. It runs in the background and
 you do not wait for it. If you need the result, pass an {on_finish}
 callback.
 
+The task must finish within 60 seconds; waiting minutes for a build or a
+subagent inside one dies partway through.
+
 **Parameters:**
 
 - `{fn}` (`function`) Zero-argument function to execute.
@@ -1403,23 +1413,23 @@ end)
 maki.async.sleep({ms})
 ```
 
-Suspend the calling task for {ms} milliseconds. The plugin thread is
-never blocked, so other tasks and the UI keep running, and a cancel
-still lands while you sleep.
+Suspend the current coroutine for {ms} milliseconds. The timer runs on
+the async executor, so nothing spins and other tasks keep running.
+Cancelling the owning task interrupts the sleep with the cancel error.
 
 For a timer that has to outlive the tool call that started it, such
 as a toast dismissing itself, use `maki.defer_fn`.
 
 **Parameters:**
 
-- `{ms}` (`integer`) Milliseconds to sleep.
+- `{ms}` (`integer`) Milliseconds to wait. Must be >= 0.
 
 **Example:**
 
 ```lua
 maki.async.run(function()
-  maki.async.sleep(4000)
-  win:close()
+  maki.async.sleep(250)
+  retry()
 end)
 ```
 

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -145,6 +145,11 @@ fn build_stack(
 ) -> Result<(Stack, Vec<String>)> {
     let mut plugin_host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !cli.no_jit)
         .context("initialize lua plugin host")?;
+    // Nobody drains `UiAction` until `EventLoop::new` below calls `attach()`,
+    // so a plugin that roundtrips to the UI while loading (or at any point
+    // before then) fails fast instead of parking on a reply that can never
+    // arrive.
+    plugin_host.ui_attachment().detach();
 
     let (fallback_config, fallback_model) = fallback.unzip();
     let (config, mut warnings) = super::load_plugins(

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -145,11 +145,6 @@ fn build_stack(
 ) -> Result<(Stack, Vec<String>)> {
     let mut plugin_host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !cli.no_jit)
         .context("initialize lua plugin host")?;
-    // Nobody drains `UiAction` until `EventLoop::new` below calls `attach()`,
-    // so a plugin that roundtrips to the UI while loading (or at any point
-    // before then) fails fast instead of parking on a reply that can never
-    // arrive.
-    plugin_host.ui_attachment().detach();
 
     let (fallback_config, fallback_model) = fallback.unzip();
     let (config, mut warnings) = super::load_plugins(


### PR DESCRIPTION
Draft, built while making the standalone [maki-monitor](https://github.com/lu-zero/maki-monitor) plugin work on top of the current job APIs.

## 1. maki.async.sleep(ms)

Plugins had no way to park a coroutine: `jobwait` consumes the job's wait slot, and busy-waiting on `os.clock` pins the executor. `sleep(ms)` wraps `smol::Timer` in the standard async-fn pattern, so other tasks keep running while the coroutine is parked. It races the owning task's cancel token the same way `Semaphore:acquire` does, so a cancelled task interrupts the sleep with the cancel error instead of waiting it out. Negative `ms` fails with an explicit error.

## 2. docs: long-running tools guide

A hand-written guide for the pattern plugin authors need for tools that supervise work that outlives the tool call (builds, servers, subagents):

- return a receipt (id, log paths) at once, deliver the outcome later as a mailbox observation with `wake`
- why a deferred tool result cannot exist on the wire: every `tool_use` needs its `tool_result` before the next request
- reload survival: `joblist(nil)` at load (never `maki.session.current()`, the UI loop only drains between frames), re-arm with `jobattach`, keep outcome state on disk
- the current waiting semantics: `jobwait` parking safely, `async.sleep` for bounded polls

## 3. fix: a completed run no longer cancels its children

Found while live-testing a background subagent: clearing the run's cancel trigger fired the token on every turn end, because `CancelTrigger` fires on Drop. A subagent session still alive across the boundary inherits the token as a child and died with `cancelled` the moment the spawning turn finished.

The trigger now carries an armed flag: Drop keeps firing it so real cancellations stay safe, and `CancelTrigger::defuse` plus `CancelMap::defuse` retire it silently. The agent loop defuses on completion and error, and only fires on `DoneReason::Cancelled`. Esc during the spawning turn still cancels everything; Esc in later turns leaves a detached run to its own session-level cancel.

## Question for discussion (no code in this PR)

Correlated notifications. `session.notify` carries only `(session, wake)`, and `Message::observation` carries no tag. Observations are also invisible in the transcript today (skipped in `history_to_display`) and in ACP replay. For monitor/task-style tools, would you want observations to be renderable and attachable to the spawning tool call, so an exit lands visually next to the call that started it? Happy to draft once there is a direction.

Follow-up stack (async.run options, background task, and the UI item handoff) moved to a separate draft PR since it is larger and up for design discussion.
