### PR TITLE
feat(picker): allow deleting completed tasks

### DIFF
--- a/maki-docgen/src/gen_keybindings.rs
+++ b/maki-docgen/src/gen_keybindings.rs
@@ -12,6 +12,11 @@ const LUA_CONTEXT_BINDS: &[(&str, &str, &str)] = &[
     ("Session Picker", "`Ctrl+N`", "New session"),
     ("Session Picker", "`Ctrl+R`", "Rename session"),
     ("Session Picker", "`Ctrl+D`", "Delete session (press twice)"),
+    (
+        "Task Picker",
+        "`Ctrl+D`",
+        "Delete finished task (press twice)",
+    ),
 ];
 
 // Built-in plugins own these globally, so they never reach `KEYBINDS`.

--- a/maki-lua/src/api/task.rs
+++ b/maki-lua/src/api/task.rs
@@ -51,13 +51,33 @@ async fn focus(
     roundtrip(lua, tx, TaskRequest::Focus { id }).await
 }
 
+/// Deletes a finished task and its transcript, so a reload cannot bring it
+/// back. The main chat and still-running tasks are refused.
+///
+/// If the deleted task was the focused one, focus falls back to the previous
+/// chat (or the main chat if the deleted task was first). Callers that need
+/// a specific focus should call `maki.task.focus()` afterwards.
+///
+/// @param id string Task id, as returned by `list()`.
+/// @return (boolean|nil, string|nil) true on success, or nil and an error.
+/// @example
+/// local _, err = maki.task.remove("toolu_01")
+#[lua_fn]
+async fn remove(
+    lua: Lua,
+    #[ctx] tx: Option<flume::Sender<UiAction>>,
+    id: String,
+) -> LuaResult<Pair<Value>> {
+    roundtrip(lua, tx, TaskRequest::Remove { id }).await
+}
+
 lua_table! {
     /// The subagents of the focused session and their transcripts. Tasks are
     /// spawned by the `task` tool and addressed by an id that survives a reload.
     /// Without an interactive UI every function returns
     /// `nil, "no interactive UI attached"`.
     "maki.task" => pub(crate) fn create_task_table(tx: Option<flume::Sender<UiAction>>),
-    DOCS [list(tx), focus(tx)]
+    DOCS [list(tx), focus(tx), remove(tx)]
 }
 
 #[cfg(test)]
