### PR TITLE
perf(highlight): run all of syntect on one thread 🤖🤖🤖

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,9 +2763,11 @@ dependencies = [
 name = "maki-highlight"
 version = "0.5.0"
 dependencies = [
+ "flume 0.11.1",
  "serde_json",
  "syntect",
  "test-case",
+ "tracing",
  "two-face",
 ]
 

--- a/maki-highlight/Cargo.toml
+++ b/maki-highlight/Cargo.toml
@@ -8,8 +8,10 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+flume = { workspace = true }
 serde_json = { workspace = true }
 syntect = { workspace = true }
+tracing = { workspace = true }
 two-face = { workspace = true }
 
 [dev-dependencies]

--- a/maki-highlight/src/lib.rs
+++ b/maki-highlight/src/lib.rs
@@ -11,6 +11,8 @@ use syntect::highlighting::{
 use syntect::parsing::{ParseState, ScopeStack, SyntaxReference, SyntaxSet};
 use syntect::util::LinesWithEndings;
 
+pub mod pool;
+
 const TOKEN_ALIASES: &[(&str, &str)] = &[("jsx", "js")];
 pub const TAB_SPACES: &str = "  ";
 const BLOCK_CACHE_MAX_BYTES: usize = 16 * 1024 * 1024;

--- a/maki-highlight/src/pool.rs
+++ b/maki-highlight/src/pool.rs
@@ -1,0 +1,140 @@
+//! Runs syntect on one dedicated thread to bound its regex cache memory.
+//!
+//! syntect has no thread-local state of its own: the memory is regex-automata's
+//! `Pool<Cache>`, one owner value plus 8 sharded stacks per compiled `Regex`, and a
+//! `SyntaxSet` holds thousands of them. That is ~10 MB per thread, 65-84% of peak
+//! heap in long sessions. The pool never contracts and thread exit does not reclaim
+//! it: 48 threads spawned sequentially, only ever one alive, still ended at +113 MB.
+//! So the previous idle-timeout render pool, respawning workers every 5s, bought a
+//! fresh cache set each time even with nothing running in parallel.
+
+use std::any::Any;
+use std::cell::Cell;
+use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
+use std::sync::OnceLock;
+use std::thread;
+
+use tracing::error;
+
+const UNKNOWN_PANIC: &str = "<non-string panic payload>";
+const THREAD_GONE: &str = "the highlight thread is gone";
+
+type Job = Box<dyn FnOnce() + Send + 'static>;
+
+static JOBS: OnceLock<flume::Sender<Job>> = OnceLock::new();
+
+fn jobs() -> &'static flume::Sender<Job> {
+    JOBS.get_or_init(|| {
+        let (tx, rx) = flume::unbounded::<Job>();
+        thread::Builder::new()
+            .name("highlight".into())
+            .spawn(move || {
+                ON_HIGHLIGHT_THREAD.set(true);
+                while let Ok(job) = rx.recv() {
+                    if let Err(payload) = catch_unwind(AssertUnwindSafe(job)) {
+                        error!(panic = panic_message(&*payload), "highlight job panicked");
+                    }
+                }
+            })
+            .expect("failed to spawn the highlight thread");
+        tx
+    })
+}
+
+thread_local! {
+    static ON_HIGHLIGHT_THREAD: Cell<bool> = const { Cell::new(false) };
+}
+
+fn panic_message(payload: &(dyn Any + Send)) -> &str {
+    payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or(UNKNOWN_PANIC)
+}
+
+/// Runs `f` on the highlight thread and waits for its result.
+///
+/// Nested calls run inline because markdown highlights its own code blocks.
+pub fn run<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
+    if ON_HIGHLIGHT_THREAD.get() {
+        return f();
+    }
+    let (done_tx, done_rx) = flume::bounded(1);
+    spawn(move || {
+        let _ = done_tx.send(catch_unwind(AssertUnwindSafe(f)));
+    });
+    match done_rx.recv() {
+        Ok(Ok(value)) => value,
+        Ok(Err(payload)) => resume_unwind(payload),
+        Err(_) => panic!("{THREAD_GONE}"),
+    }
+}
+
+pub fn spawn(f: impl FnOnce() + Send + 'static) {
+    let _ = jobs().send(Box::new(f));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    const PAYLOAD: usize = 41;
+    const WAITERS: usize = 8;
+    const BOOM: &str = "boom";
+
+    #[test]
+    fn runs_job_and_returns_value() {
+        assert_eq!(run(|| PAYLOAD + 1), PAYLOAD + 1);
+    }
+
+    #[test]
+    fn every_job_runs_on_one_thread() {
+        let waiters: Vec<_> = (0..WAITERS)
+            .map(|_| thread::spawn(|| run(|| thread::current().id())))
+            .collect();
+        let ids: Vec<_> = waiters
+            .into_iter()
+            .map(|w| w.join().expect("waiter panicked"))
+            .collect();
+        assert!(
+            ids.windows(2).all(|w| w[0] == w[1]),
+            "jobs ran on multiple threads: {ids:?}"
+        );
+    }
+
+    #[test]
+    fn nested_run_does_not_deadlock() {
+        assert_eq!(run(|| run(|| PAYLOAD)), PAYLOAD);
+    }
+
+    #[test]
+    fn many_waiters_all_make_progress() {
+        let done = Arc::new(AtomicUsize::new(0));
+        let waiters: Vec<_> = (0..WAITERS)
+            .map(|_| {
+                let done = Arc::clone(&done);
+                thread::spawn(move || run(move || done.fetch_add(1, Ordering::AcqRel)))
+            })
+            .collect();
+        for w in waiters {
+            w.join().expect("waiter panicked");
+        }
+        assert_eq!(done.load(Ordering::SeqCst), WAITERS);
+    }
+
+    #[test]
+    fn survives_a_panicking_job() {
+        spawn(|| panic!("{BOOM}"));
+        assert_eq!(run(|| PAYLOAD), PAYLOAD);
+    }
+
+    #[test]
+    fn run_resumes_the_job_panic() {
+        let payload = catch_unwind(|| run::<()>(|| panic!("{BOOM}"))).expect_err("job must panic");
+        assert_eq!(panic_message(&*payload), BOOM);
+    }
+}

