### PR TITLE
feat(lua): let plugins rewrite a tool call before it runs

### DIFF
--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -5,15 +5,19 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use serde_json::Value;
+use serde_json::{Value, json};
 use tracing::{debug, error, warn};
 
 use crate::mcp::{McpSession, TOOL_SEARCH_TOOL_NAME, UNKNOWN_MCP};
 use crate::task_set::TaskSet;
-use crate::tools::registry::{RegisteredTool, ToolInvocation};
-use crate::tools::{CallOrigin, LocalTool, LocalToolFn, ToolAudience, ToolContext, truncate_bytes};
+use crate::tools::hook::{Authority, HookCall, HookStage, OUTPUT_IS_ERROR, OUTPUT_TEXT, Verdict};
+use crate::tools::registry::{InstalledHook, RegisteredTool, ToolInvocation};
+use crate::tools::{
+    CallOrigin, Deadline, LocalTool, LocalToolFn, ToolAudience, ToolContext, truncate_bytes,
+};
 use crate::{AgentError, AgentEvent, ToolDoneEvent, ToolOutput, ToolStartEvent};
 use maki_config::ToolKey;
+use maki_storage::id::SessionRef;
 
 const DOOM_LOOP_THRESHOLD: usize = 3;
 const DOOM_LOOP_MESSAGE: &str = "You have called this tool with identical input 3 times in a row. You are stuck in a loop. Break out and try a different approach.";
@@ -39,6 +43,12 @@ const ERROR_OTHER: &str = "error";
 /// A telemetry counter is not worth an unbounded diff; past this,
 /// `similar` returns a coarser but still valid one.
 const DIFF_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// The window a chain gets when the call carries no deadline of its own.
+/// Generous, because a layer may shell out before it decides, but a layer that
+/// parks and never comes back has to end somewhere short of "when the user
+/// gives up".
+const HOOK_CHAIN_MAX: Duration = Duration::from_secs(60);
 
 pub(super) struct RecentCalls(VecDeque<(String, u64)>);
 
@@ -73,7 +83,10 @@ impl RecentCalls {
 }
 
 /// Every tool call in maki lands here (native, Lua, MCP, subagents, batch
-/// children), which makes it the one place telemetry has to wrap.
+/// children), which makes it the one place telemetry has to wrap and the one
+/// place [hooks] fire.
+///
+/// [hooks]: crate::tools::hook
 pub async fn run(
     id: String,
     name: &str,
@@ -82,15 +95,156 @@ pub async fn run(
     origin: CallOrigin,
 ) -> ToolDoneEvent {
     let resolved = resolve(ctx, name);
-    if !maki_otel::enabled() {
-        return run_inner(resolved, id, input, ctx, origin).await;
-    }
     let name = resolved.name;
-    let source = resolved.route.source();
-    let started = Instant::now();
-    let done = run_inner(resolved, id, input, ctx, origin).await;
-    report(&done, name, &source, input, started.elapsed());
+    let hook = Hook::of(ctx, &resolved, origin);
+
+    let verdict = match &hook {
+        Some(hook) => hook.filter_input(&id, input).await,
+        None => Verdict::Unchanged,
+    };
+    let input = match verdict {
+        Verdict::Unchanged => Cow::Borrowed(input),
+        Verdict::Replaced(value) => {
+            debug!(tool = %name, "input hook rewrote the call");
+            Cow::Owned(value)
+        }
+        Verdict::Denied(reason) => {
+            warn!(tool = %name, reason = %reason, "input hook stopped the call");
+            return ToolDoneEvent {
+                id,
+                tool: Arc::from(name),
+                output: ToolOutput::Plain(reason.into()),
+                is_error: true,
+                annotation: None,
+                written_path: None,
+            };
+        }
+    };
+
+    let telemetry = maki_otel::enabled().then(|| (resolved.route.source(), Instant::now()));
+    let mut done = run_inner(resolved, id, &input, ctx, origin).await;
+    if let Some(hook) = &hook {
+        hook.filter_output(&mut done).await;
+    }
+    if let Some((source, started)) = telemetry {
+        report(&done, name, &source, &input, started.elapsed());
+    }
     done
+}
+
+/// The hook installed on this registry, bound to one call. `None` when nobody
+/// installed one, or when the name routes nowhere to run.
+///
+/// The call id is handed to each stage instead of held, because `run_inner`
+/// owns it in between.
+struct Hook<'a> {
+    installed: InstalledHook,
+    ctx: &'a ToolContext,
+    tool: &'a str,
+    origin: CallOrigin,
+    authority: Authority,
+}
+
+impl<'a> Hook<'a> {
+    fn of(ctx: &'a ToolContext, resolved: &Resolved<'a>, origin: CallOrigin) -> Option<Self> {
+        Some(Self {
+            installed: ctx.registry.hook()?,
+            ctx,
+            tool: resolved.name,
+            origin,
+            authority: resolved.route.authority()?,
+        })
+    }
+
+    async fn filter_input(&self, tool_id: &str, input: &Value) -> Verdict {
+        if !self.installed.wraps(self.tool, HookStage::Input) {
+            return Verdict::Unchanged;
+        }
+        let cancelled = Verdict::Denied(ERROR_CANCELLED.to_owned());
+        self.fire(HookStage::Input, tool_id, input.clone(), cancelled)
+            .await
+    }
+
+    /// Rewrites the finished event in place. Text and error flag move together,
+    /// so a hook that cannot reach the text cannot flip the flag either.
+    async fn filter_output(&self, done: &mut ToolDoneEvent) {
+        if !self.installed.wraps(self.tool, HookStage::Output) {
+            return;
+        }
+        let was_error = done.is_error;
+        let Some(text) = done.output.filterable_text_mut() else {
+            debug!(
+                tool = %self.tool,
+                "output hook skipped: this output renders from fields, not prose"
+            );
+            return;
+        };
+        let value = json!({ OUTPUT_TEXT: &*text, OUTPUT_IS_ERROR: was_error });
+        let (rewritten, is_error) = match self
+            .fire(HookStage::Output, &done.id, value, Verdict::Unchanged)
+            .await
+        {
+            Verdict::Unchanged => return,
+            // Nothing left to stop, so the reason becomes what the model reads.
+            Verdict::Denied(reason) => (reason, true),
+            Verdict::Replaced(value) => match value.get(OUTPUT_TEXT).and_then(Value::as_str) {
+                Some(replaced) => (
+                    replaced.to_owned(),
+                    value
+                        .get(OUTPUT_IS_ERROR)
+                        .and_then(Value::as_bool)
+                        .unwrap_or(was_error),
+                ),
+                None => {
+                    warn!(
+                        tool = %self.tool,
+                        field = OUTPUT_TEXT,
+                        "output hook replaced the output without a text field, leaving it alone"
+                    );
+                    return;
+                }
+            },
+        };
+        *text = rewritten;
+        done.is_error = is_error;
+        debug!(tool = %self.tool, "output hook rewrote the output");
+    }
+
+    /// Cancellation outranks a hook: nobody is left to read the verdict, so
+    /// the wait ends with `on_cancel`.
+    async fn fire(
+        &self,
+        stage: HookStage,
+        tool_id: &str,
+        value: Value,
+        on_cancel: Verdict,
+    ) -> Verdict {
+        let call = HookCall {
+            tool: self.tool,
+            tool_id,
+            session_id: self.ctx.session_id.as_ref().map(SessionRef::as_str),
+            origin: self.origin,
+            authority: self.authority,
+            cancel: &self.ctx.cancel,
+            deadline: self.window(),
+        };
+        self.ctx
+            .cancel
+            .race(self.installed.run(stage, value, &call))
+            .await
+            .unwrap_or(on_cancel)
+    }
+
+    /// Read when a stage fires, not once per call: the input chain and the tool
+    /// spend from the same budget, so an output chain handed the entry-time
+    /// answer would inherit a window the call already used up.
+    fn window(&self) -> Instant {
+        let cap = Instant::now() + HOOK_CHAIN_MAX;
+        match self.ctx.deadline {
+            Deadline::At(at) => at.min(cap),
+            Deadline::None => cap,
+        }
+    }
 }
 
 /// Where a name goes for one context. Dispatch and telemetry read this one
@@ -113,6 +267,26 @@ impl Route<'_> {
             Self::Mcp(..) => Cow::Borrowed(SOURCE_MCP),
             Self::ToolSearch(_) => Cow::Borrowed(TOOL_SEARCH_TOOL_NAME),
             Self::Unknown => Cow::Borrowed(SOURCE_UNKNOWN),
+        }
+    }
+
+    /// What hooking this call would lend. Every route answers here, so a new
+    /// one cannot reach a hook without naming its price. Only a declared
+    /// capability narrows it: reading undeclared as free is what would let an
+    /// unprivileged plugin steer `batch` or `code_execution` into any tool it
+    /// likes.
+    fn authority(&self) -> Option<Authority> {
+        match self {
+            Self::Native(entry) => Some(
+                entry
+                    .tool
+                    .required_permission()
+                    .map_or(Authority::Unbounded, Authority::Capability),
+            ),
+            Self::ToolSearch(_) | Self::Local(_) | Self::Mcp(..) => Some(Authority::Unbounded),
+            // A rewrite cannot make the name exist, so firing here would hand
+            // out a tool's authority without the tool.
+            Self::Unknown => None,
         }
     }
 }
@@ -371,7 +545,6 @@ async fn run_native_tool(
     }
 
     let result = invocation.execute(ctx).await;