@@ -83,6 +103,7 @@ mod tests {
     const NO_REQUEST_ERR: &str = "expected a task request";
     const LIST_CALL: &str = "return task.list()";
     const FOCUS_CALL: &str = "return task.focus('toolu_01')";
+    const REMOVE_CALL: &str = "return task.remove('toolu_01')";
     const LIST_SCRIPT: &str = "
         local tasks = task.list()
         local ids, statuses = {}, {}
@@ -115,6 +136,7 @@ mod tests {
 
     #[test_case(LIST_CALL ; "list")]
     #[test_case(FOCUS_CALL ; "focus")]
+    #[test_case(REMOVE_CALL ; "remove")]
     fn without_ui_returns_error_pair(code: &str) {
         let lua = lua_with_task(None);
         let (val, err): (Value, Option<String>) =
@@ -127,6 +149,7 @@ mod tests {
     /// as the `(nil, err)` pair, word for word, without raising into the plugin.
     #[test_case(LIST_CALL ; "list")]
     #[test_case(FOCUS_CALL ; "focus")]
+    #[test_case(REMOVE_CALL ; "remove")]
     fn host_error_reply_surfaces_as_error_pair(code: &str) {
         let (tx, rx) = flume::unbounded::<UiAction>();
         let lua = lua_with_task(Some(tx));
@@ -191,5 +214,29 @@ mod tests {
         .unwrap();
         assert_eq!(err, None);
         assert_eq!(val.get::<String>("focused").unwrap(), TASK_ID);
+    }
+
+    #[test]
+    fn remove_roundtrips_through_ui_channel() {
+        let (tx, rx) = flume::unbounded::<UiAction>();
+        let lua = lua_with_task(Some(tx));
+        std::thread::spawn(move || {
+            let Ok(UiAction::Task {
+                req: TaskRequest::Remove { id },
+                reply_tx,
+            }) = rx.recv()
+            else {
+                panic!("expected remove request");
+            };
+            reply_tx.send(Ok(json!(true))).unwrap();
+            assert_eq!(id, TASK_ID);
+        });
+        let (val, err): (bool, Option<String>) = smol::block_on(
+            lua.load(format!("return task.remove('{TASK_ID}')"))
+                .eval_async(),
+        )
+        .unwrap();
+        assert!(val);
+        assert_eq!(err, None);
     }
 }

--- a/maki-lua/src/api/util/command.rs
+++ b/maki-lua/src/api/util/command.rs
@@ -443,6 +443,7 @@ pub enum SessionRequest {
 pub enum TaskRequest {
     List,
     Focus { id: String },
+    Remove { id: String },
 }
 
 pub enum ModelRequest {

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -1554,6 +1554,23 @@ where
         self.touch();
     }
 
+    /// Deleting a task drops its transcript from the log, which an append
+    /// cannot express, so the cursors are voided like any rewrite. The
+    /// `tool_ids` closure extracts tool-use ids from messages so the
+    /// subagent's tool outputs are reclaimed from the shared map.
+    pub fn remove_subagent(&mut self, id: &str, tool_ids: impl Fn(&M) -> Vec<String>) {
+        let removed = self.subagent_messages.remove(id);
+        if let Some(msgs) = &removed {
+            let stale: HashSet<String> = msgs.iter().flat_map(&tool_ids).collect();
+            self.tool_outputs.retain(|tid, _| !stale.contains(tid));
+        }
+        let len = self.subagents.len();
+        self.subagents.retain(|sa| sa.tool_use_id != id);
+        if removed.is_some() || self.subagents.len() != len {
+            self.rewrite();
+        }
+    }
+
     pub fn usage_by_model(&self) -> &HashMap<String, StoredTokenUsage> {
         &self.usage_by_model
     }

--- a/maki-ui/src/app/tasks.rs
+++ b/maki-ui/src/app/tasks.rs
@@ -14,6 +14,8 @@ use crate::components::DisplayRole;
 
 pub(crate) const MAIN_TASK_ID: &str = "main";
 const UNKNOWN_TASK_ERR: &str = "unknown task: ";
+const MAIN_DELETE_ERR: &str = "cannot delete the main chat";
+const RUNNING_DELETE_ERR: &str = "task is still running: ";
 
 /// How a chat ended, from the vaguest to the most specific. `SubagentHistory`
 /// only sees the transcript close, and the `ToolDone` carrying `is_error`
@@ -122,6 +124,40 @@ impl App {
         };
         Ok(())
     }
+
+    /// Drops a finished subagent chat and its stored transcript, so a reload
+    /// cannot bring the deleted task back. Main and still-running tasks are
+    /// refused. If the deleted task was focused, focus moves to the previous
+    /// chat (or main if it was first).
+    pub(crate) fn remove_task(&mut self, id: &str) -> Result<(), String> {
+        if id == MAIN_TASK_ID {
+            return Err(MAIN_DELETE_ERR.to_owned());
+        }
+        let pos = self
+            .chats
+            .iter()
+            .position(|chat| chat.task_id().is_some_and(|task_id| &**task_id == id))
+            .ok_or_else(|| format!("{UNKNOWN_TASK_ERR}{id}"))?;
+        let chat = &self.chats[pos];
+        if !chat.is_finished() {
+            return Err(format!("{RUNNING_DELETE_ERR}{id}"));
+        }
+
+        self.chats.remove(pos);
+        self.chat_index.retain(|_, &mut idx| idx != pos);
+        for idx in self.chat_index.values_mut() {
+            if *idx > pos {
+                *idx -= 1;
+            }
+        }
+        if self.active_chat >= pos {
+            self.active_chat = self.active_chat.saturating_sub(1);
+        }
+        self.state.session_mut().remove_subagent(id, |m| {
+            m.tool_uses().map(|(id, _, _)| id.to_owned()).collect()
+        });
+        Ok(())
+    }
 }
 
 /// Fires when a known task changes status, or when a new one shows up working.
@@ -167,6 +203,13 @@ mod tests {
     fn app_with_two_subagents() -> App {
         let mut app = app_with_subagent_id(TASK_ID);
         start_subagent(&mut app, OTHER_ID, BUILD_NAME);
+        app
+    }
+
+    fn app_with_two_finished_subagents() -> App {
+        let mut app = app_with_two_subagents();
+        close_subagent_transcript(&mut app, TASK_ID);
+        close_subagent_transcript(&mut app, OTHER_ID);
         app
     }
 
@@ -368,6 +411,73 @@ mod tests {
             collect(&mut previous, &working),
             vec![(TASK_ID.to_owned(), TaskStatus::Working)]
         );
+    }
+
+    #[test]
+    fn removing_a_finished_task_drops_it_everywhere() {
+        let mut app = app_with_two_subagents();
+        close_subagent_transcript(&mut app, TASK_ID);
+        assert!(app.state.session.subagent_messages().contains_key(TASK_ID));
+
+        app.remove_task(TASK_ID).unwrap();
+
+        assert_eq!(app.chats.len(), 2);
+        assert_eq!(
+            app.task_states()
+                .map(|task| task.id.to_string())
+                .collect::<Vec<_>>(),
+            vec![OTHER_ID.to_owned()]
+        );
+        assert_eq!(
+            app.state.session.subagents()[0].tool_use_id,
+            OTHER_ID,
+            "and stays deleted"
+        );
+        assert!(!app.state.session.subagent_messages().contains_key(TASK_ID));
+    }
+
+    #[test_case(MAIN_TASK_ID, MAIN_DELETE_ERR ; "main_is_refused")]
+    #[test_case(MISSING_ID, UNKNOWN_TASK_ERR ; "a_gone_task_reports_its_id")]
+    fn remove_refuses_without_touching_chats(id: &str, prefix: &str) {
+        let mut app = app_with_two_finished_subagents();
+        assert!(app.remove_task(id).unwrap_err().starts_with(prefix));
+        assert_eq!(app.chats.len(), 3);
+    }
+
+    #[test]
+    fn remove_refuses_a_running_task() {
+        let mut app = app_with_two_subagents();
+        let expected = format!("{RUNNING_DELETE_ERR}{TASK_ID}");
+        assert_eq!(app.remove_task(TASK_ID), Err(expected));
+        assert_eq!(app.chats.len(), 3);
+    }
+
+    /// The focus follows its task by name where possible: `chat_index` is a
+    /// turn-scoped cache, so the ids it routes to must shift with the chats.
+    #[test]
+    fn removing_a_task_before_the_focus_keeps_the_same_task_on_screen() {
+        let mut app = app_with_two_finished_subagents();
+        app.focus_task(OTHER_ID).unwrap();
+        assert_eq!(app.active_chat, 2);
+
+        app.remove_task(TASK_ID).unwrap();
+
+        assert_eq!(app.active_chat, 1);
+        assert_eq!(app.chats[app.active_chat].name, BUILD_NAME);
+        assert_eq!(app.chat_index.get(OTHER_ID), Some(&1));
+    }
+
+    /// The focused task itself may be the one deleted; the view lands on the
+    /// previous chat rather than pointing past the end of the list.
+    #[test]
+    fn removing_the_focused_task_moves_the_view_to_the_previous_chat() {
+        let mut app = app_with_two_finished_subagents();
+        app.focus_task(OTHER_ID).unwrap();
+
+        app.remove_task(OTHER_ID).unwrap();
+
+        assert_eq!(app.active_chat, 1);
+        assert_eq!(app.chats[app.active_chat].name, RESEARCH_NAME);
     }
 
     /// A task first seen already finished stays quiet, so a reload does not

--- a/maki-ui/src/components/file_picker.rs
+++ b/maki-ui/src/components/file_picker.rs
@@ -809,6 +809,14 @@ mod tests {
         let _ = tick_until(&mut picker, |s| !s.matching && s.matches.len() == 1)
             .expect(NEVER_CONVERGED);
 
+        // An idle tick can still owe a poll while the worker drains the last
+        // answer, so "settled" has to pin down both sides of the cadence.
+        let deadline = Instant::now() + CONVERGE_TIMEOUT;
+        while picker.cadence() != Cadence::IDLE {
+            assert!(Instant::now() < deadline, "the picker never stopped");
+            std::thread::yield_now();
+        }
+
         assert_eq!(picker.tick(), (Dirty::NO, None), "{QUIET}");
         assert_eq!(picker.cadence(), Cadence::IDLE);
     }

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -1246,6 +1246,7 @@ impl<'t> EventLoop<'t> {
         match req {
             TaskRequest::List => Ok(json!(self.focused_app().tasks())),
             TaskRequest::Focus { id } => self.focused_app().focus_task(&id).map(|()| json!(true)),
+            TaskRequest::Remove { id } => self.focused_app().remove_task(&id).map(|()| json!(true)),
         }
     }
 

--- a/plugins/task/picker.lua
+++ b/plugins/task/picker.lua
@@ -21,7 +21,10 @@ local RUNNING_COUNT_ICON = "● "
 local DONE_ICON = "✓ "
 local ERROR_ICON = "✗ "
 local NO_MATCHES_HINT = "  No matches"
-local FOOTER_KEYS = { { "Enter", "open" }, { "Esc", "cancel" } }
+local CONFIRM_HINT = "  Ctrl+D again to delete"
+local MAIN_DELETE_HINT = "Cannot delete the main chat"
+local RUNNING_DELETE_HINT = "Task is still running"
+local FOOTER_KEYS = { { "Enter", "open" }, { "Ctrl+D", "delete" }, { "Esc", "cancel" } }
 local HINT_KEY = "Ctrl+X"
 -- The main chat has no status, so it falls through to MAIN.
 local ICONS = {
@@ -119,9 +122,16 @@ local function render()
     for _, span in ipairs(ListPicker.highlight_spans(task.name, words, base, match_style)) do
       line[#line + 1] = span
     end
+    local confirm = board.confirm == task.id
+    if confirm then
+      line[#line + 1] = { CONFIRM_HINT, selected and "match_selected" or "error" }
+    end
     -- Rows with nothing on the right would otherwise end short of the border
     -- and read as padding on one side only, so the bar runs the full width.
     local trail = board.width - 2 - dispw(icon) - dispw(task.name)
+    if confirm then
+      trail = trail - dispw(CONFIRM_HINT)
+    end
     if trail > 0 then
       line[#line + 1] = { string.rep(" ", trail), base }
     end
@@ -176,6 +186,7 @@ local function move_sel(delta, wrap)
   if n == 0 then
     return
   end
+  board.confirm = nil
   local cur = Rows.index_of(board.rows, board.sel_id) or 1
   local idx
   if wrap then
@@ -207,11 +218,56 @@ local function open_selected()
   finish(true)
 end
 
+-- After a delete the focused task is gone, so we re-focus the row that slides
+-- into its slot (the one right after it, or the one before if it was last).
+-- Keeping `board.sel_id` across `refresh()` lets `rebuild()` re-seat the
+-- cursor there instead of jumping back to the top; `origin_id` remains the
+-- fallback for when the list ends up empty.
+local function delete_selected()
+  local idx = Rows.index_of(board.rows, board.sel_id)
+  if not idx then
+    return
+  end
+  local task = board.rows[idx].task
+  if not Rows.deletable(task) then
+    board.confirm = nil
+    maki.ui.flash(task.status and RUNNING_DELETE_HINT or MAIN_DELETE_HINT)
+    return
+  end
+  if board.confirm ~= task.id then
+    board.confirm = task.id
+    render()
+    return
+  end
+  board.confirm = nil
+  local _, err = maki.task.remove(task.id)
+  if err then
+    maki.ui.flash(err)
+    return
+  end
+  if board.origin_id == task.id then
+    board.origin_id = "main"
+  end
+  -- Keep sel_id so rebuild() re-seats the cursor on the row that takes over
+  -- the deleted row's slot, then focus whatever ends up there.
+  local this_board = board
+  refresh()
+  if board == this_board and board.sel_id then
+    local _, focus_err = maki.task.focus(board.sel_id)
+    if focus_err then
+      maki.ui.flash(focus_err)
+    end
+  end
+end
+
 local function handle_key(key)
   if key == "ctrl+c" or key == "ctrl+x" then
     finish(false)
   elseif key == "esc" then
-    if board.input:is_empty() then
+    if board.confirm then
+      board.confirm = nil
+      render()
+    elseif board.input:is_empty() then
       finish(false)
     else
       board.input:clear()
@@ -228,7 +284,10 @@ local function handle_key(key)
     move_sel(page_size())
   elseif key == "enter" then
     open_selected()
+  elseif key == "ctrl+d" then
+    delete_selected()
   elseif board.input:handle_key(key) ~= "ignored" then
+    board.confirm = nil
     rebuild()
     render()
   end

--- a/plugins/task/picker_rows.lua
+++ b/plugins/task/picker_rows.lua
@@ -43,6 +43,13 @@ function M.build(tasks, query)
   return { rows = rows, sections = { running = #running, finished = #finished } }
 end
 
+-- Only a finished subagent may leave the list: the main chat is the session
+-- itself, and dropping a running task would orphan its transcript. The host
+-- refuses these too; this check only decides who gets to ask.
+function M.deletable(task)
+  return task.status ~= nil and task.status ~= "working"
+end
+
 -- Position of {id} among {rows}, or nil. The selection is kept as an id and
 -- resolved here at render time, so a task moving between sections never drags
 -- the cursor with it.

--- a/plugins/task/tests/spec.lua
+++ b/plugins/task/tests/spec.lua
@@ -124,4 +124,13 @@ case("a_filter_that_empties_a_section_zeroes_its_count_and_header", function()
   eq(nothing.sections.finished, 0)
 end)
 
+-- The picker refuses on its own before ever round-tripping to the host, and
+-- the rule lives in Rows so it can be exercised without a UI.
+case("only_finished_subagents_are_deletable", function()
+  eq(Rows.deletable(MAIN), false, "the main chat has no status and stays")
+  eq(Rows.deletable(RESEARCH), false, "a running task stays")
+  eq(Rows.deletable(BUILD), true, "a done task goes")
+  eq(Rows.deletable(BENCH), true, "an errored task still counts as finished")
+end)
+
 th.report()

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -86,6 +86,7 @@ Some pickers add extra bindings on top of the defaults:
 | Session Picker | `Ctrl+N` | New session |
 | Session Picker | `Ctrl+R` | Rename session |
 | Session Picker | `Ctrl+D` | Delete session (press twice) |
+| Task Picker | `Ctrl+D` | Delete finished task (press twice) |
 
 ## Plugins
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -3680,6 +3680,33 @@ another session returns an error instead of landing on the wrong task.
 local _, err = maki.task.focus("main")
 ```
 
+---
+
+### `maki.task.remove()` {#maki-task-remove}
+
+```lua
+maki.task.remove({id})
+```
+
+Deletes a finished task and its transcript, so a reload cannot bring it
+back. The main chat and still-running tasks are refused.
+
+If the deleted task was the focused one, focus falls back to the previous
+chat (or the main chat if the deleted task was first). Callers that need
+a specific focus should call `maki.task.focus()` afterwards.
+
+**Parameters:**
+
+- `{id}` (`string`) Task id, as returned by `list()`.
+
+**Returns:** (`boolean|nil`, `string|nil`) true on success, or nil and an error.
+
+**Example:**
+
+```lua
+local _, err = maki.task.remove("toolu_01")
+```
+
 
 ## maki.text {#maki-text}
 


### PR DESCRIPTION
Sometimes on longer sessions, I'd end up with so many finished tasks in the picker that it made navigating between tasks really annoying, not helped at all by the fact that the picker puts the most recent task at the end of the list instead of right after the main session. So, this change enables deletion of _completed_ tasks, but never active ones, from the task-picker pane (default keybinding Ctrl+X from main screen). Tap Ctrl+D on a finished task once to delete, and then a second time to confirm, and it disappears.