--- a/maki-lua/src/api/ui/mod.rs
+++ b/maki-lua/src/api/ui/mod.rs
@@ -161,11 +161,13 @@ async fn highlight(lua: Lua, code: String, lang: String, opts: Option<Table>) ->
         .and_then(|t| t.get::<String>("prefix").ok())
         .unwrap_or_default();
     let segments = smol::unblock(move || {
-        if independent {
-            maki_highlight::highlight_lines_independent(&lang, &code)
-        } else {
-            maki_highlight::highlight_code(&lang, &code, &prefix)
-        }
+        maki_highlight::pool::run(move || {
+            if independent {
+                maki_highlight::highlight_lines_independent(&lang, &code)
+            } else {
+                maki_highlight::highlight_code(&lang, &code, &prefix)
+            }
+        })
     })
     .await;
     segments_to_lua_lines(&lua, &segments)
@@ -187,7 +189,10 @@ async fn highlight(lua: Lua, code: String, lang: String, opts: Option<Table>) ->
 /// end
 #[lua_fn]
 async fn markdown(lua: Lua, text: String, width: u16) -> LuaResult<Table> {
-    let lines = smol::unblock(move || maki_markdown::render::render(&text, width)).await;
+    let lines = smol::unblock(move || {
+        maki_highlight::pool::run(move || maki_markdown::render::render(&text, width))
+    })
+    .await;
     markdown_lines_to_lua(&lua, &lines)
 }
 

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -589,7 +589,7 @@ impl<'t> EventLoop<'t> {
 
         static PROCESS_WARMUP: std::sync::Once = std::sync::Once::new();
         PROCESS_WARMUP.call_once(|| {
-            std::thread::spawn(crate::highlight::warmup);
+            maki_highlight::pool::spawn(crate::highlight::warmup);
             crate::update::spawn_check();
         });
 

--- a/maki-ui/src/render_worker.rs
+++ b/maki-ui/src/render_worker.rs
@@ -1,27 +1,11 @@
-//! Thread pool for syntax highlighting. Threads scale up to CPU count and exit after
-//! `IDLE_TIMEOUT` (5 s) of inactivity. Jobs carry monotonic u64 IDs so callers can
-//! discard stale results.
+//! Queues tool-content rendering and lets callers discard stale results by ID.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::thread;
-use std::time::Duration;
-
-use tracing::error;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::components::code_view::{self, RenderLimits};
 use maki_agent::{ToolInput, ToolOutput};
 use ratatui::text::Line;
-
-const IDLE_TIMEOUT: Duration = Duration::from_secs(5);
-const FALLBACK_MAX_THREADS: usize = 4;
-
-struct RenderJob {
-    id: u64,
-    tool_input: Option<Arc<ToolInput>>,
-    tool_output: Option<Arc<ToolOutput>>,
-    limits: RenderLimits,
-}
 
 pub struct RenderResult {
     pub id: u64,
@@ -30,35 +14,16 @@ pub struct RenderResult {
 
 static NEXT_JOB_ID: AtomicU64 = AtomicU64::new(0);
 
-struct PoolInner {
-    job_rx: flume::Receiver<RenderJob>,
-    result_tx: flume::Sender<RenderResult>,
-    active_threads: AtomicUsize,
-    max_threads: usize,
-}
-
 pub struct RenderWorker {
-    job_tx: flume::Sender<RenderJob>,
-    inner: Arc<PoolInner>,
+    result_tx: flume::Sender<RenderResult>,
     result_rx: flume::Receiver<RenderResult>,
 }
 
 impl RenderWorker {
     pub fn new() -> Self {
-        let (job_tx, job_rx) = flume::unbounded();
         let (result_tx, result_rx) = flume::unbounded();
-        let max_threads = thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(FALLBACK_MAX_THREADS);
-
         Self {
-            job_tx,
-            inner: Arc::new(PoolInner {
-                job_rx,
-                result_tx,
-                active_threads: AtomicUsize::new(0),
-                max_threads,
-            }),
+            result_tx,
             result_rx,
         }
     }
@@ -70,90 +35,75 @@ impl RenderWorker {
         limits: RenderLimits,
     ) -> u64 {
         let id = NEXT_JOB_ID.fetch_add(1, Ordering::Relaxed);
-        let _ = self.job_tx.send(RenderJob {
-            id,
-            tool_input,
-            tool_output,
-            limits,
+        let result_tx = self.result_tx.clone();
+        maki_highlight::pool::spawn(move || {
+            let content = code_view::render_tool_content(
+                tool_input.as_deref(),
+                tool_output.as_deref(),
+                true,
+                limits,
+            );
+            let _ = result_tx.send(RenderResult {
+                id,
+                lines: content.lines,
+            });
         });
-        self.maybe_spawn_thread();
         id
     }
 
     pub fn try_recv(&self) -> Option<RenderResult> {
         self.result_rx.try_recv().ok()
     }
-
-    fn maybe_spawn_thread(&self) {
-        let current = self.inner.active_threads.load(Ordering::Acquire);
-        if current >= self.inner.max_threads {
-            return;
-        }
-        if self
-            .inner
-            .active_threads
-            .compare_exchange(current, current + 1, Ordering::AcqRel, Ordering::Relaxed)
-            .is_err()
-        {
-            return;
-        }
-
-        let inner = Arc::clone(&self.inner);
-        if let Err(e) = thread::Builder::new()
-            .name("render".into())
-            .spawn(move || worker_loop(&inner))
-        {
-            self.inner.active_threads.fetch_sub(1, Ordering::AcqRel);
-            error!("failed to spawn render thread: {e}");
-        }
-    }
-}
-
-fn worker_loop(inner: &PoolInner) {
-    while let Ok(job) = inner.job_rx.recv_timeout(IDLE_TIMEOUT) {
-        let content = code_view::render_tool_content(
-            job.tool_input.as_deref(),
-            job.tool_output.as_deref(),
-            true,
-            job.limits,
-        );
-        if inner
-            .result_tx
-            .send(RenderResult {
-                id: job.id,
-                lines: content.lines,
-            })
-            .is_err()
-        {
-            break;
-        }
-    }
-    inner.active_threads.fetch_sub(1, Ordering::AcqRel);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn make_worker(active: usize, max: usize) -> RenderWorker {
-        let (job_tx, job_rx) = flume::unbounded();
-        let (result_tx, result_rx) = flume::unbounded();
-        RenderWorker {
-            job_tx,
-            inner: Arc::new(PoolInner {
-                job_rx,
-                result_tx,
-                active_threads: AtomicUsize::new(active),
-                max_threads: max,
-            }),
-            result_rx,
-        }
+    use std::time::Duration;
+
+    use crate::components::code_view::SectionFlags;
+
+    /// The highlight pool is process-global and shared with every other test in
+    /// this binary, so a job can queue behind unrelated work under nextest.
+    const RESULT_TIMEOUT: Duration = Duration::from_secs(60);
+    const OUTPUT_LIMIT: usize = 64;
+    const NO_RESULT: &str = "shared pool never returned the job";
+    const UNEXPECTED_RESULT: &str = "worker received a result it did not submit";
+
+    fn recv_result(worker: &RenderWorker) -> RenderResult {
+        worker
+            .result_rx
+            .recv_timeout(RESULT_TIMEOUT)
+            .expect(NO_RESULT)
+    }
+
+    fn limits() -> RenderLimits {
+        RenderLimits::new(SectionFlags::default(), OUTPUT_LIMIT)
     }
 
     #[test]
-    fn does_not_spawn_when_at_cap() {
-        let worker = make_worker(2, 2);
-        worker.maybe_spawn_thread();
-        assert_eq!(worker.inner.active_threads.load(Ordering::SeqCst), 2);
+    fn empty_jobs_round_trip_through_the_shared_pool() {
+        let worker = RenderWorker::new();
+        let id = worker.send(None, None, limits());
+
+        assert_eq!(recv_result(&worker).id, id);
+    }
+
+    #[test]
+    fn results_route_back_to_the_submitting_worker_with_its_own_id() {
+        let first = RenderWorker::new();
+        let second = RenderWorker::new();
+
+        let first_id = first.send(None, None, limits());
+        let second_id = second.send(None, None, limits());
+        assert_ne!(first_id, second_id);
+
+        assert_eq!(recv_result(&first).id, first_id);
+        assert_eq!(recv_result(&second).id, second_id);
+
+        // Both jobs have completed by now, so a stray result would already be queued.
+        assert!(first.try_recv().is_none(), "{UNEXPECTED_RESULT}");
+        assert!(second.try_recv().is_none(), "{UNEXPECTED_RESULT}");
     }
 }


### PR DESCRIPTION
Syntect keeps a regex cache for every thread that uses it. Heaptrack showed about 10 MB per thread, accounting for 65-84% of peak heap in long sessions.

This moves syntax highlighting from the render and blocking thread pools onto one dedicated thread. Nested highlighting runs inline, since markdown can highlight code blocks while already on that thread.

This trades parallel highlighting for roughly 40-50 MB less retained memory.

## AI use

Maki implemented this change, and Claude Opus analyzed the heaptrack dumps that identified the per-thread regex caches.