-
     let elapsed = started.elapsed();
     match result.output {
         Ok(output) => {
@@ -724,27 +897,30 @@ fn report(done: &ToolDoneEvent, name: &str, source: &str, input: &Value, took: D
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::sync::Arc;
+    use std::sync::Mutex;
     use std::sync::atomic::{AtomicBool, Ordering};
 
-    use maki_config::{Effect, PermissionRule, PermissionsConfig, ToolKey};
+    use maki_config::{Effect, Permission, PermissionRule, PermissionsConfig, ToolKey};
     use test_case::test_case;
 
     use super::*;
     use crate::AgentMode;
+    use crate::cancel::CancelToken;
     use crate::mcp::test_support::stub_session;
     use crate::mcp::tool_names;
     use crate::permissions::{PERMISSION_DENIED_PREFIX, PermissionManager};
     use crate::template::Vars;
     use crate::tools::registry::{ToolRegistry, ToolSource};
+    use crate::tools::schema::{JsonPath, ToolInputErrorKind};
     use crate::tools::test_support::{
         GUARDED_TOOL_NAME, GuardedMock, mock_tool, stub_ctx, stub_ctx_with_permissions,
     };
     use crate::tools::{
         BoxFuture, DescriptionContext, ExecFuture, HeaderFuture, HeaderResult, ParseError,
         PermissionScopes, RequestTools, TOOL_NAME_FIELD, Tool, ToolAudience, ToolExecResult,
-        local_tool,
+        ToolHook, local_tool,
     };
 
     const TEST_ID: &str = "t1";
@@ -755,11 +931,30 @@ mod tests {
     const SHADOWED_NAME: &str = "batch";
     const CLIENT_NAME: &str = "client_probe";
     const TEST_PLUGIN: &str = "test";
+    const HOOK_TOOL_NAME: &str = "hook_probe";
+    const HOOK_FIELD: &str = "command";
+    const HOOK_PLAIN: &str = "ls";
+    const HOOK_REWRITTEN_FROM: &str = "grep -r x .";
+    const HOOK_REWRITTEN_TO: &str = "rg x";
+    const HOOK_DENIED: &str = "sudo rm -rf /";
+    const HOOK_DENY_REASON: &str = "not on my watch";
+    const HOOK_OUTPUT_TEXT: &str = "trimmed";
+    const HOOK_PERMISSION: Permission = Permission::Run;
+    const HOOK_FIELD_TYPE: &str = "string";
+    const HOOK_DIFF_COMMAND: &str = "apply";
+    const HOOK_DIFF_PATH: &str = "/tmp/diffed.txt";
+    const HOOK_DIFF_SUMMARY: &str = "1 file changed";
+    const HOOK_ESCAPED_PATH: &str = "/tmp/not-the-plan.md";
     const TEST_PLUGIN_SOURCE: &str = "lua:test";
     const START_PROBE_NAME: &str = "start_probe";
     /// Allowed by the shared stub permissions; nothing is ever written here.
     const TEST_ROOT: &str = "/tmp";
     const PLAN_PATH: &str = "/tmp/plan.md";
+    const HOOK_CALL_DEADLINE: Duration = Duration::from_secs(7);
+    const HOOK_SLOW_COMMAND: &str = "slow";
+    /// Real elapsed time inside the call, so the gap between the two stages'
+    /// windows is a measurement rather than a race.
+    const HOOK_SLOW_RUN: Duration = Duration::from_millis(20);
 
     fn recent_calls(entries: &[(&str, Value)]) -> RecentCalls {
         let mut rc = RecentCalls::new();
@@ -865,6 +1060,547 @@ mod tests {
 
     fn denying_ctx(tool: ToolKey) -> ToolContext {
         ruled_ctx(&AgentMode::Build, tool, Effect::Deny)
+    }
+
+    fn build_ctx() -> ToolContext {
+        stub_ctx(&AgentMode::Build)
+    }
+
+    /// Its permission scope, its write target and its output are all its
+    /// input, which is how a test sees the input each stage of dispatch got.
+    struct HookMock(Option<Permission>);
+
+    struct HookMockInvocation(String);
+
+    impl ToolInvocation for HookMockInvocation {
+        fn start_header(&self) -> HeaderFuture {
+            HeaderFuture::Ready(HeaderResult::plain(HOOK_TOOL_NAME.into()))
+        }
+        fn permission_scopes(&self) -> BoxFuture<'_, Option<PermissionScopes>> {
+            Box::pin(std::future::ready(Some(PermissionScopes::single(
+                self.0.clone(),
+            ))))
+        }
+        fn mutable_path(&self) -> Option<&Path> {
+            Some(Path::new(&self.0))
+        }
+        fn execute<'a>(self: Box<Self>, _ctx: &'a ToolContext) -> ExecFuture<'a> {
+            Box::pin(async move {
+                if self.0 == HOOK_SLOW_COMMAND {
+                    smol::Timer::after(HOOK_SLOW_RUN).await;
+                }
+                Ok(output_of(&self.0)).into()
+            })
+        }
+    }
+
+    fn ran(command: &str) -> String {
+        format!("ran {command}")
+    }
+
+    /// One command answers with a shape the UI renders from fields, the one
+    /// kind of output a hook may not touch.
+    fn output_of(command: &str) -> ToolOutput {
+        if command == HOOK_DIFF_COMMAND {
+            return ToolOutput::Diff {
+                path: HOOK_DIFF_PATH.to_owned(),
+                before: String::new(),
+                after: String::new(),
+                summary: HOOK_DIFF_SUMMARY.to_owned(),
+            };
+        }
+        ToolOutput::Plain(ran(command).into())
+    }
+
+    /// Shared by the mock and the assertion, so the test cannot pass against
+    /// some other error.
+    fn missing_command() -> ParseError {
+        ParseError {
+            path: JsonPath::default(),
+            kind: ToolInputErrorKind::Missing {
+                expected: HOOK_FIELD_TYPE,
+            },
+        }
+    }
+
+    impl Tool for HookMock {
+        fn name(&self) -> &str {
+            HOOK_TOOL_NAME
+        }
+        fn description(&self, _ctx: &DescriptionContext) -> Cow<'_, str> {
+            "hook mock".into()
+        }
+        fn schema(&self) -> Value {
+            serde_json::json!({"type": "object", "properties": {"command": {"type": "string"}}})
+        }
+        fn required_permission(&self) -> Option<Permission> {
+            self.0
+        }
+        fn parse(&self, input: &Value) -> Result<Box<dyn ToolInvocation>, ParseError> {
+            match input[HOOK_FIELD].as_str() {
+                Some(command) => Ok(Box::new(HookMockInvocation(command.to_owned()))),
+                None => Err(missing_command()),
+            }
+        }
+    }
+
+    /// One firing as the hook saw it.
+    #[derive(Clone, Debug)]
+    struct Seen {
+        stage: HookStage,
+        authority: Authority,
+        tool: String,
+        tool_id: String,
+        session_id: Option<String>,
+        origin: CallOrigin,
+        value: Value,
+        cancelled: bool,
+        deadline: Instant,
+    }
+
+    #[derive(Clone, Copy)]
+    enum Reply {
+        Answers(fn(HookStage, &Value) -> Verdict),
+        /// Never resolves, so only cancellation can end the wait.
+        Pending,
+    }
+
+    /// Stands in for the Lua slot chain: records every firing and answers with
+    /// whatever the test scripted.
+    #[derive(Clone)]
+    struct RecordingHook {
+        seen: Arc<Mutex<Vec<Seen>>>,
+        wrapped: &'static [HookStage],
+        reply: Reply,
+    }
+
+    impl Default for RecordingHook {
+        fn default() -> Self {
+            Self {
+                seen: Arc::default(),
+                wrapped: &HookStage::ALL,
+                reply: Reply::Answers(steer_the_call),
+            }
+        }
+    }
+
+    /// Rewrites, denies or defers on the way in, the way a plugin steering the
+    /// model off one command onto another would.
+    fn steer_the_call(stage: HookStage, value: &Value) -> Verdict {
+        match stage {
+            HookStage::Input => match value[HOOK_FIELD].as_str() {
+                Some(HOOK_DENIED) => Verdict::Denied(HOOK_DENY_REASON.into()),
+                Some(HOOK_REWRITTEN_FROM) => Verdict::Replaced(call_input(HOOK_REWRITTEN_TO)),
+                _ => Verdict::Unchanged,
+            },
+            HookStage::Output => Verdict::Unchanged,
+        }
+    }
+
+    impl RecordingHook {
+        fn wrapping(wrapped: &'static [HookStage]) -> Self {
+            Self {
+                wrapped,
+                ..Self::default()
+            }
+        }
+
+        fn answering(answer: fn(HookStage, &Value) -> Verdict) -> Self {
+            Self {
+                reply: Reply::Answers(answer),
+                ..Self::default()
+            }
+        }
+
+        fn never_answering(wrapped: &'static [HookStage]) -> Self {
+            Self {
+                wrapped,
+                reply: Reply::Pending,
+                ..Self::default()
+            }
+        }
+
+        fn seen(&self) -> Vec<Seen> {
+            self.seen.lock().unwrap().clone()
+        }
+
+        fn stages(&self) -> Vec<(HookStage, Authority)> {
+            self.seen().iter().map(|s| (s.stage, s.authority)).collect()
+        }
+
+        fn at(&self, stage: HookStage) -> Option<Seen> {
+            self.seen().into_iter().find(|s| s.stage == stage)
+        }
+    }
+
+    impl ToolHook for RecordingHook {
+        fn wraps(&self, _tool: &str, stage: HookStage) -> bool {
+            self.wrapped.contains(&stage)
+        }
+
+        fn run<'a>(
+            &'a self,
+            stage: HookStage,
+            value: Value,
+            call: &'a HookCall<'a>,
+        ) -> BoxFuture<'a, Verdict> {
+            self.seen.lock().unwrap().push(Seen {
+                stage,
+                authority: call.authority,
+                tool: call.tool.to_owned(),
+                tool_id: call.tool_id.to_owned(),
+                session_id: call.session_id.map(str::to_owned),
+                origin: call.origin,
+                value: value.clone(),
+                cancelled: call.cancel.is_cancelled(),
+                deadline: call.deadline,
+            });
+            match self.reply {
+                Reply::Answers(answer) => Box::pin(std::future::ready(answer(stage, &value))),
+                Reply::Pending => Box::pin(std::future::pending()),
+            }
+        }
+    }
+
+    fn hooked_ctx(ctx: ToolContext) -> (ToolContext, RecordingHook) {
+        hooked_with(ctx, None, RecordingHook::default())
+    }
+
+    fn plain_hooked_ctx(hook: RecordingHook) -> (ToolContext, RecordingHook) {
+        hooked_with(build_ctx(), None, hook)
+    }
+
+    fn hooked_with(
+        mut ctx: ToolContext,
+        permission: Option<Permission>,
+        hook: RecordingHook,
+    ) -> (ToolContext, RecordingHook) {
+        ctx.registry = registered(Arc::new(HookMock(permission)));
+        ctx.registry.set_hook(hook.clone());
+        (ctx, hook)
+    }
+
+    fn cancelled_token() -> CancelToken {
+        let (trigger, token) = CancelToken::new();
+        trigger.cancel();
+        token
+    }
+
+    fn call_input(command: &str) -> Value {
+        serde_json::json!({ HOOK_FIELD: command })
+    }
+
+    fn both_stages(authority: Authority) -> Vec<(HookStage, Authority)> {
+        HookStage::ALL.map(|stage| (stage, authority)).into()
+    }
+
+    /// The rewritten call is the one that runs and the one the rules judge.
+    /// Were it the other way round, an `allow bash: git status` rule would be a
+    /// way to run anything.
+    #[test_case(build_ctx                                       , false ; "reaches_execute")]
+    #[test_case(|| denying_ctx(ToolKey::native(HOOK_TOOL_NAME))  , true  ; "reaches_the_permission_prompt")]
+    fn an_input_rewrite_is_the_call_that_runs(build: fn() -> ToolContext, is_error: bool) {
+        smol::block_on(async {
+            let (ctx, _hook) = hooked_ctx(build());
+            let done = dispatch(&ctx, HOOK_TOOL_NAME, &call_input(HOOK_REWRITTEN_FROM)).await;
+
+            let text = done.output.as_text();
+            assert_eq!(done.is_error, is_error, "{text}");
+            assert!(
+                text.contains(HOOK_REWRITTEN_TO) && !text.contains(HOOK_REWRITTEN_FROM),
+                "everything downstream names the rewritten command: {text}"
+            );
+        });
+    }
+
+    #[test]
+    fn input_hook_denial_never_runs_the_tool() {
+        smol::block_on(async {
+            let (ctx, hook) = hooked_ctx(stub_ctx(&AgentMode::Build));
+            let done = dispatch(&ctx, HOOK_TOOL_NAME, &call_input(HOOK_DENIED)).await;
+
+            assert!(done.is_error);
+            assert_eq!(done.output.as_text(), HOOK_DENY_REASON);
+            assert_eq!(
+                hook.stages(),
+                vec![(HookStage::Input, Authority::Unbounded)],
+                "a stopped call has no output to hook"
+            );
+        });
+    }
+
+    /// Everything the model reads passes the output stage, so a hook that
+    /// redacts or trims cannot be walked around by failing the call.
+    #[test]
+    fn a_refused_call_still_reaches_the_output_stage() {
+        smol::block_on(async {
+            let (ctx, hook) = hooked_ctx(denying_ctx(ToolKey::native(HOOK_TOOL_NAME)));
+            let done = dispatch(&ctx, HOOK_TOOL_NAME, &call_input(HOOK_PLAIN)).await;
+
+            assert!(done.is_error);
+            assert!(done.output.as_text().contains(PERMISSION_DENIED_PREFIX));
+            assert_eq!(hook.stages(), both_stages(Authority::Unbounded));
+
+            let firing = hook.at(HookStage::Output).expect("the output stage fired");
+            assert_eq!(firing.value[OUTPUT_IS_ERROR], Value::Bool(true));
+            let text = firing.value[OUTPUT_TEXT].as_str().unwrap_or_default();
+            assert!(text.contains(PERMISSION_DENIED_PREFIX), "got: {text}");
+        });
+    }
+
+    /// A name that routes nowhere lends no authority, so nothing fires.
+    #[test]
+    fn unknown_names_are_not_hooked() {
+        smol::block_on(async {
+            let (ctx, hook) = hooked_ctx(stub_ctx(&AgentMode::Build));
+            let done = dispatch(&ctx, "nope", &call_input(HOOK_DENIED)).await;
+
+            assert!(done.is_error);
+            assert!(done.output.as_text().contains(UNKNOWN_TOOL_PREFIX));
+            assert!(hook.stages().is_empty());
+        });
+    }
+
+    fn mcp_route_ctx() -> ToolContext {
+        mcp_ctx(&stub_mcp(&[PROBE_QUALIFIED]))
+    }
+
+    fn host_route_ctx() -> ToolContext {
+        local_ctx(CLIENT_NAME, |_| Ok(String::new()))
+    }
+
+    /// Hooking in dispatch is what reaches a route maki did not write the code
+    /// behind, and each one has to answer for what that lends. Only a declared
+    /// capability narrows the price; everything else prices at the maximum.
+    /// The name stays the one the model called, not whatever dispatch routes
+    /// it to.
+    #[test_case(build_ctx,      HOOK_TOOL_NAME,        Some(HOOK_PERMISSION), Authority::Capability(HOOK_PERMISSION) ; "a_checked_tool_lends_its_capability")]
+    #[test_case(build_ctx,      HOOK_TOOL_NAME,        None,                  Authority::Unbounded                   ; "a_tool_declaring_nothing_declares_no_limit")]
+    #[test_case(mcp_route_ctx,  TOOL_SEARCH_TOOL_NAME, None,                  Authority::Unbounded                   ; "search_declares_nothing_either")]
+    #[test_case(mcp_route_ctx,  PROBE_WIRE,            None,                  Authority::Unbounded                   ; "an_mcp_tool_is_code_maki_does_not_own")]
+    #[test_case(host_route_ctx, CLIENT_NAME,           None,                  Authority::Unbounded                   ; "a_host_tool_is_code_maki_does_not_own")]
+    fn a_route_lends_the_authority_it_declares(
+        build: fn() -> ToolContext,
+        name: &str,
+        permission: Option<Permission>,
+        expected: Authority,
+    ) {
+        smol::block_on(async {
+            let (ctx, hook) = hooked_with(build(), permission, RecordingHook::default());
+            dispatch(&ctx, name, &call_input(HOOK_PLAIN)).await;
+
+            let firing = hook.at(HookStage::Input).expect("the input stage fired");
+            assert_eq!(firing.authority, expected);
+            assert_eq!(firing.tool, name, "hooked under the name the model called");
+        });
+    }
+
+    /// `wraps` is why an unwrapped slot costs nothing: a stage the hook
+    /// declines never reaches `run` at all.
+    #[test_case(&[HookStage::Input]  ; "input_only")]
+    #[test_case(&[HookStage::Output] ; "output_only")]
+    fn a_stage_the_hook_declines_never_fires(wrapped: &'static [HookStage]) {
+        smol::block_on(async {
+            let (ctx, hook) = plain_hooked_ctx(RecordingHook::wrapping(wrapped));
+            let done = dispatch(&ctx, HOOK_TOOL_NAME, &call_input(HOOK_PLAIN)).await;
+
+            assert!(!done.is_error);
+            assert_eq!(done.output.as_text(), ran(HOOK_PLAIN));
+            let fired: Vec<HookStage> = hook.seen().iter().map(|s| s.stage).collect();
+            assert_eq!(fired, wrapped);
+        });
+    }
+
+    /// Nobody is left reading the answer, so waiting on a verdict that never
+    /// comes would only keep the call alive. Each stage keeps what it has: no
+    /// input was judged, and an output already produced stands.
+    #[test_case(&[HookStage::Input],  true,  ERROR_CANCELLED.to_owned() ; "input")]
+    #[test_case(&[HookStage::Output], false, ran(HOOK_PLAIN)            ; "output")]
+    fn a_cancelled_call_does_not_wait_for_a_verdict(
+        wrapped: &'static [HookStage],
+        is_error: bool,
+        expected: String,
+    ) {
+        smol::block_on(async {
+            let mut ctx = build_ctx();
+            ctx.cancel = cancelled_token();
+            let (ctx, _hook) = hooked_with(ctx, None, RecordingHook::never_answering(wrapped));
+
+            let done = dispatch(&ctx, HOOK_TOOL_NAME, &call_input(HOOK_PLAIN)).await;
+
+            assert_eq!(done.is_error, is_error);
+            assert_eq!(done.output.as_text(), expected);
+        });
+    }
+
+    /// A chain runs off this thread, so it only dies with the call it filters
+    /// when it is handed that call's own token and an instant to be killed at.
+    #[test]
+    fn a_firing_carries_the_calls_cancellation_and_deadline() {
+        smol::block_on(async {
+            let at = Instant::now() + HOOK_CALL_DEADLINE;
+            let mut ctx = build_ctx();
+            ctx.deadline = Deadline::At(at);
+            ctx.cancel = cancelled_token();
+            let (ctx, hook) = hooked_ctx(ctx);
+
+            dispatch(&ctx, HOOK_TOOL_NAME, &call_input(HOOK_PLAIN)).await;
+
+            let firing = hook.at(HookStage::Input).expect("the input stage fired");
+            assert!(firing.cancelled, "the call's own token, not a fresh one");
+            assert_eq!(firing.deadline, at, "and no later than the call itself");
+        });
+    }
+
+    /// A call with no deadline of its own still bounds each chain, or a layer
+    /// that hangs hangs the call with it. Bounded from where the stage starts,
+    /// too: the input chain and the tool spend from the same budget, and an
+    /// output chain handed the entry-time answer would get whatever they left,
+    /// which for a slow tool is nothing.
+    #[test]
+    fn a_call_without_a_deadline_bounds_each_stage_from_where_it_starts() {
+        smol::block_on(async {
+            let (ctx, hook) = hooked_ctx(build_ctx());
+            let before = Instant::now();
+
+            dispatch(&ctx, HOOK_TOOL_NAME, &call_input(HOOK_SLOW_COMMAND)).await;
+
+            let input = hook.at(HookStage::Input).expect("the input stage fired");
+            let output = hook.at(HookStage::Output).expect("the output stage fired");
+            assert!(
+                input.deadline >= before && input.deadline <= Instant::now() + HOOK_CHAIN_MAX,
+                "a deadline already past kills every chain"
+            );
+            assert!(
+                output.deadline - input.deadline >= HOOK_SLOW_RUN,
+                "the output chain inherited a window the call had already spent"
+            );
+        });
+    }
+
+    fn replace_the_output(stage: HookStage, _value: &Value) -> Verdict {
+        match stage {
+            HookStage::Input => Verdict::Unchanged,
+            HookStage::Output => Verdict::Replaced(
+                serde_json::json!({OUTPUT_TEXT: HOOK_OUTPUT_TEXT, OUTPUT_IS_ERROR: true}),
+            ),
+        }
+    }
+
+    fn replace_the_output_without_text(stage: HookStage, _value: &Value) -> Verdict {
+        match stage {
+            HookStage::Input => Verdict::Unchanged,
+            HookStage::Output => Verdict::Replaced(serde_json::json!({OUTPUT_IS_ERROR: true})),
+        }
+    }
+
+    fn deny_the_output(stage: HookStage, _value: &Value) -> Verdict {
+        match stage {
+            HookStage::Input => Verdict::Unchanged,
+            HookStage::Output => Verdict::Denied(HOOK_DENY_REASON.into()),
+        }
+    }
+
+    /// Text and error flag move together, and a hook that has run out of call
+    /// to stop has only the text left to say so with.
+    #[test_case(replace_the_output,              true,  HOOK_OUTPUT_TEXT.to_owned() ; "a_replacement_moves_text_and_flag")]
+    #[test_case(replace_the_output_without_text, false, ran(HOOK_PLAIN)             ; "a_replacement_without_text_changes_neither")]
+    #[test_case(deny_the_output,                 true,  HOOK_DENY_REASON.to_owned() ; "a_denial_becomes_the_result")]
+    fn the_output_stage_decides_what_the_model_reads(
+        answer: fn(HookStage, &Value) -> Verdict,
+        is_error: bool,
+        expected: String,
+    ) {
+        smol::block_on(async {
+            let (ctx, _hook) = plain_hooked_ctx(RecordingHook::answering(answer));
+            let done = dispatch(&ctx, HOOK_TOOL_NAME, &call_input(HOOK_PLAIN)).await;
+
+            assert_eq!(done.is_error, is_error);
+            assert_eq!(done.output.as_text(), expected);
+        });
+    }
+
+    /// An output the UI renders from fields carries no prose to lend, and
+    /// editing it would desync the fields from the text.
+    #[test]
+    fn a_rendered_output_skips_the_output_stage() {
+        smol::block_on(async {
+            let (ctx, hook) = plain_hooked_ctx(RecordingHook::answering(deny_the_output));
+            let done = dispatch(&ctx, HOOK_TOOL_NAME, &call_input(HOOK_DIFF_COMMAND)).await;
+
+            assert!(!done.is_error);
+            assert_eq!(done.output.as_text(), HOOK_DIFF_SUMMARY);
+            assert_eq!(
+                hook.stages(),
+                vec![(HookStage::Input, Authority::Unbounded)]
+            );
+        });
+    }
+
+    fn drop_the_field(stage: HookStage, _value: &Value) -> Verdict {
+        match stage {
+            HookStage::Input => Verdict::Replaced(serde_json::json!({})),
+            HookStage::Output => Verdict::Unchanged,
+        }
+    }
+
+    /// The rewrite lands before the schema check, so a shape the tool cannot
+    /// parse is an ordinary parse error rather than something dispatch has to
+    /// survive.
+    #[test]
+    fn a_rewrite_the_tool_cannot_parse_is_a_parse_error() {
+        smol::block_on(async {
+            let (ctx, _hook) = plain_hooked_ctx(RecordingHook::answering(drop_the_field));
+            let done = dispatch(&ctx, HOOK_TOOL_NAME, &call_input(HOOK_PLAIN)).await;
+
+            assert!(done.is_error);
+            assert_eq!(done.output.as_text(), missing_command().to_string());
+        });
+    }
+
+    fn rewrite_the_target(stage: HookStage, _value: &Value) -> Verdict {
+        match stage {
+            HookStage::Input => Verdict::Replaced(call_input(HOOK_ESCAPED_PATH)),
+            HookStage::Output => Verdict::Unchanged,
+        }
+    }
+
+    /// The write gate reads its target off the rewritten input, so a hook
+    /// cannot point a plan-mode write anywhere but the plan file. The
+    /// untouched call is the control, otherwise the gate could be refusing for
+    /// some unrelated reason.
+    #[test_case(RecordingHook::answering(rewrite_the_target), crate::tools::PLAN_WRITE_RESTRICTED.to_owned() ; "rewritten_away_from_the_plan_file")]
+    #[test_case(RecordingHook::default(),                     ran(PLAN_PATH)                                 ; "left_on_the_plan_file")]
+    fn a_rewritten_write_target_is_still_plan_gated(hook: RecordingHook, expected: String) {
+        smol::block_on(async {
+            let plan = AgentMode::Plan(PathBuf::from(PLAN_PATH));
+            let (ctx, _hook) = hooked_with(stub_ctx(&plan), None, hook);
+            let done = dispatch(&ctx, HOOK_TOOL_NAME, &call_input(PLAN_PATH)).await;
+
+            assert_eq!(done.output.as_text(), expected);
+        });
+    }
+
+    /// A plugin keys its state on these, so a stage firing under another
+    /// call's identity would write onto that other call.
+    #[test]
+    fn both_stages_carry_the_call_id_the_session_and_the_origin() {
+        smol::block_on(async {
+            let session = SessionRef::generate();
+            let mut ctx = build_ctx();
+            ctx.session_id = Some(session.clone());
+            let (ctx, hook) = hooked_ctx(ctx);
+
+            dispatch_nested(&ctx, HOOK_TOOL_NAME, &call_input(HOOK_PLAIN)).await;
+
+            let seen = hook.seen();
+            assert_eq!(seen.len(), HookStage::ALL.len(), "both stages fire");
+            for firing in seen {
+                assert_eq!(firing.tool_id, TEST_ID);
+                assert_eq!(firing.session_id.as_deref(), Some(session.as_str()));
+                assert_eq!(firing.origin, CallOrigin::Nested);
+            }
+        });
     }
 
     #[test]

--- a/maki-agent/src/tools/hook.rs
+++ b/maki-agent/src/tools/hook.rs
@@ -1,0 +1,98 @@
+//! One interception point for tool calls, shared by every route dispatch
+//! knows: registry tools, MCP tools, and host (ACP client) tools alike.
+//!
+//! It lives on the [`ToolRegistry`](super::registry::ToolRegistry) rather than
+//! on the [`Tool`](super::Tool) trait, so a tool is hookable because dispatch
+//! reached it, not because whoever wrote it remembered to ask.
+
+use std::time::Instant;
+
+use serde_json::Value;
+
+use super::CallOrigin;
+use super::registry::BoxFuture;
+use crate::cancel::CancelToken;
+use maki_config::Permission;
+
+/// Fields of the value a [`HookStage::Output`] hook sees and returns.
+pub const OUTPUT_TEXT: &str = "text";
+pub const OUTPUT_IS_ERROR: &str = "is_error";
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+pub enum HookStage {
+    /// Before the input is parsed and before permission rules resolve, so
+    /// rules judge the call as the hook left it. Any later and a hook could
+    /// smuggle in an argument the rules never approved.
+    Input,
+    /// After the call finished, on the text it produced (failures included),
+    /// before that text becomes history.
+    Output,
+}
+
+impl HookStage {
+    /// Order matters: stages index array slots via `as usize`.
+    pub const ALL: [Self; 2] = [Self::Input, Self::Output];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Input => "input",
+            Self::Output => "output",
+        }
+    }
+}
+
+/// What hooking a call would hand whoever wrote the hook. Rewriting an input
+/// decides what the tool then does, so the host prices that before it lets
+/// untrusted code near it.
+///
+/// There is no "free" variant on purpose. A tool declaring no capability has
+/// not told us it exercises none, only that nothing asks: `batch`, `task` and
+/// `code_execution` declare nothing and reach every other tool. So a tool
+/// landing tomorrow is never silently free to layer.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Authority {
+    /// Exactly the capability the tool declares; a layer needs that one.
+    Capability(Permission),
+    /// Reach nobody declared: a tool naming no capability, an MCP server tool,
+    /// an ACP client tool, search. A layer needs every capability, because no
+    /// narrower answer would be honest.
+    Unbounded,
+}
+
+pub struct HookCall<'a> {
+    pub tool: &'a str,
+    pub tool_id: &'a str,
+    pub session_id: Option<&'a str>,
+    pub origin: CallOrigin,
+    pub authority: Authority,
+    /// The call's own cancellation, so a hook that runs elsewhere (the Lua
+    /// thread) dies with the call rather than outliving the reply channel.
+    pub cancel: &'a CancelToken,
+    /// When the chain has to be dead by, whatever it is waiting on.
+    pub deadline: Instant,
+}
+
+/// How a hook answered. `Unchanged` also covers every way a hook can fail: a
+/// hook is an opinion about a call, never a precondition for making it, so a
+/// broken one costs exactly what no hook costs.
+pub enum Verdict {
+    Unchanged,
+    Replaced(Value),
+    Denied(String),
+}
+
+pub trait ToolHook: Send + Sync + 'static {
+    /// Synchronous and allocation free, because dispatch asks it for every
+    /// call: a stage nobody wrapped never leaves the calling thread.
+    fn wraps(&self, tool: &str, stage: HookStage) -> bool;
+
+    /// `value` is the call's input at [`HookStage::Input`], and
+    /// `{ [OUTPUT_TEXT]: string, [OUTPUT_IS_ERROR]: bool }` at
+    /// [`HookStage::Output`].
+    fn run<'a>(
+        &'a self,
+        stage: HookStage,
+        value: Value,
+        call: &'a HookCall<'a>,
+    ) -> BoxFuture<'a, Verdict>;
+}

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -7,11 +7,13 @@
 
 mod file_tracker;
 pub mod grep;
+pub mod hook;
 pub mod interpreter_bridge;
 pub mod registry;
 pub mod schema;
 
 pub use file_tracker::FileReadTracker;
+pub use hook::{Authority, HookCall, HookStage, ToolHook, Verdict};
 pub use registry::{
     BoxFuture, ExecFuture, HeaderFuture, HeaderResult, ParseError, PermissionScopes,
     RegisteredTool, RegistryError, Tool, ToolAudience, ToolExecResult, ToolInvocation,
@@ -57,6 +59,13 @@ pub enum CallOrigin {
 impl CallOrigin {
     pub fn is_model(self) -> bool {
         matches!(self, Self::Model)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Model => "model",
+            Self::Nested => "nested",
+        }
     }
 }
 

--- a/maki-agent/src/tools/registry.rs
+++ b/maki-agent/src/tools/registry.rs
@@ -8,7 +8,7 @@ use std::pin::Pin;
 use std::sync::{Arc, LazyLock};
 use std::task::{Context, Poll};
 
-use arc_swap::ArcSwap;
+use arc_swap::{ArcSwap, ArcSwapOption};
 use bitflags::bitflags;
 use maki_config::Permission;
 use serde_json::{Value, json};
@@ -16,6 +16,7 @@ use serde_json::{Value, json};
 use crate::template::Vars;
 use crate::{BufferSnapshot, ToolOutput};
 
+use super::hook::ToolHook;
 use super::{DescriptionContext, ToolContext};
 
 bitflags! {
@@ -260,7 +261,15 @@ impl RegisteredTool {
 /// Lock-free reads via `ArcSwap`, writes swap in a new snapshot atomically.
 pub struct ToolRegistry {
     tools: ArcSwap<Vec<RegisteredTool>>,
+    /// Whoever may rewrite or stop a call before and after it runs. One per
+    /// registry rather than one per tool, so a tool arriving from a new place
+    /// is hookable the day it lands.
+    hook: ArcSwapOption<Box<dyn ToolHook>>,
 }
+
+/// `ArcSwapOption` needs a sized payload, hence the `Box`. Auto-deref hides
+/// it at every call site.
+pub type InstalledHook = Arc<Box<dyn ToolHook>>;
 
 impl Default for ToolRegistry {
     fn default() -> Self {
@@ -278,7 +287,20 @@ impl ToolRegistry {
     pub fn new() -> Self {
         Self {
             tools: ArcSwap::from_pointee(Vec::new()),
+            hook: ArcSwapOption::empty(),
         }
+    }
+
+    /// Installed by the plugin host once its Lua thread is up. Last writer
+    /// wins, so a registry outliving the host that hooked it points at the
+    /// host that replaced it, never at the dead one.
+    pub fn set_hook(&self, hook: impl ToolHook) {
+        let boxed: Box<dyn ToolHook> = Box::new(hook);
+        self.hook.store(Some(Arc::new(boxed)));
+    }
+
+    pub fn hook(&self) -> Option<InstalledHook> {
+        self.hook.load_full()
     }
 
     /// The process-wide registry. Every tool in it comes from a Lua plugin

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -342,6 +342,25 @@ impl ToolOutput {
         }
     }
 
+    /// The text a [`HookStage::Output`] hook may read and rewrite, or `None`
+    /// when the output has none to lend. Only a plain-text shape with no
+    /// `state` qualifies: the other variants render from their own fields, and
+    /// a `state` sidecar is saved with the session and re-rendered on restore,
+    /// so text a hook redacted would come back verbatim after a restart.
+    ///
+    /// One accessor for both directions, so a getter and a setter can never
+    /// drift into letting a hook read text it cannot write back.
+    ///
+    /// [`HookStage::Output`]: crate::tools::HookStage::Output
+    pub fn filterable_text_mut(&mut self) -> Option<&mut String> {
+        match self {
+            Self::Plain(t) | Self::Markdown(t) | Self::ReadDir(t) if t.state.is_none() => {
+                Some(&mut t.text)
+            }
+            _ => None,
+        }
+    }
+
     pub fn as_text(&self) -> String {
         match self {
             Self::Diff { summary, .. } => summary.clone(),
@@ -956,6 +975,28 @@ mod tests {
     #[test_case(ToolOutput::Diff { path: "a.rs".into(), before: String::new(), after: String::new(), summary: "ok".into() }, None ; "diff_no_annotation")]
     fn annotation_cases(output: ToolOutput, expected: Option<&str>) {
         assert_eq!(output.annotation().as_deref(), expected);
+    }
+
+    const FILTERABLE_TEXT: &str = "body";
+
+    fn text_with_state() -> TextOutput {
+        TextOutput {
+            text: FILTERABLE_TEXT.into(),
+            instructions: None,
+            state: Some(serde_json::json!({ "text": FILTERABLE_TEXT })),
+        }
+    }
+
+    #[test_case(ToolOutput::Plain(FILTERABLE_TEXT.into()),   Some(FILTERABLE_TEXT) ; "plain_without_state_lends_text")]
+    #[test_case(ToolOutput::Plain(text_with_state()),        None                  ; "plain_with_state_withholds_text")]
+    #[test_case(ToolOutput::Markdown(text_with_state()),     None                  ; "markdown_with_state_withholds_text")]
+    #[test_case(ToolOutput::ReadDir(FILTERABLE_TEXT.into()), Some(FILTERABLE_TEXT) ; "read_dir_without_state_lends_text")]
+    #[test_case(ToolOutput::Diff { path: "a.rs".into(), before: String::new(), after: String::new(), summary: FILTERABLE_TEXT.into() }, None ; "diff_withholds_text")]
+    fn filterable_text_needs_text_to_be_the_sole_representation(
+        mut output: ToolOutput,
+        expected: Option<&str>,
+    ) {
+        assert_eq!(output.filterable_text_mut().map(|t| t.as_str()), expected);
     }
 
     #[test_case(None ; "no_stop_reason")]

--- a/maki-lua/src/api/autocmd.rs
+++ b/maki-lua/src/api/autocmd.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use maki_lua_macro::{lua_fn, lua_table};
 use mlua::{Function, Lua, Result as LuaResult, Table, Value};
 
-use crate::api::util::dispatch::DepthGuard;
+use crate::api::util::dispatch::{DepthGuard, Reentry};
 use crate::runtime::{run_detached, strip_traceback};
 
 static NEXT_AUTOCMD_ID: AtomicU64 = AtomicU64::new(1);
@@ -71,7 +71,7 @@ fn pattern_matches(patterns: Option<&[String]>, fired: Option<&str>) -> bool {
 /// gets its own `ev` table, so one plugin's mutation cannot leak into the
 /// next.
 pub(crate) async fn dispatch(lua: Lua, event: String, pattern: Option<String>, data: Value) {
-    let Ok(_guard) = DepthGuard::enter(&lua, "autocmd", &event) else {
+    let Ok(_guard) = DepthGuard::enter(&lua, "autocmd", &event, Reentry::Vm) else {
         tracing::warn!(event, "autocmd dispatch exceeded max depth, skipping");
         return;
     };
@@ -249,9 +249,7 @@ fn del_autocmd(lua: &Lua, id: u64) -> LuaResult<()> {
 /// Fire one or more events manually. Every matching autocmd callback
 /// runs to completion before this function returns.
 ///
-/// A handler may suspend, so this call may too. That rules it out inside
-/// a slot chain, which runs synchronously (see `declare_slot`). Fire the
-/// event from the code that calls the slot instead.
+/// A handler may suspend, so this call may too.
 ///
 /// @param event string|string[] Event name or list of names to fire.
 /// @param opts table? Options:

--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -1199,11 +1199,6 @@ fn jobforget(lua: &Lua, #[ctx] plugin: Arc<str>, job_id: u32) -> LuaResult<()> {
 /// Task and plugin jobs leave the store on exit, so waiting after that
 /// is an error.
 ///
-/// Waiting parks the caller, so a slot chain cannot call it. From a
-/// slot, start the job with an `on_exit` that stashes the result in
-/// your plugin state and pick it back up with `jobfind` next time.
-/// `maki.api.declare_slot` explains the restriction.
-///
 /// @param job_id integer Job id returned by `jobstart`.
 /// @param timeout_ms integer? Maximum wait in milliseconds (default 30000).
 /// @return (table?) `{ stdout, stderr, exit_code, truncated }`, or nil on timeout.

--- a/maki-lua/src/api/slot.rs
+++ b/maki-lua/src/api/slot.rs
@@ -1,11 +1,21 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::future::Future;
 use std::mem;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
+use arc_swap::ArcSwap;
+use maki_agent::tools::HookStage;
 use maki_lua_macro::{lua_fn, lua_table};
 use mlua::{Function, Lua, MultiValue, Result as LuaResult, Table, Value};
 
-use crate::api::util::dispatch::{DepthGuard, call_isolated};
+use crate::api::util::dispatch::{DepthGuard, Reentry, call_swallowing};
+
+/// Slot names the host fires itself. A plugin declaring one would shadow a
+/// point whose firing order dispatch guarantees, so the namespace is closed.
+pub(crate) const HOST_PREFIX: &str = "tool.";
+
+const SEAM: &str = "slot";
 
 #[derive(Clone)]
 pub(crate) struct SlotLayer {
@@ -22,12 +32,21 @@ pub(crate) struct SlotEntry {
     pub layers: Vec<SlotLayer>,
 }
 
-#[derive(Default)]
 pub(crate) struct SlotStore {
     pub slots: HashMap<String, SlotEntry>,
+    /// The published view of `slots`, for the one reader that cannot take the
+    /// Lua state: a tool call on the agent's thread.
+    layered: Arc<LayeredTools>,
 }
 
 impl SlotStore {
+    pub fn new(layered: Arc<LayeredTools>) -> Self {
+        Self {
+            slots: HashMap::new(),
+            layered,
+        }
+    }
+
     pub fn clear_plugin(&mut self, plugin: &str) {
         for entry in self.slots.values_mut() {
             entry.layers.retain(|l| l.plugin.as_ref() != plugin);
@@ -38,6 +57,40 @@ impl SlotStore {
         }
         self.slots
             .retain(|_, e| e.owner.is_some() || !e.layers.is_empty());
+        self.publish();
+    }
+
+    /// Rebuilds the published index from `slots`, which stays the only thing
+    /// anyone writes. Every mutation ends here, so a tool call never reads a
+    /// layer a reload took away, or misses one it just added.
+    fn publish(&self) {
+        let mut stages = StageSets::default();
+        for (name, entry) in &self.slots {
+            if entry.layers.is_empty() {
+                continue;
+            }
+            if let Some((tool, stage)) = host_slot_target(name) {
+                stages[stage as usize].insert(Arc::from(tool));
+            }
+        }
+        self.layered.0.store(Arc::new(stages));
+    }
+}
+
+type StageSets = [HashSet<Arc<str>>; HookStage::ALL.len()];
+
+/// Which tools have a layer on which stage, keyed by tool rather than by slot
+/// name so the check every tool call makes costs one atomic load and one
+/// lookup, with nothing formatted and nothing allocated.
+///
+/// Owned by the runtime that created the [`SlotStore`], so two plugin hosts in
+/// one process each answer for their own layers.
+#[derive(Default)]
+pub struct LayeredTools(ArcSwap<StageSets>);
+
+impl LayeredTools {
+    pub fn wraps(&self, tool: &str, stage: HookStage) -> bool {
+        self.0.load()[stage as usize].contains(tool)
     }
 }
 
@@ -66,37 +119,50 @@ fn slot_store_mut(lua: &Lua) -> LuaResult<mlua::AppDataRefMut<'_, SlotStore>> {
         .ok_or_else(|| mlua::Error::runtime("slot store not initialized"))
 }
 
-fn make_prev(
-    lua: &Lua,
-    name: &str,
-    default: &Function,
-    layers: &Arc<[SlotLayer]>,
-    rest: usize,
-    state: &PrevCell,
-) -> LuaResult<Function> {
-    let name = name.to_owned();
-    let default = default.clone();
-    let layers = Arc::clone(layers);
+/// The innermost call of a host-fired chain: no plugin owns those slots, so
+/// the arguments fall through unchanged when every layer defers.
+fn identity_default(lua: &Lua) -> LuaResult<Function> {
+    lua.create_function(|_, args: MultiValue| Ok(args))
+}
+
+/// Everything a chain needs except its position in it. Bundled because
+/// `create_async_function` wants an owned copy per call, and the alternative is
+/// cloning four captures by hand at every hop.
+#[derive(Clone)]
+struct Chain {
+    lua: Lua,
+    name: Arc<str>,
+    default: Function,
+    layers: Arc<[SlotLayer]>,
+}
+
+fn make_prev(chain: &Chain, rest: usize, state: &PrevCell) -> LuaResult<Function> {
+    let owned = chain.clone();
     let state = Arc::clone(state);
-    lua.create_function(
-        move |lua, args: MultiValue| match take_state(&state, PrevState::Running) {
-            PrevState::Armed => {
-                let r = invoke_chain(lua, &name, &default, &layers, rest, args);
-                set_state(&state, PrevState::Done(r.clone()));
-                r
+    chain.lua.create_async_function(move |_, args: MultiValue| {
+        let chain = owned.clone();
+        let state = Arc::clone(&state);
+        async move {
+            match take_state(&state, PrevState::Running) {
+                PrevState::Armed => {
+                    let r = invoke_chain(chain, rest, args).await;
+                    set_state(&state, PrevState::Done(r.clone()));
+                    r
+                }
+                prior => {
+                    let what = match prior {
+                        PrevState::Expired => "expired",
+                        _ => "already consumed",
+                    };
+                    set_state(&state, prior);
+                    Err(mlua::Error::runtime(format!(
+                        "prev for slot '{}' {what}",
+                        chain.name
+                    )))
+                }
             }
-            prior => {
-                let what = match prior {
-                    PrevState::Expired => "expired",
-                    _ => "already consumed",
-                };
-                set_state(&state, prior);
-                Err(mlua::Error::runtime(format!(
-                    "prev for slot '{name}' {what}"
-                )))
-            }
-        },
-    )
+        }
+    })
 }
 
 /// Runs the chain so everything below a layer executes exactly once.
@@ -105,6 +171,10 @@ fn make_prev(
 /// single-shot `prev` that continues the chain. The `(default, layers)`
 /// snapshot cannot race an unload: all Lua runs on the runtime thread and
 /// unloads arrive through the request channel.
+///
+/// Layers may park, which is what lets one shell out or read a file before it
+/// decides. They run in the caller's task ([`call_swallowing`]), so the
+/// caller's cancellation and deadline reach the layers producing its answer.
 ///
 /// When a layer errors, its `prev` state tells us how far it got:
 /// - never called `prev`: skip the broken layer, run the rest with the
@@ -115,51 +185,118 @@ fn make_prev(
 /// Errors from the default propagate unwrapped: the default is the owner's
 /// own function, same as any local call.
 fn invoke_chain(
-    lua: &Lua,
-    name: &str,
-    default: &Function,
-    layers: &Arc<[SlotLayer]>,
+    chain: Chain,
     idx: usize,
     args: MultiValue,
+) -> Pin<Box<dyn Future<Output = LuaResult<MultiValue>> + Send>> {
+    Box::pin(async move {
+        let Some(layer) = idx.checked_sub(1).map(|i| chain.layers[i].clone()) else {
+            return chain.default.call_async(args).await;
+        };
+        let state: PrevCell = Arc::new(Mutex::new(PrevState::Armed));
+        let prev = make_prev(&chain, idx - 1, &state)?;
+        let mut layer_args = args.clone();
+        layer_args.push_front(Value::Function(prev));
+        let result =
+            call_swallowing::<MultiValue>(&layer.func, layer_args, &chain.name, &layer.plugin)
+                .await;
+        match (result, take_state(&state, PrevState::Expired)) {
+            (Some(r), _) => Ok(r),
+            (None, PrevState::Done(r)) => r,
+            (None, PrevState::Armed) => invoke_chain(chain, idx - 1, args).await,
+            (None, PrevState::Running | PrevState::Expired) => Err(mlua::Error::runtime(format!(
+                "prev for slot '{}' left in inconsistent state",
+                chain.name
+            ))),
+        }
+    })
+}
+
+fn snapshot(lua: &Lua, name: &str) -> Option<(Option<Function>, Arc<[SlotLayer]>)> {
+    let store = lua.app_data_ref::<SlotStore>()?;
+    let entry = store.slots.get(name)?;
+    Some((entry.default.clone(), entry.layers.as_slice().into()))
+}
+
+/// The one way into [`invoke_chain`], so no caller can start a chain without
+/// the depth bound that stops a layer from re-entering its own seam forever.
+async fn run_chain(
+    lua: &Lua,
+    name: Arc<str>,
+    default: Function,
+    layers: Arc<[SlotLayer]>,
+    args: MultiValue,
 ) -> LuaResult<MultiValue> {
-    let Some(layer) = idx.checked_sub(1).map(|i| &layers[i]) else {
-        return default.call(args);
+    let _guard = DepthGuard::enter(lua, SEAM, &name, Reentry::Task).map_err(|_| {
+        mlua::Error::runtime(format!(
+            "slot '{name}' exceeded max depth (recursive filler? call prev instead)"
+        ))
+    })?;
+    let depth = layers.len();
+    let chain = Chain {
+        lua: lua.clone(),
+        name,
+        default,
+        layers,
     };
-    let state: PrevCell = Arc::new(Mutex::new(PrevState::Armed));
-    let prev = make_prev(lua, name, default, layers, idx - 1, &state)?;
-    let mut layer_args = args.clone();
-    layer_args.push_front(Value::Function(prev));
-    let result = call_isolated::<MultiValue>(lua, &layer.func, layer_args, name, &layer.plugin);
-    match (result, take_state(&state, PrevState::Expired)) {
-        (Some(r), _) => Ok(r),
-        (None, PrevState::Done(r)) => r,
-        (None, PrevState::Armed) => invoke_chain(lua, name, default, layers, idx - 1, args),
-        (None, PrevState::Running | PrevState::Expired) => Err(mlua::Error::runtime(format!(
-            "prev for slot '{name}' left in inconsistent state"
-        ))),
+    invoke_chain(chain, depth, args).await
+}
+
+/// The slot a stage of a tool call fires: `("bash", Input)` -> `tool.bash.input`.
+pub(crate) fn host_slot_name(tool: &str, stage: HookStage) -> String {
+    format!("{HOST_PREFIX}{tool}.{}", stage.as_str())
+}
+
+/// The inverse of [`host_slot_name`]. `None` for any other name, including a
+/// `tool.` name whose suffix names no stage.
+pub(crate) fn host_slot_target(slot: &str) -> Option<(&str, HookStage)> {
+    let (tool, suffix) = slot.strip_prefix(HOST_PREFIX)?.rsplit_once('.')?;
+    let stage = HookStage::ALL.into_iter().find(|s| s.as_str() == suffix)?;
+    Some((tool, stage))
+}
+
+/// Fires a host-owned slot: same layer contract as a declared one, with an
+/// identity default nobody can replace. `allow_layer` says which plugins'
+/// layers may see it, and living in the caller keeps slots ignorant of tools
+/// and permissions.
+///
+/// `None` means nothing ran, which the identity default handing back `args`
+/// would not say: the caller has to leave the value alone rather than report a
+/// rewrite.
+pub(crate) async fn run_host_chain(
+    lua: &Lua,
+    name: &str,
+    args: MultiValue,
+    allow_layer: &dyn Fn(&str) -> bool,
+) -> LuaResult<Option<MultiValue>> {
+    let Some((_, layers)) = snapshot(lua, name) else {
+        return Ok(None);
+    };
+    let layers: Arc<[SlotLayer]> = layers
+        .iter()
+        .filter(|layer| allow_layer(&layer.plugin))
+        .cloned()
+        .collect();
+    if layers.is_empty() {
+        return Ok(None);
     }
+    run_chain(lua, Arc::from(name), identity_default(lua)?, layers, args)
+        .await
+        .map(Some)
 }
 
 /// The callable closes over `name` only and reads the store on every call,
 /// so a handle given out before a reload keeps working after it.
 fn make_callable(lua: &Lua, name: String) -> LuaResult<Function> {
-    lua.create_function(move |lua, args: MultiValue| {
-        let _guard = DepthGuard::enter(lua, "slot", &name).map_err(|_| {
-            mlua::Error::runtime(format!(
-                "slot '{name}' exceeded max depth (recursive filler? call prev instead)"
-            ))
-        })?;
-        let (default, layers): (Function, Arc<[SlotLayer]>) = {
-            let store = lua
-                .app_data_ref::<SlotStore>()
-                .ok_or_else(|| mlua::Error::runtime("slot store not initialized"))?;
-            store
-                .slots
-                .get(&name)
-                .and_then(|e| Some((e.default.clone()?, e.layers.as_slice().into())))
-                .ok_or_else(|| mlua::Error::runtime(format!("slot '{name}' is not declared")))?
-        };
-        invoke_chain(lua, &name, &default, &layers, layers.len(), args)
+    let name: Arc<str> = Arc::from(name.as_str());
+    lua.create_async_function(move |lua, args: MultiValue| {
+        let name = Arc::clone(&name);
+        async move {
+            let (default, layers) = snapshot(&lua, &name)
+                .and_then(|(default, layers)| Some((default?, layers)))
+                .ok_or_else(|| mlua::Error::runtime(format!("slot '{name}' is not declared")))?;
+            run_chain(&lua, name, default, layers, args).await
+        }
     })
 }
 
@@ -168,14 +305,15 @@ fn make_callable(lua: &Lua, name: String) -> LuaResult<Function> {
 /// `set_slot`. The returned callable runs the full chain: outermost
 /// layer first, then inward, ending at {default}.
 ///
-/// Throws if another plugin already owns a slot with the same {name}.
+/// Throws if another plugin already owns a slot with the same {name}, or
+/// if {name} starts with `"tool."`, which the host fires itself.
 ///
-/// The chain runs synchronously, so neither the default nor a layer may
-/// call a suspending API (`maki.fs.*`, `maki.fn.jobwait`,
-/// `maki.api.exec_autocmds`, ...). Parking raises "attempt to yield
-/// across metamethod/C-call boundary": from the default that error
-/// reaches your caller, from a layer it only drops that layer. Do the
-/// waiting outside the chain and pass the result in.
+/// The chain is async: the default and every layer may park (`maki.fs.*`,
+/// `maki.fn.jobwait`, `maki.agent.call_tool`, ...), and so does the
+/// returned callable. Call it from a tool handler, a command, or an
+/// autocmd, rather than from a `header` or `restore` function, which
+/// cannot wait. The chain runs in your task, so cancelling the caller
+/// cancels the layers it is waiting on.
 ///
 /// @param name string Unique slot name, e.g. `"myplugin.render"`.
 /// @param default function Default implementation, called when no layers wrap it.
@@ -192,6 +330,12 @@ fn declare_slot(
     name: String,
     default: Function,
 ) -> LuaResult<Function> {
+    if name.starts_with(HOST_PREFIX) {
+        return Err(mlua::Error::runtime(format!(
+            "slot '{name}' is host owned: '{HOST_PREFIX}' names are fired by maki itself, \
+             use set_slot to wrap one"
+        )));
+    }
     {
         let mut store = slot_store_mut(lua)?;
         let entry = store.slots.entry(name.clone()).or_default();
@@ -214,8 +358,20 @@ fn declare_slot(
 /// You can call this before the owner runs `declare_slot`. The layer
 /// is queued and attached when the slot is declared.
 ///
-/// Layers run synchronously, so one that calls a suspending API is
-/// dropped and the chain continues without it, see `declare_slot`.
+/// A layer may park, and one that throws is skipped: the chain continues
+/// as if it had returned `prev(...)` untouched, so a broken layer never
+/// takes the seam down with it.
+///
+/// Layers wrap in registration order, so the last one registered runs
+/// first and sees the value before the others do.
+///
+/// Maki fires two slots per tool itself: `tool.<name>.input` before
+/// permissions look at the call, and `tool.<name>.output` on the text it
+/// produced. Both take `function(prev, value, ctx)` and answer with a
+/// table to replace the value, nothing to leave it alone, or
+/// `nil, reason` to stop the call. Wrapping one costs the capability the
+/// tool declares, and a tool declaring none costs every permission. See
+/// [Hooks](/docs/hooks/).
 ///
 /// @param name string Slot name to wrap.
 /// @param wrapper function Layer: `function(prev, ...)`. Call `prev(...)` to continue.
@@ -226,15 +382,12 @@ fn declare_slot(
 /// end)
 #[lua_fn]
 fn set_slot(lua: &Lua, #[ctx] plugin: Arc<str>, name: String, wrapper: Function) -> LuaResult<()> {
-    slot_store_mut(lua)?
-        .slots
-        .entry(name)
-        .or_default()
-        .layers
-        .push(SlotLayer {
-            plugin: Arc::clone(&plugin),
-            func: wrapper,
-        });
+    let mut store = slot_store_mut(lua)?;
+    store.slots.entry(name).or_default().layers.push(SlotLayer {
+        plugin: Arc::clone(&plugin),
+        func: wrapper,
+    });
+    store.publish();
     Ok(())
 }
 
@@ -274,6 +427,8 @@ lua_table! {
 
 #[cfg(test)]
 mod tests {
+    use test_case::test_case;
+
     use super::*;
 
     fn noop(lua: &Lua) -> Function {
@@ -294,10 +449,30 @@ mod tests {
         }
     }
 
+    #[test_case("tool.bash.input", Some(("bash", HookStage::Input)); "input")]
+    #[test_case("tool.bash.output", Some(("bash", HookStage::Output)); "output")]
+    #[test_case("tool.mcp__srv__do.input", Some(("mcp__srv__do", HookStage::Input)); "underscored_name")]
+    #[test_case("tool.srv.do.input", Some(("srv.do", HookStage::Input)); "dotted_name")]
+    #[test_case("tool.bash.header", None; "unknown_suffix")]
+    #[test_case("tool.bash", None; "no_suffix")]
+    #[test_case("myplugin.render", None; "not_host_owned")]
+    fn host_slot_target_reads_the_wrapped_tool(slot: &str, target: Option<(&str, HookStage)>) {
+        assert_eq!(host_slot_target(slot), target);
+    }
+
+    /// The two directions have to stay each other's inverse, since dispatch
+    /// builds the name it fires and `publish` parses the names it was given.
+    #[test_case("bash", HookStage::Input ; "input")]
+    #[test_case("srv.do", HookStage::Output ; "dotted_output")]
+    fn host_slot_names_round_trip(tool: &str, stage: HookStage) {
+        let name = host_slot_name(tool, stage);
+        assert_eq!(host_slot_target(&name), Some((tool, stage)));
+    }
+
     #[test]
     fn clear_plugin_semantics() {
         let lua = Lua::new();
-        let mut store = SlotStore::default();
+        let mut store = SlotStore::new(Arc::default());
         store
             .slots
             .insert("s".into(), entry(&lua, "owner", &["a", "b"]));
@@ -320,6 +495,32 @@ mod tests {
         assert!(
             !store.slots.contains_key("solo"),
             "fully-cleared entry is dropped"
+        );
+    }
+
+    /// The published index is derived, never written to directly, so an unload
+    /// can only narrow it.
+    #[test]
+    fn publishing_follows_the_layers() {
+        let lua = Lua::new();
+        let layered: Arc<LayeredTools> = Arc::default();
+        let mut store = SlotStore::new(Arc::clone(&layered));
+        store.slots.insert(
+            host_slot_name("bash", HookStage::Input),
+            entry(&lua, "owner", &["a"]),
+        );
+        store
+            .slots
+            .insert("myplugin.render".into(), entry(&lua, "owner", &["a"]));
+        store.publish();
+        assert!(layered.wraps("bash", HookStage::Input));
+        assert!(!layered.wraps("bash", HookStage::Output));
+        assert!(!layered.wraps("myplugin.render", HookStage::Input));
+
+        store.clear_plugin("a");
+        assert!(
+            !layered.wraps("bash", HookStage::Input),
+            "the index drops with the plugin that registered the layer"
         );
     }
 }

--- a/maki-lua/src/api/util/convert.rs
+++ b/maki-lua/src/api/util/convert.rs
@@ -3,6 +3,13 @@ use serde_json::Value as JsonValue;
 
 pub(crate) const NIL_TOOL_RESULT_ERR: &str = "tool returned nil without an error message";
 
+/// How many nulls an array encoding may invent for keys the table does not
+/// hold. A JSON null arrives as an absent Lua key, so a round trip has to be
+/// able to put a few back, but nothing bounds the largest key a table carries.
+/// Past this the table is a sparse map, not an array, and the object encoding
+/// keeps every key while allocating per entry.
+const MAX_ARRAY_HOLES: usize = 4096;
+
 pub(crate) fn lua_tool_result(values: mlua::MultiValue) -> Result<String, String> {
     let mut iter = values.into_iter();
     match iter.next() {
@@ -58,6 +65,28 @@ pub(crate) fn json_to_lua(lua: &Lua, value: &JsonValue) -> LuaResult<Value> {
 /// Symmetric counterpart to [`json_to_lua`]. We avoid mlua's `from_value`
 /// for the same `arbitrary_precision` reason documented above.
 pub(crate) fn lua_to_json(lua: &Lua, val: &Value) -> LuaResult<JsonValue> {
+    within_template(lua, val, None)
+}
+
+/// [`lua_to_json`], guided by the JSON that [`json_to_lua`] built `val` from:
+/// whatever the Lua side produced wins, and a null the Lua side left absent is
+/// restored from `template`.
+///
+/// A JSON null arrives as a Lua nil, and assigning nil to a table key is a
+/// no-op, so a layer never sees a null and cannot hand one back. They have to
+/// be carried across instead. Guiding stops wherever the two sides stop being
+/// the same container kind, so a layer that swapped a subtree for a scalar owns
+/// it outright. The price: a layer cannot delete a key whose value is null, it
+/// comes back, while deleting a key holding a real value works.
+pub(crate) fn lua_to_json_within(
+    lua: &Lua,
+    val: &Value,
+    template: &JsonValue,
+) -> LuaResult<JsonValue> {
+    within_template(lua, val, Some(template))
+}
+
+fn within_template(lua: &Lua, val: &Value, template: Option<&JsonValue>) -> LuaResult<JsonValue> {
     Ok(match val {
         Value::Nil => JsonValue::Null,
         Value::Boolean(b) => JsonValue::Bool(*b),
@@ -67,11 +96,16 @@ pub(crate) fn lua_to_json(lua: &Lua, val: &Value) -> LuaResult<JsonValue> {
             .unwrap_or(JsonValue::Null),
         Value::String(s) => JsonValue::String(s.to_str()?.to_owned()),
         Value::Table(tbl) => {
-            // A table serializes as a JSON array only when every key is a
-            // positive integer and they are dense from 1 (count == max), so no
-            // string key silently disappears and sparse tables like
+            // An untagged table serializes as a JSON array only when every key
+            // is a positive integer and they are dense from 1 (count == max),
+            // so no string key silently disappears and sparse tables like
             // `{ [1] = "a", [3] = "c" }` deterministically become objects
             // (`lua_rawlen` borders are implementation-defined for those).
+            // The array metatable outranks that, since `json_to_lua` writes it
+            // on every JSON array and a null element leaves an absent key:
+            // density cannot be re-derived, and the gaps are holes to fill with
+            // null. Keys an array cannot express still fall back to the object
+            // encoding, which keeps all of them.
             let mut has_non_int = false;
             let mut int_count = 0;
             let mut max_int = 0;
@@ -88,18 +122,37 @@ pub(crate) fn lua_to_json(lua: &Lua, val: &Value) -> LuaResult<JsonValue> {
                 entries.push((k, v));
             }
 
+            let tagged = tbl.metatable().as_ref() == Some(&lua.array_metatable());
+            // Slots the entries do not pay for. The array encoding has to
+            // materialize every one of them, and the largest key alone decides
+            // how many, so this is the only thing standing between
+            // `decoded[os.time()] = 1` and an allocation the size of a clock.
+            let holes = max_int - int_count;
             let is_array = !has_non_int
-                && int_count == max_int
-                && (int_count > 0 || tbl.metatable().as_ref() == Some(&lua.array_metatable()));
+                && if tagged {
+                    holes <= MAX_ARRAY_HOLES
+                } else {
+                    int_count > 0 && holes == 0
+                };
             if is_array {
-                let mut arr = vec![JsonValue::Null; int_count];
+                let template = template.and_then(JsonValue::as_array);
+                // A trailing null never moved `max_int`, so only the template
+                // knows the array ran on past the last key the Lua side kept.
+                // A trailing non-null there was a real value the layer dropped.
+                let mut len = max_int;
+                while template.is_some_and(|t| t.get(len).is_some_and(JsonValue::is_null)) {
+                    len += 1;
+                }
+                let mut arr = vec![JsonValue::Null; len];
                 for (k, v) in entries {
                     let Value::Integer(i) = k else { unreachable!() };
-                    arr[i as usize - 1] = lua_to_json(lua, &v)?;
+                    let idx = i as usize - 1;
+                    arr[idx] = within_template(lua, &v, template.and_then(|t| t.get(idx)))?;
                 }
                 return Ok(JsonValue::Array(arr));
             }
 
+            let template = template.and_then(JsonValue::as_object);
             let mut map = serde_json::Map::new();
             for (k, v) in entries {
                 let key = match k {
@@ -109,7 +162,11 @@ pub(crate) fn lua_to_json(lua: &Lua, val: &Value) -> LuaResult<JsonValue> {
                     Value::Boolean(b) => b.to_string(),
                     _ => continue,
                 };
-                map.insert(key, lua_to_json(lua, &v)?);
+                let child = template.and_then(|t| t.get(&key));
+                map.insert(key, within_template(lua, &v, child)?);
+            }
+            for (key, _) in template.into_iter().flatten().filter(|(_, v)| v.is_null()) {
+                map.entry(key.as_str()).or_insert(JsonValue::Null);
             }
             JsonValue::Object(map)
         }
@@ -123,7 +180,11 @@ mod tests {
     use serde_json::Value as JsonValue;
     use test_case::test_case;
 
-    use super::{json_to_lua, lua_to_json};
+    use super::{MAX_ARRAY_HOLES, json_to_lua, lua_to_json, lua_to_json_within};
+
+    /// The name `LAYER_CASES` snippets edit through, standing in for the
+    /// `value` argument a real hook layer is handed.
+    const LAYER_GLOBAL: &str = "value";
 
     #[test_case(Value::Nil, JsonValue::Null ; "nil_to_null")]
     #[test_case(Value::Boolean(true), JsonValue::Bool(true) ; "bool_true")]
@@ -233,6 +294,27 @@ mod tests {
         assert_eq!(result, serde_json::json!({"1": 10, "2": 20, "total": 5}));
     }
 
+    /// The array encoding materializes every hole, and the largest key alone
+    /// says how many, so a table used as a sparse map has to leave the encoding
+    /// rather than allocate up to its key. Nothing is lost: the object keeps
+    /// every entry.
+    #[test_case(MAX_ARRAY_HOLES,     true  ; "holes_the_entries_can_carry")]
+    #[test_case(MAX_ARRAY_HOLES + 1, false ; "a_key_too_far_falls_back_to_object")]
+    fn lua_to_json_array_encoding_bounds_the_holes_it_invents(holes: usize, array: bool) {
+        let lua = Lua::new();
+        let value = json_to_lua(&lua, &serde_json::json!([1])).unwrap();
+        let key = holes + 2;
+        value.as_table().unwrap().set(key, 2).unwrap();
+
+        let result = lua_to_json(&lua, &value).unwrap();
+        assert_eq!(result.is_array(), array);
+        assert_eq!(
+            result.get(key - 1).or_else(|| result.get(key.to_string())),
+            Some(&serde_json::json!(2)),
+            "either encoding keeps the entry"
+        );
+    }
+
     #[test]
     fn lua_to_json_mixed_table_becomes_object() {
         let lua = Lua::new();
@@ -272,6 +354,9 @@ mod tests {
         "[]",
         r#"{}"#,
         r#"{"a":1,"b":[true,"x"]}"#,
+        "[1,null,3]",
+        "[[],{}]",
+        r#"{"a":[1,2,null,3]}"#,
     ];
 
     #[test_case(0 ; "null")]
@@ -283,11 +368,76 @@ mod tests {
     #[test_case(6 ; "empty_array")]
     #[test_case(7 ; "empty_object")]
     #[test_case(8 ; "nested_object")]
+    #[test_case(9 ; "array_with_interior_null")]
+    #[test_case(10 ; "nested_empty_containers")]
+    #[test_case(11 ; "object_holding_array_with_null")]
     fn lua_to_json_roundtrip(idx: usize) {
         let original: JsonValue = serde_json::from_str(ROUNDTRIP_CASES[idx]).unwrap();
         let lua = Lua::new();
         let lua_val = json_to_lua(&lua, &original).unwrap();
         let back = lua_to_json(&lua, &lua_val).unwrap();
         assert_eq!(back, original);
+    }
+
+    /// A layer sees no null at all, so a pass-through of any input has to come
+    /// back exactly as it went in.
+    const TEMPLATE_IDENTITY_CASES: &[&str] = &[
+        r#"{"a":null,"b":1}"#,
+        "[1,null]",
+        "[null]",
+        r#"{"a":[1,null]}"#,
+        "[1,null,3]",
+        "{}",
+        "[]",
+        r#"{"a":{"b":null,"c":[null,{"d":null},null]},"e":[[null],null],"f":null}"#,
+    ];
+
+    #[test_case(0 ; "object_with_null")]
+    #[test_case(1 ; "array_with_trailing_null")]
+    #[test_case(2 ; "array_of_one_null")]
+    #[test_case(3 ; "nested_array_with_trailing_null")]
+    #[test_case(4 ; "array_with_interior_null")]
+    #[test_case(5 ; "empty_object")]
+    #[test_case(6 ; "empty_array")]
+    #[test_case(7 ; "deeply_nested_mix")]
+    fn lua_to_json_within_template_roundtrips_nulls(idx: usize) {
+        let original: JsonValue = serde_json::from_str(TEMPLATE_IDENTITY_CASES[idx]).unwrap();
+        let lua = Lua::new();
+        let lua_val = json_to_lua(&lua, &original).unwrap();
+
+        let back = lua_to_json_within(&lua, &lua_val, &original).unwrap();
+        assert_eq!(back, original);
+    }
+
+    /// `(template, what the layer does to it, what the caller must get back)`.
+    const LAYER_CASES: &[(&str, &str, &str)] = &[
+        ("[1,2,3]", "value[3] = nil", "[1,2]"),
+        (
+            r#"{"a":null,"b":1}"#,
+            r#"value.a = "x""#,
+            r#"{"a":"x","b":1}"#,
+        ),
+        (
+            r#"{"a":{"b":null},"c":2}"#,
+            "value.a = 1",
+            r#"{"a":1,"c":2}"#,
+        ),
+        (r#"{"a":null,"b":1}"#, "value.b = nil", r#"{"a":null}"#),
+    ];
+
+    #[test_case(0 ; "truncating_a_real_value_shortens_the_array")]
+    #[test_case(1 ; "a_null_replaced_by_a_value_keeps_the_value")]
+    #[test_case(2 ; "an_object_replaced_by_a_scalar_ends_the_template")]
+    #[test_case(3 ; "deleting_a_non_null_key_still_deletes_it")]
+    fn lua_to_json_within_template_lets_the_layer_win(idx: usize) {
+        let (template, edit, expected) = LAYER_CASES[idx];
+        let template: JsonValue = serde_json::from_str(template).unwrap();
+        let lua = Lua::new();
+        let lua_val = json_to_lua(&lua, &template).unwrap();
+        lua.globals().set(LAYER_GLOBAL, lua_val.clone()).unwrap();
+        lua.load(edit).exec().unwrap();
+
+        let result = lua_to_json_within(&lua, &lua_val, &template).unwrap();
+        assert_eq!(result, serde_json::from_str::<JsonValue>(expected).unwrap());
     }
 }

--- a/maki-lua/src/api/util/dispatch.rs
+++ b/maki-lua/src/api/util/dispatch.rs
@@ -2,13 +2,46 @@ use std::collections::HashMap;
 
 use mlua::{FromLuaMulti, Function, IntoLuaMulti, Lua};
 
-use crate::runtime::{TaskScope, strip_traceback};
+use crate::runtime::{TaskHandle, lock_cell, strip_traceback};
 
-pub(crate) const MAX_HOOK_DEPTH: u8 = 8;
+pub const MAX_HOOK_DEPTH: u8 = 8;
+
+/// Tasks are numbered from 1, so this one means "outside any task". Plugin
+/// load and the other startup paths live there, one at a time.
+const NO_TASK: u64 = 0;
+
+/// What a depth count is scoped to. A seam either keeps its callbacks in the
+/// caller's task or hands each one a fresh task, and only the seam knows
+/// which.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub(crate) enum Reentry {
+    /// One count for the whole VM, for seams that detach every callback
+    /// (autocmds). A refire shares no task with the fire it came from, so
+    /// nothing narrower could see it.
+    Vm,
+    /// One count per Lua task, for seams whose chain runs inside the caller's
+    /// task (slots). Re-entering stays in one task while two chains at once
+    /// are two tasks, and counting those together would read a wide `batch` as
+    /// recursion and drop layers it should have run. So this bounds re-entry
+    /// within one chain, never a cycle across calls: a chain fired again by a
+    /// fresh tool call is a fresh task, bounded by that call's window instead.
+    Task,
+}
+
+impl Reentry {
+    fn task(self, lua: &Lua) -> u64 {
+        match self {
+            Self::Vm => NO_TASK,
+            Self::Task => lua
+                .app_data_ref::<TaskHandle>()
+                .map_or(NO_TASK, |handle| lock_cell(&handle).id),
+        }
+    }
+}
 
 #[derive(Default)]
 pub(crate) struct DepthStore {
-    depths: HashMap<(&'static str, String), u8>,
+    depths: HashMap<(&'static str, String, u64), u8>,
 }
 
 #[derive(Debug)]
@@ -18,25 +51,31 @@ pub(crate) struct DepthExceeded;
 /// path can never leave the depth stuck high.
 pub(crate) struct DepthGuard {
     lua: Lua,
-    key: (&'static str, String),
+    key: (&'static str, String, u64),
 }
 
 impl DepthGuard {
-    pub(crate) fn enter(lua: &Lua, kind: &'static str, name: &str) -> Result<Self, DepthExceeded> {
+    pub(crate) fn enter(
+        lua: &Lua,
+        kind: &'static str,
+        name: &str,
+        scope: Reentry,
+    ) -> Result<Self, DepthExceeded> {
         if lua.app_data_ref::<DepthStore>().is_none() {
             lua.set_app_data(DepthStore::default());
         }
+        let key = (kind, name.to_owned(), scope.task(lua));
         let mut store = lua
             .app_data_mut::<DepthStore>()
             .expect("DepthStore just ensured");
-        let depth = store.depths.entry((kind, name.to_owned())).or_insert(0);
+        let depth = store.depths.entry(key.clone()).or_insert(0);
         if *depth >= MAX_HOOK_DEPTH {
             return Err(DepthExceeded);
         }
         *depth += 1;
         Ok(Self {
             lua: lua.clone(),
-            key: (kind, name.to_owned()),
+            key,
         })
     }
 }
@@ -55,19 +94,19 @@ impl Drop for DepthGuard {
 }
 
 /// Calls a plugin callback so its failure stays its own: errors are logged
-/// with plugin and seam name, then swallowed. The detached [`TaskScope`]
-/// matters here, because a callback that inherits the firer's scope gets
-/// cancelled when the firer's task dies, and plugin B should not pay for
-/// plugin A's crash.
-pub(crate) fn call_isolated<R: FromLuaMulti>(
-    lua: &Lua,
+/// with plugin and seam name, then swallowed.
+///
+/// Runs in the caller's task, not a detached one. Every seam using this waits
+/// for the answer, so the caller's cancellation and deadline belong on the
+/// callback producing it, and [`Reentry::Task`] only tells nesting from
+/// concurrency while nesting stays inside one task.
+pub(crate) async fn call_swallowing<R: FromLuaMulti>(
     func: &Function,
     args: impl IntoLuaMulti,
     seam: &str,
     plugin: &str,
 ) -> Option<R> {
-    let _scope = TaskScope::detached(lua);
-    match func.call::<R>(args) {
+    match func.call_async::<R>(args).await {
         Ok(r) => Some(r),
         Err(e) => {
             tracing::warn!(seam, plugin, error = %strip_traceback(&e), "plugin callback failed");
@@ -78,28 +117,57 @@ pub(crate) fn call_isolated<R: FromLuaMulti>(
 
 #[cfg(test)]
 mod tests {
+    use crate::runtime::TaskScope;
+
     use super::*;
 
-    #[test]
-    fn depth_guard_enforces_max_and_unwinds() {
+    const SEAM: &str = "seam";
+
+    #[test_case::test_case(Reentry::Vm ; "vm")]
+    #[test_case::test_case(Reentry::Task ; "task")]
+    fn depth_guard_enforces_max_and_unwinds(scope: Reentry) {
         let lua = Lua::new();
         let guards: Vec<_> = (0..MAX_HOOK_DEPTH)
-            .map(|_| DepthGuard::enter(&lua, "test", "seam").expect("within bound"))
+            .map(|_| DepthGuard::enter(&lua, "test", SEAM, scope).expect("within bound"))
             .collect();
-        assert!(DepthGuard::enter(&lua, "test", "seam").is_err());
-        assert!(DepthGuard::enter(&lua, "test", "other").is_ok());
+        assert!(DepthGuard::enter(&lua, "test", SEAM, scope).is_err());
+        assert!(DepthGuard::enter(&lua, "test", "other", scope).is_ok());
         drop(guards);
-        assert!(DepthGuard::enter(&lua, "test", "seam").is_ok());
+        assert!(DepthGuard::enter(&lua, "test", SEAM, scope).is_ok());
         let store = lua.app_data_ref::<DepthStore>().unwrap();
         assert!(store.depths.is_empty(), "zero entries removed");
     }
 
+    /// Chains running at once are separate tasks and never add up, while
+    /// nesting inside one of them still trips the bound.
     #[test]
-    fn call_isolated_swallows_errors() {
+    fn task_scoped_depth_separates_concurrency_from_nesting() {
+        let lua = Lua::new();
+        let concurrent: Vec<_> = (0..=MAX_HOOK_DEPTH)
+            .map(|_| {
+                let scope = TaskScope::detached(&lua);
+                let guard = DepthGuard::enter(&lua, "test", SEAM, Reentry::Task)
+                    .expect("a fresh task starts at zero");
+                (scope, guard)
+            })
+            .collect();
+        let nested: Vec<_> = (1..MAX_HOOK_DEPTH)
+            .map(|_| {
+                DepthGuard::enter(&lua, "test", SEAM, Reentry::Task).expect("within the bound")
+            })
+            .collect();
+        assert!(DepthGuard::enter(&lua, "test", SEAM, Reentry::Task).is_err());
+        drop((concurrent, nested));
+    }
+
+    #[test]
+    fn call_swallowing_hides_errors_but_not_values() {
         let lua = Lua::new();
         let bad: Function = lua.load("error('boom')").into_function().unwrap();
         let ok: Function = lua.load("return 7").into_function().unwrap();
-        assert!(call_isolated::<i64>(&lua, &bad, (), "seam", "p").is_none());
-        assert_eq!(call_isolated::<i64>(&lua, &ok, (), "seam", "p"), Some(7));
+        smol::block_on(async {
+            assert!(call_swallowing::<i64>(&bad, (), SEAM, "p").await.is_none());
+            assert_eq!(call_swallowing::<i64>(&ok, (), SEAM, "p").await, Some(7));
+        });
     }
 }

--- a/maki-lua/src/hook.rs
+++ b/maki-lua/src/hook.rs
@@ -1,0 +1,59 @@
+//! The bridge between [`maki_agent::tools::hook`] and the slot chains plugins
+//! register. Everything here is a hop: dispatch asks, the Lua thread answers,
+//! and nothing decides anything on the way.
+
+use std::sync::Arc;
+
+use flume::Sender;
+use maki_agent::tools::hook::{HookCall, HookStage, ToolHook, Verdict};
+use maki_agent::tools::registry::BoxFuture;
+use serde_json::{Value, json};
+
+use crate::api::slot::{LayeredTools, host_slot_name};
+use crate::runtime::{HookRun, Request};
+
+pub(crate) struct SlotHook {
+    pub(crate) tx: Sender<Request>,
+    pub(crate) layered: Arc<LayeredTools>,
+}
+
+impl ToolHook for SlotHook {
+    fn wraps(&self, tool: &str, stage: HookStage) -> bool {
+        self.layered.wraps(tool, stage)
+    }
+
+    fn run<'a>(
+        &'a self,
+        stage: HookStage,
+        value: Value,
+        call: &'a HookCall<'a>,
+    ) -> BoxFuture<'a, Verdict> {
+        let (reply, answer) = flume::bounded(1);
+        let request = Request::RunHook {
+            run: HookRun {
+                slot: host_slot_name(call.tool, stage),
+                authority: call.authority,
+                cancel: call.cancel.clone(),
+                deadline: call.deadline,
+                value,
+                // The `ctx` table a layer receives.
+                call: json!({
+                    "tool": call.tool,
+                    "tool_id": call.tool_id,
+                    "session_id": call.session_id,
+                    "origin": call.origin.as_str(),
+                }),
+            },
+            reply,
+        };
+        // A runtime that is gone, or one that drops the request on the way
+        // down, leaves the call as it found it. A missing opinion about a
+        // call is not a failure of that call.
+        Box::pin(async move {
+            if self.tx.send_async(request).await.is_err() {
+                return Verdict::Unchanged;
+            }
+            answer.recv_async().await.unwrap_or(Verdict::Unchanged)
+        })
+    }
+}

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -2,6 +2,7 @@ mod api;
 pub mod docs;
 pub mod docs_render;
 mod error;
+mod hook;
 pub mod language;
 mod loader;
 mod pack;
@@ -35,6 +36,7 @@ pub mod test_support {
     use crate::api::util::command::{
         HintEntries, HintReader, HintWriter, LuaCommandInfo, LuaCommandReader, LuaCommandWriter,
     };
+    pub use crate::api::util::dispatch::MAX_HOOK_DEPTH;
     use maki_storage::id::MakiId;
 
     pub struct LuaCommandWriterHandle(LuaCommandWriter);

--- a/maki-lua/src/plugin_permissions.rs
+++ b/maki-lua/src/plugin_permissions.rs
@@ -50,6 +50,12 @@ impl PluginPermissions {
         self.allowed[perm as usize]
     }
 
+    /// Layering a call whose reach nobody declared takes full trust, since no
+    /// narrower price would be honest.
+    pub fn holds_all(&self) -> bool {
+        self.allowed.iter().all(|&allowed| allowed)
+    }
+
     pub fn from_manifest(manifest: &toml::Value) -> Self {
         let perms = manifest.get("permissions");
         let mut allowed = [true; Permission::COUNT];

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -18,13 +18,17 @@ use include_dir::Dir;
 use maki_agent::cancel::CancelToken;
 use maki_agent::permissions::PluginRuleStore;
 use maki_agent::prompt::{PromptId, ResolvedSlots, Slot, SlotEntry};
+use maki_agent::tools::hook::{Authority, Verdict};
 use maki_agent::tools::{
     HeaderResult, PermissionScopes, RegistryError, Tool, ToolLive, ToolRegistry, ToolSource,
 };
 use maki_agent::{
     BufferSnapshot, SessionEndReason, SharedBuf, SnapshotLine, SnapshotSpan, SpanStyle,
 };
-use mlua::{Chunk, ChunkMode, Compiler, Function, Lua, RegistryKey, Table, Value as LuaValue, ffi};
+use mlua::{
+    Chunk, ChunkMode, Compiler, Function, Lua, MultiValue, RegistryKey, Table, Value as LuaValue,
+    ffi,
+};
 use serde_json::Value;
 
 use maki_config::RawConfig;
@@ -36,7 +40,7 @@ use crate::api::r#fn::{JobEvent, JobOwner, JobStore, deliver_job_event};
 use crate::api::keymap::KeymapReader;
 use crate::api::keymap::{KeymapStore, KeymapWriter};
 use crate::api::options::{PluginOptionSpecs, PluginOpts, collect_plugin_options};
-use crate::api::slot::SlotStore;
+use crate::api::slot::{LayeredTools, SlotStore, run_host_chain};
 use crate::api::tool::{
     LuaTool, PendingRules, PendingTool, PendingTools, ToolCallReply, ToolPermission, resolve_rules,
 };
@@ -46,7 +50,7 @@ use crate::api::util::command::{CommandHandlerMap, HintWriter, publish_command_s
 use crate::api::util::command::{
     LuaCommandReader, LuaCommandWriter, UiAction, UiAttachment, install_ui_attachment,
 };
-use crate::api::util::convert::json_to_lua;
+use crate::api::util::convert::{json_to_lua, lua_to_json_within};
 use crate::api::util::ctx::LuaCtx;
 use crate::api::util::setup::ConfigStore;
 use crate::docs_render;
@@ -208,6 +212,19 @@ enum PluginLoad<'a> {
     Function { function: Function, argument: Table },
 }
 
+/// One firing of a host-owned slot, as the call being filtered described it.
+pub(crate) struct HookRun {
+    pub slot: String,
+    pub authority: Authority,
+    /// The filtered call's own cancellation and window. The chain runs on the
+    /// Lua thread, so without them nothing here knows when the caller stopped
+    /// waiting, and a layer that parks outlives the call it filters.
+    pub cancel: CancelToken,
+    pub deadline: Instant,
+    pub value: Value,
+    pub call: Value,
+}
+
 /// Load/clear drain in-flight tools first so we never mutate a
 /// plugin environment while a tool call is still running.
 pub enum Request {
@@ -255,6 +272,13 @@ pub enum Request {
         tool: Arc<str>,
         input: Value,
         reply: flume::Sender<Option<PermissionScopes>>,
+    },
+    /// A host-owned slot chain (`tool.<name>.input`, `tool.<name>.output`).
+    /// Only sent when the slot has layers, so the idle case never reaches the
+    /// request loop at all.
+    RunHook {
+        run: HookRun,
+        reply: flume::Sender<Verdict>,
     },
     ClearPlugin {
         plugin: Arc<str>,
@@ -1076,6 +1100,37 @@ pub(crate) async fn run_detached<F: Future>(lua: &Lua, fut: F) -> F::Output {
     run_scoped(lua, TaskScope::detached(lua), fut).await
 }
 
+/// [`run_detached`] for plugin code a host caller is blocked on, carrying every
+/// obligation that waiting creates:
+///
+/// - counted against the [`InflightGate`], so a reload drains the code instead
+///   of tearing its environment away;
+/// - [`covered`], so a tool call the code makes rides this slot rather than
+///   queueing behind a gate its own caller is holding;
+/// - scoped to the caller's cancellation and `deadline`, so the watchdog can
+///   interrupt code that spins past either;
+/// - [`until_abandoned`], the only thing that ends code parked in an await,
+///   which runs no Lua for the watchdog to interrupt.
+///
+/// Four properties one call away, so a request handler cannot pick up three and
+/// quietly miss the fourth. `Err` says why the wait ended, never how the code
+/// fared.
+async fn run_awaited<F: Future>(
+    lua: &Lua,
+    gate: &Rc<InflightGate>,
+    cancel: CancelToken,
+    deadline: Instant,
+    fut: F,
+) -> Result<F::Output, &'static str> {
+    let scope = TaskScope::new(lua, TaskCell::new(cancel, Some(deadline), None));
+    let handle = Arc::clone(scope.handle());
+    covered(
+        Some(GateGuard::new(gate)),
+        until_abandoned(run_scoped(lua, scope, fut), &handle),
+    )
+    .await
+}
+
 /// [`run_detached`] for a slash-command handler, seeding the hop count that
 /// `maki.api.run_command` checks before extending the chain.
 pub(crate) async fn run_command_scoped<F: Future>(lua: &Lua, depth: u8, fut: F) -> F::Output {
@@ -1598,14 +1653,15 @@ impl SpawnQueue {
 }
 
 /// Ends `fut` once nobody waits for its reply any more: at `deadline`, or
-/// [`CANCEL_ABANDON_AFTER`] past a cancel. The watchdog cannot do this on
-/// its own, because a task parked in an await runs no Lua to interrupt and
-/// renews its grace at every yield. `or`, not `race`: a handler that
-/// finished in the same slice deserves to have its result reported.
-async fn until_abandoned(
-    fut: impl Future<Output = Result<LuaValue, mlua::Error>>,
+/// [`CANCEL_ABANDON_AFTER`] past a cancel, answering with why. The watchdog
+/// cannot do this on its own, because a task parked in an await runs no Lua
+/// to interrupt and renews its grace at every yield. `or`, not `race`: a
+/// handler that finished in the same slice deserves to have its result
+/// reported, even one whose deadline had already lapsed when it started.
+async fn until_abandoned<T>(
+    fut: impl Future<Output = T>,
     handle: &TaskHandle,
-) -> Result<LuaValue, mlua::Error> {
+) -> Result<T, &'static str> {
     let cancel = lock_cell(handle).cancel.clone();
     let timed_out = async {
         loop {
@@ -1629,10 +1685,8 @@ async fn until_abandoned(
         smol::Timer::after(CANCEL_ABANDON_AFTER).await;
         CANCELLED_MSG
     };
-    futures_lite::future::or(fut, async {
-        Err(mlua::Error::runtime(
-            futures_lite::future::or(timed_out, cancelled).await,
-        ))
+    futures_lite::future::or(async { Ok(fut.await) }, async {
+        Err(futures_lite::future::or(timed_out, cancelled).await)
     })
     .await
 }
@@ -1644,7 +1698,9 @@ async fn run_work_fn(
 ) -> Result<LuaValue, mlua::Error> {
     let func: Function = lua.registry_value(work_fn)?;
     let fut = lua.create_thread(func)?.into_async::<LuaValue>(())?;
-    until_abandoned(fut, handle).await
+    until_abandoned(fut, handle)
+        .await
+        .unwrap_or_else(|msg| Err(mlua::Error::runtime(msg)))
 }
 
 fn spawn_async_task(
@@ -1740,6 +1796,9 @@ struct ToolKeys {
 struct PluginOwner {
     tools: HashMap<Arc<str>, ToolKeys>,
     revision_guard: Option<Arc<maki_pack::lock::Lock>>,
+    /// What this load granted the plugin. Kept past the load so a slot layer
+    /// can be weighed against the authority of each call it filters.
+    permissions: PluginPermissions,
 }
 
 type PluginMap = Rc<RefCell<HashMap<Arc<str>, PluginOwner>>>;
@@ -1810,7 +1869,12 @@ impl LuaRuntime {
         lua.set_app_data(PluginOptionSpecs::default());
         lua.set_app_data(crate::api::pack::PackStore::default());
         lua.set_app_data(AutocmdStore::default());
-        lua.set_app_data(SlotStore::default());
+        let layered: Arc<LayeredTools> = Arc::default();
+        lua.set_app_data(SlotStore::new(Arc::clone(&layered)));
+        registry.set_hook(crate::hook::SlotHook {
+            tx: tx.clone(),
+            layered,
+        });
         lua.set_app_data(KeymapStore::new());
         lua.set_app_data(keymap_writer);
         lua.set_app_data(HintStore::new());
@@ -2292,6 +2356,7 @@ impl LuaRuntime {
             PluginOwner {
                 tools: keys,
                 revision_guard,
+                permissions,
             },
         );
         if package {
@@ -2798,6 +2863,111 @@ fn run_describe(
     }
 }
 
+/// Whether a plugin may layer this host slot at all.
+///
+/// A layer on `tool.<name>.input` rewrites the call the tool then makes, so it
+/// borrows that call's [`Authority`] and has to already hold it. Without this,
+/// a plugin denied `run` could turn any bash command into its own.
+///
+/// Decided when the chain fires rather than when the layer is registered,
+/// because a layer may legitimately be set before its target tool exists, and
+/// permissions a reload narrows take effect on the very next call.
+fn layer_delegation<'a>(
+    plugins: &'a PluginMap,
+    authority: Authority,
+    slot: &'a str,
+) -> impl Fn(&str) -> bool + 'a {
+    move |plugin| {
+        let loaded = plugins.borrow();
+        let granted = loaded.get(plugin).map(|owner| &owner.permissions);
+        let held = match authority {
+            Authority::Capability(required) => granted.is_some_and(|p| p.is_allowed(required)),
+            // Steering a call whose reach nobody declared takes every
+            // capability: a meta-tool like `batch` names none and reaches all.
+            Authority::Unbounded => granted.is_some_and(PluginPermissions::holds_all),
+        };
+        if !held {
+            // Every call of a layered tool re-decides this, so a warning here
+            // would repeat for the life of the misconfiguration.
+            tracing::debug!(plugin, slot, ?authority, "slot layer skipped: not granted");
+        }
+        held
+    }
+}
+
+/// Fires a host-owned chain and reads back the one contract every host slot
+/// shares: a table replaces the value, `nil` leaves it alone, and
+/// `nil, reason` stops the call with a reason the model reads.
+///
+/// Every failure below is a pass-through, because a layer is an opinion about a
+/// call and never a precondition for making it.
+///
+/// [`run_awaited`] is what makes the chain answerable to the call waiting on
+/// it, down to a layer that never comes back ending at the window dispatch
+/// gave it.
+async fn run_hook(
+    lua: &Lua,
+    plugins: &PluginMap,
+    gate: &Rc<InflightGate>,
+    run: HookRun,
+) -> Verdict {
+    let HookRun {
+        slot,
+        authority,
+        cancel,
+        deadline,
+        value,
+        call,
+    } = run;
+    let slot = slot.as_str();
+    let args = match (json_to_lua(lua, &value), json_to_lua(lua, &call)) {
+        (Ok(value), Ok(call)) => MultiValue::from_vec(vec![value, call]),
+        _ => return Verdict::Unchanged,
+    };
+    let allow_layer = layer_delegation(plugins, authority, slot);
+    let chain = run_host_chain(lua, slot, args, &allow_layer);
+    let returned = match run_awaited(lua, gate, cancel, deadline, chain).await {
+        Ok(Ok(Some(values))) => values,
+        Ok(Ok(None)) => return Verdict::Unchanged,
+        Ok(Err(e)) => {
+            tracing::warn!(slot, error = %strip_traceback(&e), "slot chain failed");
+            return Verdict::Unchanged;
+        }
+        Err(msg) => {
+            tracing::warn!(slot, reason = msg, "slot chain abandoned");
+            return Verdict::Unchanged;
+        }
+    };
+
+    let mut returned = returned.into_iter();
+    match returned.next() {
+        Some(table @ LuaValue::Table(_)) => match lua_to_json_within(lua, &table, &value) {
+            // The identity default hands back the value it was given, so a
+            // layer that only deferred returns a table too. Comparing is the
+            // only way to tell that apart from a rewrite, and it keeps the
+            // original `Value` in play instead of a re-encode of it.
+            Ok(replacement) if replacement == value => Verdict::Unchanged,
+            Ok(replacement) => Verdict::Replaced(replacement),
+            Err(e) => {
+                tracing::warn!(slot, error = %strip_traceback(&e), "slot returned a table that is not json");
+                Verdict::Unchanged
+            }
+        },
+        None | Some(LuaValue::Nil) => match returned.next() {
+            Some(LuaValue::String(reason)) => Verdict::Denied(reason.to_string_lossy()),
+            _ => Verdict::Unchanged,
+        },
+        Some(other) => {
+            tracing::warn!(
+                slot,
+                returned = other.type_name(),
+                "slot must return a table, nil, or nil plus a reason"
+            );
+            Verdict::Unchanged
+        }
+    }
+}
+
 /// Sends no `ToolSnapshot` on completion: the preview buf must stay live so
 /// the UI keeps polling it until the handler's own `LiveToolBuf` takes over.
 async fn run_tool_start(
@@ -2888,7 +3058,10 @@ async fn run_tool_call(
     }
 
     let call_future = scope.scope_future(async {
-        match until_abandoned(async_thread, &handle).await {
+        match until_abandoned(async_thread, &handle)
+            .await
+            .unwrap_or_else(|msg| Err(mlua::Error::runtime(msg)))
+        {
             Ok(LuaValue::Nil) => {
                 let (live, sink) = {
                     let cell = lock_cell(&handle);
@@ -3247,6 +3420,19 @@ pub fn spawn(
                         } => {
                             let res = rt.compute_permission_scopes(&plugin, &tool, input).await;
                             let _ = reply.send(res);
+                        }
+                        Request::RunHook { run, reply } => {
+                            // Spawned rather than awaited: a layer may park,
+                            // and every other session is waiting on this
+                            // request loop.
+                            let lua = rt.lua.clone();
+                            let plugins = Rc::clone(&rt.plugins);
+                            let gate = Rc::clone(&gate);
+                            ex.spawn(async move {
+                                let verdict = run_hook(&lua, &plugins, &gate, run).await;
+                                let _ = reply.send(verdict);
+                            })
+                            .detach();
                         }
                         Request::RunInitLua {
                             source,
@@ -4082,7 +4268,7 @@ mod tests {
     /// ahead of a result the handler already produced.
     #[test]
     fn until_abandoned_ends_a_parked_handler_only_after_its_window() {
-        let parked = || std::future::pending::<Result<LuaValue, mlua::Error>>();
+        let parked = std::future::pending::<()>;
         smol::block_on(async {
             let early = futures_lite::future::poll_once(until_abandoned(
                 parked(),
@@ -4094,16 +4280,18 @@ mod tests {
                 "a cancel must not abandon the handler before its window"
             );
 
-            let err = until_abandoned(
-                parked(),
-                &task_handle(CancelToken::none(), Some(Instant::now())),
-            )
-            .await
-            .expect_err("a lapsed deadline must end a parked handler");
-            assert!(err.to_string().contains(HANDLER_TIMEOUT_MSG));
+            assert_eq!(
+                until_abandoned(
+                    parked(),
+                    &task_handle(CancelToken::none(), Some(Instant::now())),
+                )
+                .await
+                .expect_err("a lapsed deadline must end a parked handler"),
+                HANDLER_TIMEOUT_MSG
+            );
 
             until_abandoned(
-                std::future::ready(Ok(LuaValue::Boolean(true))),
+                std::future::ready(()),
                 &task_handle(cancelled_token(), Some(Instant::now())),
             )
             .await
@@ -4124,15 +4312,11 @@ mod tests {
                 cell.deadline.set(Some(Instant::now()));
                 cell.deadline_changed.notify(usize::MAX);
             };
-            let wait = until_abandoned(
-                std::future::pending::<Result<LuaValue, mlua::Error>>(),
-                &handle,
-            );
+            let wait = until_abandoned(std::future::pending::<()>(), &handle);
             let (_, err) = futures_lite::future::zip(set, wait).await;
-            assert!(
-                err.expect_err("the new deadline must end the handler")
-                    .to_string()
-                    .contains(HANDLER_TIMEOUT_MSG)
+            assert_eq!(
+                err.expect_err("the new deadline must end the handler"),
+                HANDLER_TIMEOUT_MSG
             );
         });
     }

--- a/maki-lua/tests/events_slots.rs
+++ b/maki-lua/tests/events_slots.rs
@@ -1,12 +1,18 @@
+use std::future::Future;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use maki_agent::tools::ToolRegistry;
-use maki_lua::{PluginHost, SessionEndReason};
+use maki_agent::cancel::CancelToken;
+use maki_agent::tools::hook::{self, Authority, HookCall, HookStage, Verdict};
+use maki_agent::tools::{CallOrigin, ToolRegistry};
+use maki_lua::{Permission, PluginHost, PluginPermissions, SessionEndReason};
 use maki_storage::id::MakiId;
+use test_case::test_case;
 
 const PROBE_SCHEMA: &str = r#"{ type = "object", properties = {}, additionalProperties = false }"#;
-const DISPATCH_TIMEOUT: Duration = Duration::from_secs(5);
+/// Generous on purpose. A bound a slow machine can trip is a bound that fails
+/// for the wrong reason, and this one is only reached when something is stuck.
+const DISPATCH_TIMEOUT: Duration = Duration::from_secs(30);
 const DISPATCH_POLL: Duration = Duration::from_millis(10);
 
 fn host() -> (Arc<ToolRegistry>, PluginHost) {
@@ -318,6 +324,750 @@ maki.api.create_autocmd("Shared", {{ callback = function() n = n + 1 end }})
     assert_eq!(exec_tool(&reg, "probe_keep"), "1");
 }
 
+// ------------------------------------------------------ host tool slots
+
+const SLOT_TOOL: &str = "slotted";
+const COMMAND_FIELD: &str = "command";
+const ARGV_FIELD: &str = "argv";
+const TOOL_ID: &str = "t1";
+const GUARDED_TOOL: &str = "guarded";
+const LAYER_PLUGIN: &str = "policy_layer";
+const HIJACKED: &str = "hijacked";
+const COMMAND: &str = "ls";
+const PASS_THROUGH: (Option<String>, Option<String>) = (None, None);
+const NEVER_ANSWERED: &str = "the chain never answered";
+const INNER_LAYER: &str = "inner_layer";
+const OUTER_LAYER: &str = "outer_layer";
+const INNER_MARK: &str = ":inner";
+const OUTER_MARK: &str = ":outer";
+/// Far longer than [`HOOK_WINDOW`], so a layer parked on it can only answer
+/// because the window let it, never because the job came back in time.
+const PARKED_FOR: Duration = Duration::from_secs(5);
+/// What a call with no deadline of its own would hand a chain, scaled down:
+/// long enough that no healthy layer is rushed, short enough to prove a parked
+/// one ends on it.
+const HOOK_WINDOW: Duration = Duration::from_millis(200);
+
+/// One string field in the schema, so a layer has something to rewrite.
+fn slotted_tool(host: &PluginHost) {
+    load(
+        host,
+        "slotted_owner",
+        r#"
+maki.api.register_tool({
+    name = "slotted",
+    description = "probe",
+    schema = { type = "object", properties = { command = { type = "string" } } },
+    audiences = { "main" },
+    handler = function(input) return "ran " .. tostring(input.command) end,
+})
+"#,
+    );
+}
+
+/// The call every firing here filters, so a test only names the field it is
+/// about.
+fn call_of<'a>(
+    tool: &'a str,
+    authority: Authority,
+    origin: CallOrigin,
+    cancel: &'a CancelToken,
+) -> HookCall<'a> {
+    HookCall {
+        tool,
+        tool_id: TOOL_ID,
+        session_id: None,
+        origin,
+        authority,
+        cancel,
+        deadline: Instant::now() + DISPATCH_TIMEOUT,
+    }
+}
+
+fn fire_call(
+    reg: &ToolRegistry,
+    call: &HookCall<'_>,
+    stage: HookStage,
+    value: serde_json::Value,
+) -> Verdict {
+    let hook = reg.hook().expect("the plugin host installs one at boot");
+    if !hook.wraps(call.tool, stage) {
+        return Verdict::Unchanged;
+    }
+    within(hook.run(stage, value, call))
+}
+
+/// Bounded, so a seam that stops answering fails the test instead of hanging
+/// the suite.
+fn within<T>(work: impl Future<Output = T>) -> T {
+    smol::block_on(async {
+        let work = async { Some(work.await) };
+        let give_up = async {
+            smol::Timer::after(DISPATCH_TIMEOUT).await;
+            None
+        };
+        smol::future::or(work, give_up).await.expect(NEVER_ANSWERED)
+    })
+}
+
+/// Fires one stage the way `tool_dispatch::run` does, with the authority the
+/// registered tool lends: its own capability, or everything when it declares
+/// none, the way an MCP or client tool is priced.
+fn fire(
+    reg: &ToolRegistry,
+    tool: &str,
+    origin: CallOrigin,
+    stage: HookStage,
+    value: serde_json::Value,
+) -> Verdict {
+    let entry = reg.get(tool).expect("tool registered");
+    let authority = entry
+        .tool
+        .required_permission()
+        .map_or(Authority::Unbounded, Authority::Capability);
+    fire_call(
+        reg,
+        &call_of(tool, authority, origin, &CancelToken::none()),
+        stage,
+        value,
+    )
+}
+
+/// `(replacement, denial reason)`, so a test names the one it means.
+fn input(reg: &ToolRegistry, tool: &str, command: &str) -> (Option<String>, Option<String>) {
+    input_from(reg, tool, CallOrigin::Model, command)
+}
+
+fn input_from(
+    reg: &ToolRegistry,
+    tool: &str,
+    origin: CallOrigin,
+    command: &str,
+) -> (Option<String>, Option<String>) {
+    match fire(
+        reg,
+        tool,
+        origin,
+        HookStage::Input,
+        serde_json::json!({ COMMAND_FIELD: command }),
+    ) {
+        Verdict::Unchanged => (None, None),
+        Verdict::Replaced(v) => (Some(v[COMMAND_FIELD].as_str().unwrap().to_owned()), None),
+        Verdict::Denied(reason) => (None, Some(reason)),
+    }
+}
+
+fn output(reg: &ToolRegistry, tool: &str, text: &str, is_error: bool) -> Option<(String, bool)> {
+    let value = serde_json::json!({ hook::OUTPUT_TEXT: text, hook::OUTPUT_IS_ERROR: is_error });
+    match fire(reg, tool, CallOrigin::Model, HookStage::Output, value) {
+        Verdict::Unchanged => None,
+        Verdict::Denied(reason) => Some((reason, true)),
+        Verdict::Replaced(v) => Some((
+            v[hook::OUTPUT_TEXT].as_str().unwrap().to_owned(),
+            v[hook::OUTPUT_IS_ERROR].as_bool().unwrap_or(is_error),
+        )),
+    }
+}
+
+#[test]
+fn tool_input_slot_rewrites_denies_and_passes_through() {
+    let (reg, host) = host();
+    slotted_tool(&host);
+    load(
+        &host,
+        "policy",
+        r#"
+maki.api.set_slot("tool.slotted.input", function(prev, input, ctx)
+    assert(ctx.tool == "slotted", ctx.tool)
+    assert(ctx.origin == "model", ctx.origin)
+    if input.command == "denied" then
+        return nil, "use rg"
+    end
+    if input.command == "grep -r x ." then
+        input.command = "rg x"
+        return prev(input, ctx)
+    end
+end)
+"#,
+    );
+
+    assert_eq!(
+        input(&reg, SLOT_TOOL, "grep -r x ."),
+        (Some("rg x".to_owned()), None)
+    );
+    assert_eq!(
+        input(&reg, SLOT_TOOL, "denied"),
+        (None, Some("use rg".to_owned()))
+    );
+    assert_eq!(
+        input(&reg, SLOT_TOOL, "ls"),
+        (None, None),
+        "a layer that returns nothing leaves the call alone"
+    );
+}
+
+/// Same shape as `bash`: permission checked, so layering it hands the layer
+/// that tool's authority.
+fn guarded_tool(host: &PluginHost) {
+    load(
+        host,
+        "guarded_owner",
+        r#"
+maki.api.register_tool({
+    name = "guarded",
+    description = "probe",
+    schema = { type = "object", properties = { command = { type = "string" } } },
+    audiences = { "main" },
+    permission = "run",
+    permission_scopes = function(input)
+        return { scopes = { input.command }, force_prompt = false }
+    end,
+    handler = function(input) return "ran " .. tostring(input.command) end,
+})
+"#,
+    );
+}
+
+fn load_granted(host: &PluginHost, plugin: &str, source: &str, granted: PluginPermissions) {
+    host.load_source_with_permissions(plugin, source, granted)
+        .expect("layer plugin loads whatever it is granted");
+}
+
+fn only_run() -> PluginPermissions {
+    let mut permissions = PluginPermissions::denied();
+    permissions.set(Permission::Run, true);
+    permissions
+}
+
+/// Everything but one, because the point is that "almost all" is not all.
+fn all_but_run() -> PluginPermissions {
+    let mut permissions = PluginPermissions::trusted();
+    permissions.set(Permission::Run, false);
+    permissions
+}
+
+/// A layer on one host slot whose body is the whole contract under test.
+fn layer(tool: &str, stage: HookStage, body: &str) -> String {
+    format!(
+        r#"maki.api.set_slot("tool.{tool}.{}", function(prev, value, ctx) {body} end)"#,
+        stage.as_str()
+    )
+}
+
+/// Rewrites, so `Replaced` means the layer ran and `Unchanged` means it was
+/// skipped. That is the answer every entitlement test reads.
+fn hijack_layer(tool: &str) -> String {
+    layer(
+        tool,
+        HookStage::Input,
+        &format!(r#"value.{COMMAND_FIELD} = "{HIJACKED}"; return prev(value, ctx)"#),
+    )
+}
+
+/// Appends {mark}, so the order two of them ran in survives into the answer.
+fn marking_layer(tool: &str, mark: &str) -> String {
+    layer(
+        tool,
+        HookStage::Input,
+        &format!(
+            r#"value.{COMMAND_FIELD} = value.{COMMAND_FIELD} .. "{mark}"; return prev(value, ctx)"#
+        ),
+    )
+}
+
+/// The price list. A tool that declares a capability sells its layers exactly
+/// that one. A tool declaring none, like an MCP server's tool, has said nothing
+/// about how far it reaches, so layering it costs every capability.
+///
+/// The layer is registered before its target exists, because nobody guarantees
+/// load order between a layer and the tool it wraps.
+#[test_case(GUARDED_TOOL, only_run,                   true  ; "the_declared_capability_is_enough")]
+#[test_case(SLOT_TOOL,    only_run,                   false ; "an_undeclared_reach_takes_more_than_one")]
+#[test_case(SLOT_TOOL,    all_but_run,                false ; "almost_every_capability_is_not_every_one")]
+#[test_case(SLOT_TOOL,    PluginPermissions::trusted, true  ; "full_trust_layers_anything")]
+fn a_layer_pays_the_authority_of_the_call_it_filters(
+    tool: &str,
+    granted: fn() -> PluginPermissions,
+    runs: bool,
+) {
+    let (reg, host) = host();
+    load_granted(&host, LAYER_PLUGIN, &hijack_layer(tool), granted());
+    slotted_tool(&host);
+    guarded_tool(&host);
+
+    let expected = runs.then(|| HIJACKED.to_owned());
+    assert_eq!(input(&reg, tool, COMMAND), (expected, None));
+}
+
+#[test]
+fn tool_slot_with_no_layers_never_reaches_lua() {
+    let (reg, host) = host();
+    slotted_tool(&host);
+    assert_eq!(input(&reg, SLOT_TOOL, COMMAND), PASS_THROUGH);
+    assert_eq!(output(&reg, SLOT_TOOL, "out", false), None);
+}
+
+/// The chain owns a task, which is what delivers job events to a layer waiting
+/// on one.
+#[test]
+fn tool_input_layer_may_run_a_job() {
+    let (reg, host) = host();
+    slotted_tool(&host);
+    load(
+        &host,
+        "job_policy",
+        r#"
+maki.api.set_slot("tool.slotted.input", function(prev, input, ctx)
+    local result = maki.fn.jobwait(maki.fn.jobstart({ "echo", "from-job" }))
+    input.command = result.stdout
+    return prev(input, ctx)
+end)
+"#,
+    );
+
+    assert_eq!(
+        input(&reg, SLOT_TOOL, "ls"),
+        (Some("from-job".to_owned()), None)
+    );
+}
+
+#[test]
+fn tool_output_slot_rewrites_text_and_error_flag() {
+    let (reg, host) = host();
+    slotted_tool(&host);
+    load(
+        &host,
+        "trimmer",
+        r#"
+maki.api.set_slot("tool.slotted.output", function(prev, out, ctx)
+    out.text = out.text:sub(1, 3)
+    out.is_error = true
+    return prev(out, ctx)
+end)
+"#,
+    );
+
+    assert_eq!(
+        output(&reg, SLOT_TOOL, "0123456789", false),
+        Some(("012".to_owned(), true))
+    );
+}
+
+#[test]
+fn unloading_the_layer_owner_restores_the_fast_path() {
+    let (reg, host) = host();
+    slotted_tool(&host);
+    load(&host, "temporary", &hijack_layer(SLOT_TOOL));
+    assert_eq!(
+        input(&reg, SLOT_TOOL, COMMAND),
+        (Some(HIJACKED.to_owned()), None)
+    );
+
+    host.unload("temporary").unwrap();
+    assert_eq!(
+        input(&reg, SLOT_TOOL, COMMAND),
+        PASS_THROUGH,
+        "the layer index drops with the plugin that registered it"
+    );
+}
+
+/// Chains overlap whenever tools run in parallel, and each one still has to
+/// run its layer. A reentrancy bound that read overlap as nesting would drop
+/// layers exactly when a `batch` is widest.
+#[test]
+fn overlapping_chains_all_run() {
+    const CONCURRENT: usize = maki_lua::test_support::MAX_HOOK_DEPTH as usize * 2;
+    let (reg, host) = host();
+    slotted_tool(&host);
+    // Parks first, then marks: a pass-through is reported as untouched, so the
+    // rewrite is what says this chain's own layer ran.
+    load(
+        &host,
+        "parking_policy",
+        &format!(
+            r#"
+maki.api.set_slot("tool.slotted.input", function(prev, input, ctx)
+    maki.fs.read("/nope")
+    input.{COMMAND_FIELD} = input.{COMMAND_FIELD} .. "{INNER_MARK}"
+    return prev(input, ctx)
+end)
+"#
+        ),
+    );
+    let hook = reg.hook().expect("the plugin host installs one at boot");
+    let cancel = CancelToken::none();
+    let call = call_of(SLOT_TOOL, Authority::Unbounded, CallOrigin::Model, &cancel);
+
+    // Joined, so the chains are genuinely in flight at once. Awaiting them one
+    // at a time would never overlap and never notice.
+    let verdicts = within(futures::future::join_all((0..CONCURRENT).map(|i| {
+        let value = serde_json::json!({ COMMAND_FIELD: i.to_string() });
+        hook.run(HookStage::Input, value, &call)
+    })));
+    let ran = verdicts
+        .iter()
+        .filter(|v| matches!(v, Verdict::Replaced(_)))
+        .count();
+    assert_eq!(ran, CONCURRENT, "every overlapping chain ran its layer");
+}
+
+/// The documented layer shape returns `prev(...)`, and the identity default
+/// hands back what it was given, so a layer that changed nothing still answers
+/// with a table. Reporting that as a rewrite would swap the input the caller
+/// holds for a re-encode of it, and a JSON null is a Lua nil, which is an
+/// absent key, so the re-encode would quietly lose fields on the way.
+#[test_case(serde_json::json!({ COMMAND_FIELD: COMMAND }) ; "a_value_the_layer_could_have_touched")]
+#[test_case(serde_json::json!({ COMMAND_FIELD: null, ARGV_FIELD: [COMMAND, null] }) ; "nulls_no_layer_ever_sees")]
+fn a_pass_through_layer_leaves_the_input_untouched(value: serde_json::Value) {
+    let (reg, host) = host();
+    slotted_tool(&host);
+    load(
+        &host,
+        LAYER_PLUGIN,
+        &layer(SLOT_TOOL, HookStage::Input, "return prev(value, ctx)"),
+    );
+
+    let verdict = fire(&reg, SLOT_TOOL, CallOrigin::Model, HookStage::Input, value);
+
+    assert!(
+        matches!(verdict, Verdict::Unchanged),
+        "a layer that only deferred is not a rewrite"
+    );
+}
+
+/// The chain runs on the Lua thread, so the agent side giving up on the reply
+/// is not the same as the chain ending: without the call's own token the
+/// watchdog has nothing to interrupt this layer with, and it spins forever.
+#[test]
+fn cancelling_the_call_kills_the_chain() {
+    let (reg, host) = host();
+    slotted_tool(&host);
+    load(
+        &host,
+        LAYER_PLUGIN,
+        &layer(
+            SLOT_TOOL,
+            HookStage::Input,
+            &format!(
+                r#"local n = 0
+                while true do n = n + 1 end
+                value.{COMMAND_FIELD} = "{HIJACKED}"
+                return prev(value, ctx)"#
+            ),
+        ),
+    );
+
+    let (trigger, cancel) = CancelToken::new();
+    trigger.cancel();
+    let call = call_of(SLOT_TOOL, Authority::Unbounded, CallOrigin::Model, &cancel);
+    let value = serde_json::json!({ COMMAND_FIELD: COMMAND });
+
+    let verdict = fire_call(&reg, &call, HookStage::Input, value);
+
+    assert!(
+        matches!(verdict, Verdict::Unchanged),
+        "the killed layer never reached its rewrite"
+    );
+}
+
+/// The watchdog only interrupts Lua that runs, and a layer parked in an await
+/// runs none: it renews its grace at every yield and would sit there as long as
+/// whatever it waits on. Only the window dispatch hands the chain ends this
+/// one, well before the job it is parked on comes back.
+#[test]
+fn a_parked_layer_ends_at_the_window_it_was_given() {
+    let (reg, host) = host();
+    slotted_tool(&host);
+    load(
+        &host,
+        LAYER_PLUGIN,
+        &layer(
+            SLOT_TOOL,
+            HookStage::Input,
+            &format!(
+                r#"maki.fn.jobwait(maki.fn.jobstart({{ "sleep", "{}" }}), {})
+                value.{COMMAND_FIELD} = "{HIJACKED}"
+                return prev(value, ctx)"#,
+                PARKED_FOR.as_secs(),
+                PARKED_FOR.as_millis()
+            ),
+        ),
+    );
+
+    let cancel = CancelToken::none();
+    let mut call = call_of(SLOT_TOOL, Authority::Unbounded, CallOrigin::Model, &cancel);
+    call.deadline = Instant::now() + HOOK_WINDOW;
+    let value = serde_json::json!({ COMMAND_FIELD: COMMAND });
+
+    let verdict = fire_call(&reg, &call, HookStage::Input, value);
+
+    assert!(
+        matches!(verdict, Verdict::Unchanged),
+        "the abandoned layer never reached its rewrite"
+    );
+}
+
+#[test]
+fn host_slot_names_are_reserved() {
+    let (_reg, host) = host();
+    let err = host
+        .load_source(
+            "squatter",
+            r#"maki.api.declare_slot("tool.bash.input", function(i) return i end)"#,
+        )
+        .expect_err("declaring a host slot must fail");
+    assert!(format!("{err}").contains("host owned"), "{err}");
+}
+
+/// A layer answering off contract costs what no layer costs: dispatch keeps the
+/// call it already had rather than hand the tool a shape nobody promised. One
+/// case is a table conversion that genuinely fails, the only way to reach the
+/// "not json" arm.
+#[test_case(r#"return "nope""# ; "string")]
+#[test_case("return 42" ; "number")]
+#[test_case("return true" ; "boolean")]
+#[test_case("return nil, 42" ; "non_string_reason")]
+#[test_case(r#"return { "\255\254" }"# ; "table_that_is_not_json")]
+fn a_malformed_layer_answer_leaves_the_call_alone(answer: &str) {
+    let (reg, host) = host();
+    slotted_tool(&host);
+    load(
+        &host,
+        LAYER_PLUGIN,
+        &layer(SLOT_TOOL, HookStage::Input, answer),
+    );
+
+    assert_eq!(input(&reg, SLOT_TOOL, COMMAND), PASS_THROUGH);
+}
+
+/// The reason is what the model reads instead of the output, so it has to
+/// arrive verbatim rather than as a replacement value.
+#[test]
+fn an_output_layer_stops_the_call_with_its_reason() {
+    const REASON: &str = "redacted";
+    let (reg, host) = host();
+    slotted_tool(&host);
+    load(
+        &host,
+        LAYER_PLUGIN,
+        &layer(
+            SLOT_TOOL,
+            HookStage::Output,
+            &format!(r#"return nil, "{REASON}""#),
+        ),
+    );
+
+    assert_eq!(
+        output(&reg, SLOT_TOOL, "secret", false),
+        Some((REASON.to_owned(), true))
+    );
+}
+
+/// One plugin's broken layer must not take the seam down or swallow the layers
+/// another plugin registered underneath it.
+#[test]
+fn a_broken_layer_is_skipped_and_the_chain_still_answers() {
+    let (reg, host) = host();
+    slotted_tool(&host);
+    load(&host, INNER_LAYER, &hijack_layer(SLOT_TOOL));
+    load(
+        &host,
+        OUTER_LAYER,
+        &layer(SLOT_TOOL, HookStage::Input, r#"error("boom")"#),
+    );
+
+    assert_eq!(
+        input(&reg, SLOT_TOOL, COMMAND),
+        (Some(HIJACKED.to_owned()), None)
+    );
+}
+
+/// Layers wrap in registration order across plugins too, so the last one
+/// registered sees the call first. Otherwise two plugins that both rewrite
+/// would compose differently depending on a load order nobody can see.
+#[test]
+fn layers_compose_with_the_last_registered_outermost() {
+    let (reg, host) = host();
+    slotted_tool(&host);
+    load(&host, INNER_LAYER, &marking_layer(SLOT_TOOL, INNER_MARK));
+    load(&host, OUTER_LAYER, &marking_layer(SLOT_TOOL, OUTER_MARK));
+
+    assert_eq!(
+        input(&reg, SLOT_TOOL, COMMAND),
+        (Some(format!("{COMMAND}{OUTER_MARK}{INNER_MARK}")), None)
+    );
+}
+
+/// Entitlement is per layer, not per slot. The plugin holding the tool's
+/// capability keeps its rewrite, the one without it is dropped from the chain,
+/// and being dropped is not a denial.
+#[test]
+fn only_the_entitled_layer_of_two_runs() {
+    let (reg, host) = host();
+    guarded_tool(&host);
+    let denied = PluginPermissions::denied();
+    load_granted(
+        &host,
+        INNER_LAYER,
+        &marking_layer(GUARDED_TOOL, INNER_MARK),
+        denied,
+    );
+    load_granted(
+        &host,
+        OUTER_LAYER,
+        &marking_layer(GUARDED_TOOL, OUTER_MARK),
+        only_run(),
+    );
+
+    assert_eq!(
+        input(&reg, GUARDED_TOOL, COMMAND),
+        (Some(format!("{COMMAND}{OUTER_MARK}")), None),
+        "the denied layer is skipped, not consulted and not a denial"
+    );
+}
+
+/// A layer owns the decision it makes: answering without calling `prev` is how
+/// it stops the layers below from seeing the call at all.
+#[test]
+fn a_layer_that_never_calls_prev_short_circuits() {
+    const PROBE: &str = "probe_inner_ran";
+    const SHORT: &str = "short";
+    let (reg, host) = host();
+    slotted_tool(&host);
+    load(
+        &host,
+        LAYER_PLUGIN,
+        &format!(
+            r#"
+local inner_ran = false
+{}
+{}
+{}
+"#,
+            layer(
+                SLOT_TOOL,
+                HookStage::Input,
+                "inner_ran = true; return prev(value, ctx)"
+            ),
+            layer(
+                SLOT_TOOL,
+                HookStage::Input,
+                &format!(r#"return {{ {COMMAND_FIELD} = "{SHORT}" }}"#)
+            ),
+            probe_tool(PROBE, "return tostring(inner_ran)")
+        ),
+    );
+
+    assert_eq!(
+        input(&reg, SLOT_TOOL, COMMAND),
+        (Some(SHORT.to_owned()), None)
+    );
+    assert_eq!(
+        exec_tool(&reg, PROBE),
+        "false",
+        "the layer below the one that answered must never have run"
+    );
+}
+
+/// The grant is read when the chain fires, so narrowing it costs one reload
+/// rather than a restart.
+#[test]
+fn a_reload_that_narrows_permissions_applies_to_the_next_call() {
+    let (reg, host) = host();
+    guarded_tool(&host);
+    load_granted(&host, LAYER_PLUGIN, &hijack_layer(GUARDED_TOOL), only_run());
+    assert_eq!(
+        input(&reg, GUARDED_TOOL, COMMAND),
+        (Some(HIJACKED.to_owned()), None)
+    );
+
+    let source = hijack_layer(GUARDED_TOOL);
+    load_granted(&host, LAYER_PLUGIN, &source, PluginPermissions::denied());
+    assert_eq!(
+        input(&reg, GUARDED_TOOL, COMMAND),
+        PASS_THROUGH,
+        "the reloaded plugin is weighed by what this load granted it"
+    );
+}
+
+/// The hook outlives the runtime that installed it, and a call in flight at
+/// shutdown still has to be answered. The only honest answer left is the one
+/// no layer would have changed.
+#[test]
+fn a_dropped_host_leaves_the_call_unchanged() {
+    let (reg, host) = host();
+    slotted_tool(&host);
+    load(&host, LAYER_PLUGIN, &hijack_layer(SLOT_TOOL));
+    let hook = reg.hook().expect("the plugin host installs one at boot");
+    assert!(hook.wraps(SLOT_TOOL, HookStage::Input));
+
+    drop(host);
+
+    let cancel = CancelToken::none();
+    let call = call_of(SLOT_TOOL, Authority::Unbounded, CallOrigin::Model, &cancel);
+    let value = serde_json::json!({ COMMAND_FIELD: COMMAND });
+    let verdict = within(hook.run(HookStage::Input, value, &call));
+
+    assert!(
+        matches!(verdict, Verdict::Unchanged),
+        "a runtime that is gone is not a denial"
+    );
+}
+
+/// `tool.` is the host's namespace, but only two names in it mean anything. A
+/// third is accepted and inert rather than rejected, and above all it must not
+/// enrol the tool into a stage it never named.
+#[test]
+fn a_tool_slot_that_names_no_stage_never_fires() {
+    let (reg, host) = host();
+    slotted_tool(&host);
+    load(
+        &host,
+        LAYER_PLUGIN,
+        &format!(
+            r#"maki.api.set_slot("tool.{SLOT_TOOL}.header", function(prev, value, ctx)
+                value.{COMMAND_FIELD} = "{HIJACKED}"
+                return prev(value, ctx)
+            end)"#
+        ),
+    );
+
+    let hook = reg.hook().expect("the plugin host installs one at boot");
+    for stage in HookStage::ALL {
+        assert!(
+            !hook.wraps(SLOT_TOOL, stage),
+            "a name that is not a stage must not wrap {stage:?}"
+        );
+    }
+    assert_eq!(input(&reg, SLOT_TOOL, COMMAND), PASS_THROUGH);
+}
+
+/// What a layer is told about the call it filters. `origin` is the one field it
+/// cannot get anywhere else, and it says whether the model asked for this call
+/// or another tool did.
+#[test_case(CallOrigin::Model, "model" ; "model")]
+#[test_case(CallOrigin::Nested, "nested" ; "nested")]
+fn the_ctx_table_names_the_call(origin: CallOrigin, expected_origin: &str) {
+    let (reg, host) = host();
+    slotted_tool(&host);
+    load(
+        &host,
+        LAYER_PLUGIN,
+        &layer(
+            SLOT_TOOL,
+            HookStage::Input,
+            &format!(
+                r#"value.{COMMAND_FIELD} = ctx.tool_id .. "|" .. ctx.origin; return prev(value, ctx)"#
+            ),
+        ),
+    );
+
+    assert_eq!(
+        input_from(&reg, SLOT_TOOL, origin, COMMAND),
+        (Some(format!("{TOOL_ID}|{expected_origin}")), None)
+    );
+}
+
 // ---------------------------------------------------------------- slots
 
 #[test]
@@ -375,25 +1125,28 @@ assert(runs == 1, "rest of chain ran exactly once: " .. runs)
     );
 }
 
-/// Slot dispatch is a plain synchronous call, so `maki.fs.read` parks on the
-/// C-call boundary long before it reaches the filesystem. From the default
-/// that error travels to the caller, from a layer it costs only the layer and
-/// the chain still answers.
+/// Chains are async all the way down, so a layer can wait for the answer it
+/// needs before deciding. Without that, wrapping a seam would only pay off for
+/// decisions that need nothing but the argument.
 #[test]
-fn slot_chain_must_not_suspend() {
+fn slot_chain_may_suspend() {
     let (_reg, host) = host();
     load(
         &host,
         "slot_suspends",
         r#"
-local d = maki.api.declare_slot("sd", function() return maki.fs.read("/nope") end)
-local ok, err = pcall(d)
-assert(not ok, "a suspending default must fail the call")
-assert(tostring(err):find("yield"), tostring(err))
+local d = maki.api.declare_slot("sd", function()
+    local _, err = maki.fs.read("/nope")
+    return err ~= nil
+end)
+assert(d() == true, "a parking default reaches the filesystem and comes back")
 
-local l = maki.api.declare_slot("sl", function() return "base" end)
-maki.api.set_slot("sl", function(prev) return maki.fs.read("/nope") end)
-assert(l() == "base", "a suspending layer is skipped, chain keeps working")
+local l = maki.api.declare_slot("sl", function(x) return x end)
+maki.api.set_slot("sl", function(prev, x)
+    local _, err = maki.fs.read("/nope")
+    return prev(x .. tostring(err ~= nil))
+end)
+assert(l("v") == "vtrue", l("v"))
 "#,
     );
 }

--- a/site/docs/content/_index.md
+++ b/site/docs/content/_index.md
@@ -58,6 +58,7 @@ The docs are sorted by what you came here to do:
     <a class="card" href="/docs/commands/"><span class="card-title">Commands</span><span class="card-desc">The / palette, sessions, toggles, custom commands.</span></a>
     <a class="card" href="/docs/keybindings/"><span class="card-title">Keybindings</span><span class="card-desc">Defaults, precedence, rebinding from Lua.</span></a>
     <a class="card" href="/docs/lua-api/"><span class="card-title">Lua API</span><span class="card-desc">The plugin surface, mirrored from Neovim.</span></a>
+    <a class="card" href="/docs/hooks/"><span class="card-title">Hooks</span><span class="card-desc">Rewrite, block, or trim a tool call from Lua.</span></a>
     <a class="card" href="/docs/packages/"><span class="card-title">Lua Packages</span><span class="card-desc">Load external Lua plugins from Neovim-style package directories.</span></a>
     <a class="card" href="/docs/cli/"><span class="card-title">CLI</span><span class="card-desc">Flags and subcommands (auth, models, acp, prompt, ...).</span></a>
     <a class="card" href="/docs/telemetry/"><span class="card-title">Telemetry</span><span class="card-desc">Opt-in OpenTelemetry metrics and events, to a collector you run.</span></a>

--- a/site/docs/content/hooks/_index.md
+++ b/site/docs/content/hooks/_index.md
@@ -1,0 +1,232 @@
++++
+title = "Hooks"
+weight = 13
+[extra]
+group = "Reference"
++++
+
+# Hooks
+
+Maki has two ways for Lua to react to what the agent does.
+
+| You want to | Use |
+| --- | --- |
+| Know that something happened | [Autocmds](/docs/lua-api/#maki-api-create_autocmd) |
+| Change what happens, or stop it | Slots |
+
+Autocmds are notifications. Many plugins can listen to one event, they run in no
+particular order, and what they return is ignored. Slots are a chain: each layer
+gets the value, decides, and passes it down by calling `prev`. The last layer
+registered runs first.
+
+Both come from Neovim. An autocmd matches `nvim_create_autocmd`, and a slot
+plays the role `vim.ui.select` plays there, with the wrapping made explicit so
+two plugins can layer the same point without capturing each other's function.
+
+## Tool slots
+
+Every tool has two slots that maki fires itself, so the tool's author does not
+have to add a hook point. Both fire from the single function every tool call
+passes through, so builtins, MCP tools, and ACP client tools behave alike:
+
+| Slot | Fires | Gets |
+| --- | --- | --- |
+| `tool.<name>.input` | before the input is parsed or checked against your permission rules | the call the model wrote |
+| `tool.<name>.output` | on the result of a call that ran, including a failure or a permission refusal | `{ text, is_error }` |
+
+A call an input layer stopped never reaches the output slot: the reason came
+from a layer, so there is nothing left to filter. A name that resolves to no
+tool fires neither slot.
+
+Layers take `function(prev, value, ctx)` and answer in one of three ways:
+
+- return a table: it replaces the value for the rest of the call
+- return nothing: the value is left alone
+- return `nil, reason`: the call is stopped and the model reads `reason`
+
+Stopping means something different per stage. On `input` the tool never runs and
+`reason` becomes the tool result, marked as an error. On `output` the work is
+already done, so `reason` only replaces the text the model reads.
+
+`ctx` carries `tool`, `tool_id`, `session_id`, and `origin`. Origin is `"model"`
+for a call the model made and `"nested"` for one made on its behalf by `batch`,
+`code_execution`, or a plugin calling `maki.agent.call_tool`. Nested calls have
+no id of their own, so their `tool_id` is empty. A subagent runs its own model,
+so its calls arrive as `"model"` under the subagent's `session_id`.
+
+### Rewriting a command
+
+The model reaches for `grep -r` even when `rg` is installed. Denying costs a
+model round trip every time it happens. A rewrite fixes the command in place:
+
+```lua
+maki.api.set_slot("tool.bash.input", function(prev, input, ctx)
+  local rewritten = input.command:gsub("^grep %-r ", "rg ")
+  if rewritten == input.command then
+    return
+  end
+  input.command = rewritten
+  return prev(input, ctx)
+end)
+```
+
+`rg` and `grep -r` do not search the same files: `rg` skips what `.gitignore`
+lists, hidden files, and binaries. That is why maki does not do this for you.
+
+### Blocking a command
+
+When there is no good rewrite, stop the call and say why. The reason reaches
+the model as the tool result:
+
+```lua
+maki.api.set_slot("tool.bash.input", function(prev, input, ctx)
+  if input.command:find("git push %-%-force") then
+    return nil, "Force pushing is not allowed here. Open a PR instead."
+  end
+  return prev(input, ctx)
+end)
+```
+
+### Trimming output
+
+An output layer runs before the output becomes part of the conversation, so what
+it drops is never paid for again:
+
+```lua
+local MAX = 200
+
+maki.api.set_slot("tool.bash.output", function(prev, out, ctx)
+  local lines = {}
+  for line in out.text:gmatch("[^\n]+") do
+    if not line:match("^%s*Compiling ") then
+      table.insert(lines, line)
+    end
+  end
+  out.text = table.concat(lines, "\n", 1, math.min(#lines, MAX))
+  return prev(out, ctx)
+end)
+```
+
+A replacement table has to carry `text`. Without it the output is left alone and
+the reason is logged. Set `is_error` to turn a success into a failure, or a
+failure into a success.
+
+An output slot fires only when the text is the whole output. Tools the UI renders
+from fields, like `read` or `edit`, are excluded, because prose edited underneath
+would disagree with the display. So are tools whose result carries structured
+state saved with the session, like `batch` or `question`. That state is what gets
+re-rendered on restore, so a value redacted in the text would come back after a
+restart.
+
+## Rules
+
+**Permissions judge what runs.** An input layer runs before the schema check and
+before rules are resolved, so a layer cannot turn `allow bash: git status` into
+something else. The prompt you see names the rewritten call.
+
+**A layer borrows the tool's capability.** Wrapping `tool.bash.input` decides
+what bash runs, so the plugin holding that layer needs `run`, the capability the
+bash tool declares. A layer from a plugin without it is skipped and the rest of
+the chain still runs. The check happens per call, so a missing grant shows up in
+debug logs rather than as a warning at load.
+
+| Tool | A layer needs |
+| --- | --- |
+| declares a permission, like `bash` | that permission |
+| declares none: `read`, `batch`, MCP tools, ACP client tools, `tool_search` | every permission |
+
+Declaring no capability does not mean a tool uses none. `batch`,
+`code_execution` and `task` declare nothing while invoking any other tool, so
+reading undeclared as free would hand a plugin everything. Undeclared costs the
+maximum instead. See [plugin permissions](/docs/lua-api/#plugin-permissions).
+
+**A layer may wait, within a window.** Chains are async, so a layer can read a
+file or run a job before it decides. It runs inside the call it is filtering, so
+cancelling the call cancels the layer too. Each stage gets whatever the call has
+left of its own deadline, capped at 60 seconds. A layer still running when the
+window closes is dropped, and the call proceeds as if that layer had passed the
+value along.
+
+Cancellation lands differently on the two stages. An input layer cut short stops
+the call, because nothing has run yet and nobody is left to read a result. An
+output layer cut short leaves the output as it found it, since the work is
+already done.
+
+**A broken layer is skipped.** If a layer throws, the chain continues as if it
+had passed the value along, and the error is logged with the plugin name.
+
+**Order is registration order.** The last layer registered is the outermost one
+and sees the value first. Package load order decides this, so avoid writing two
+layers that only work in one order.
+
+**`prev` is single use.** Calling it twice throws. Everything below a layer runs
+once per call.
+
+**History keeps the call the model wrote.** The tool header, the permission
+prompt, and the tool result show what ran. If a rewrite changes what the call
+means, tell the model by appending a line in the output layer.
+
+**Idle slots cost nothing.** A tool with no layers never crosses into Lua, and a
+chain that hands back the value it was given leaves the original untouched.
+
+**JSON null arrives as `nil`.** A Lua table cannot hold a null, so a null field
+and a field that was never there look the same inside a layer. Maki carries
+nulls across for you, which is what makes an untouched value a true no-op. The
+cost: you cannot delete a field whose value is null, because maki cannot tell
+that apart from leaving it alone. Set it to another value, or deny the call.
+
+## Wrapping every tool
+
+Slot names are per tool, so a layer on `tool.bash.input` costs nothing when
+`read` is called. To cover all of them, loop over the registry:
+
+```lua
+local function redact(prev, out, ctx)
+  out.text = out.text:gsub("sk%-%w+", "[redacted]")
+  return prev(out, ctx)
+end
+
+for _, tool in ipairs(maki.api.get_tools()) do
+  maki.api.set_slot("tool." .. tool.name .. ".output", redact)
+end
+```
+
+Most builtins declare no capability, so this loop only does anything for a plugin
+granted every permission. Run it from a plugin without them and each layer is
+skipped when its tool is called.
+
+This sees the tools registered so far, so run it from `init.lua`, which loads
+after the builtin plugins. It also misses MCP tools, which arrive when their
+server connects. Naming one slot directly has no such ordering rule: `set_slot`
+accepts a name before anything registers it.
+
+## Plugin slots
+
+A plugin can define an extension point of its own with
+[`declare_slot`](/docs/lua-api/#maki-api-declare_slot). The declaring plugin
+owns the name and supplies the default, and anyone can wrap it with `set_slot`:
+
+```lua
+-- owner
+local render = maki.api.declare_slot("myplugin.render", function(text)
+  return text:upper()
+end)
+
+-- anyone
+maki.api.set_slot("myplugin.render", function(prev, text)
+  return "[" .. prev(text) .. "]"
+end)
+
+-- render("hi") now returns "[HI]"
+```
+
+Names starting with `tool.` are reserved for maki, which fires them at points
+whose ordering it guarantees.
+
+Use `maki.api.get_slots()` to see who owns and who wraps each slot.
+
+## Limits
+
+A layer has no agent context, so `maki.agent.call_tool` and
+`maki.agent.session` are out of reach inside one. Read files, run jobs, and
+decide from those.

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -754,9 +754,7 @@ maki.api.exec_autocmds({event}, {opts?})
 Fire one or more events manually. Every matching autocmd callback
 runs to completion before this function returns.
 
-A handler may suspend, so this call may too. That rules it out inside
-a slot chain, which runs synchronously (see `declare_slot`). Fire the
-event from the code that calls the slot instead.
+A handler may suspend, so this call may too.
 
 **Parameters:**
 
@@ -787,14 +785,15 @@ Create a named extension point owned by your plugin. You provide a
 `set_slot`. The returned callable runs the full chain: outermost
 layer first, then inward, ending at {default}.
 
-Throws if another plugin already owns a slot with the same {name}.
+Throws if another plugin already owns a slot with the same {name}, or
+if {name} starts with `"tool."`, which the host fires itself.
 
-The chain runs synchronously, so neither the default nor a layer may
-call a suspending API (`maki.fs.*`, `maki.fn.jobwait`,
-`maki.api.exec_autocmds`, ...). Parking raises "attempt to yield
-across metamethod/C-call boundary": from the default that error
-reaches your caller, from a layer it only drops that layer. Do the
-waiting outside the chain and pass the result in.
+The chain is async: the default and every layer may park (`maki.fs.*`,
+`maki.fn.jobwait`, `maki.agent.call_tool`, ...), and so does the
+returned callable. Call it from a tool handler, a command, or an
+autocmd, rather than from a `header` or `restore` function, which
+cannot wait. The chain runs in your task, so cancelling the caller
+cancels the layers it is waiting on.
 
 **Parameters:**
 
@@ -828,8 +827,20 @@ Calling `prev` more than once throws.
 You can call this before the owner runs `declare_slot`. The layer
 is queued and attached when the slot is declared.
 
-Layers run synchronously, so one that calls a suspending API is
-dropped and the chain continues without it, see `declare_slot`.
+A layer may park, and one that throws is skipped: the chain continues
+as if it had returned `prev(...)` untouched, so a broken layer never
+takes the seam down with it.
+
+Layers wrap in registration order, so the last one registered runs
+first and sees the value before the others do.
+
+Maki fires two slots per tool itself: `tool.<name>.input` before
+permissions look at the call, and `tool.<name>.output` on the text it
+produced. Both take `function(prev, value, ctx)` and answer with a
+table to replace the value, nothing to leave it alone, or
+`nil, reason` to stop the call. Wrapping one costs the capability the
+tool declares, and a tool declaring none costs every permission. See
+[Hooks](/docs/hooks/).
 
 **Parameters:**
 
@@ -1751,11 +1762,6 @@ output into a buffer while parked here. An already-exited
 session-owned job answers from its snapshot and fires no callbacks.
 Task and plugin jobs leave the store on exit, so waiting after that
 is an error.
-
-Waiting parks the caller, so a slot chain cannot call it. From a
-slot, start the job with an `on_exit` that stashes the result in
-your plugin state and pick it back up with `jobfind` next time.
-`maki.api.declare_slot` explains the restriction.
 
 Requires the `run` [plugin permission](#plugin-permissions).
 

--- a/site/docs/content/permissions/_index.md
+++ b/site/docs/content/permissions/_index.md
@@ -18,6 +18,10 @@ Rules come from four layers, combined for resolution:
 
 Any matching deny blocks the tool. No exceptions, so a config deny always beats a plugin allow.
 
+A [`tool.<name>.input` hook](/docs/hooks/) runs before any of this. Rules are
+resolved against the call as the hook left it, so what the prompt shows you is
+what runs.
+
 ## Check Flow
 
 For every tool call, each scope resolves like this:


### PR DESCRIPTION
A plugin could add a tool or take over a name, but not touch a call the model made through someone else's tool, so steering the model off `grep -r` meant denying the call and paying a model round trip every time.

Every registered tool now fires `tool.<name>.input` and `tool.<name>.output`, and a layer replaces the value, leaves it alone, or stops the call with a reason the model reads. Input layers run before the schema check and before permission rules resolve, so rules and the prompt judge the call as the layer left it, otherwise `allow bash: git status` would have become a way to run anything.

Layering a tool borrows its authority, so it costs the capability that tool declares, and every capability when it declares none, checked when the chain fires because a layer may be registered before its tool exists. Chains became async on the way, which is what lets a layer read a file or run a job before deciding.

Closes #893.