### PR TITLE
fix(ui): keep scrollbar glyphs out of overlay copy

### DIFF
--- a/maki-ui/src/app/mouse.rs
+++ b/maki-ui/src/app/mouse.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 use crate::clipboard::CopyResult;
+use crate::components::scrollbar;
 use crate::selection::{
     self, ContentRegion, DocPos, EdgeScroll, RowPos, ScreenSelection, Selection, SelectionState,
     SelectionZone,
@@ -206,8 +207,12 @@ impl App {
                     self.selection_state = None;
                     return;
                 };
+                let mut area = sel.area;
+                if scrollbar::is_enabled() {
+                    area.width = area.width.saturating_sub(1);
+                }
                 let regions = [ContentRegion {
-                    area: sel.area,
+                    area,
                     ..Default::default()
                 }];
                 selection::extract_selected_text(buf, &screen_sel, &regions)

--- a/maki-ui/src/components/btw_modal.rs
+++ b/maki-ui/src/components/btw_modal.rs
@@ -1,7 +1,7 @@
 use crate::components::ModalScroll;
 use crate::components::Overlay;
 use crate::components::modal::Modal;
-use crate::components::scrollbar::render_vertical_scrollbar;
+use crate::components::scrollbar::render_vertical_scrollbar_in_border;
 use crate::components::streaming_content::StreamingContent;
 use crate::components::tool_display::{assistant_style, thinking_indicator, thinking_style};
 use crate::theme;
@@ -172,7 +172,7 @@ impl BtwModal {
         frame.render_widget(paragraph, padded);
 
         if total > viewport_h {
-            render_vertical_scrollbar(frame, inner, u32::from(total), u32::from(scroll));
+            render_vertical_scrollbar_in_border(frame, inner, u32::from(total), u32::from(scroll));
         }
 
         popup

--- a/maki-ui/src/components/help_modal.rs
+++ b/maki-ui/src/components/help_modal.rs
@@ -4,7 +4,7 @@ use crate::components::keybindings::{
     ALT_SEP, KEYBINDS, KeybindContext, ResolvedLabel, all_contexts, key,
 };
 use crate::components::modal::Modal;
-use crate::components::scrollbar::render_vertical_scrollbar;
+use crate::components::scrollbar::render_vertical_scrollbar_in_border;
 use crate::theme;
 
 use crossterm::event::{KeyCode, KeyEvent};
@@ -215,7 +215,7 @@ impl HelpModal {
         frame.render_widget(paragraph, inner);
 
         if total > viewport_h {
-            render_vertical_scrollbar(frame, inner, u32::from(total), u32::from(scroll));
+            render_vertical_scrollbar_in_border(frame, inner, u32::from(total), u32::from(scroll));
         }
 
         popup

--- a/maki-ui/src/components/scrollbar.rs
+++ b/maki-ui/src/components/scrollbar.rs
@@ -28,14 +28,33 @@ pub fn render_vertical_scrollbar(frame: &mut Frame, area: Rect, content_len: u32
         .content_length(max_scroll as usize + 1)
         .position(position as usize);
 
-    let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+    let scrollbar = scrollbar_widget();
+
+    frame.render_stateful_widget(scrollbar, area, &mut state);
+}
+
+/// Paints the scrollbar into the border column immediately right of `inner`,
+/// so no content cell is overwritten and copied text stays clean.
+pub fn render_vertical_scrollbar_in_border(
+    frame: &mut Frame,
+    inner: Rect,
+    content_len: u32,
+    position: u32,
+) {
+    if inner.height <= 2 || inner.right() >= frame.area().width {
+        return;
+    }
+    let rail = Rect::new(inner.right(), inner.y + 1, 1, inner.height - 2);
+    render_vertical_scrollbar(frame, rail, content_len, position);
+}
+
+fn scrollbar_widget() -> Scrollbar<'static> {
+    Scrollbar::new(ScrollbarOrientation::VerticalRight)
         .thumb_symbol(SCROLLBAR_THUMB)
         // ListPicker renders highlighted rows over the scrollbar track; resetting
         // the thumb style keeps its color stable instead of inheriting row bg.
         .thumb_style(Style::new().fg(Color::Reset).bg(Color::Reset))
         .track_symbol(None)
         .begin_symbol(None)
-        .end_symbol(None);
-
-    frame.render_stateful_widget(scrollbar, area, &mut state);
+        .end_symbol(None)
 }

--- a/maki-ui/src/components/scrollbar.rs
+++ b/maki-ui/src/components/scrollbar.rs
@@ -5,7 +5,12 @@ use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 use ratatui::widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState};
 
+use crate::theme;
+
 pub const SCROLLBAR_THUMB: &str = "\u{2590}";
+
+const THIN_TRACK: &str = "\u{2502}";
+const HEAVY_THUMB: &str = "\u{2503}";
 
 static ENABLED: AtomicBool = AtomicBool::new(true);
 
@@ -33,19 +38,28 @@ pub fn render_vertical_scrollbar(frame: &mut Frame, area: Rect, content_len: u32
     frame.render_stateful_widget(scrollbar, area, &mut state);
 }
 
-/// Paints the scrollbar into the border column immediately right of `inner`,
-/// so no content cell is overwritten and copied text stays clean.
+/// Paints the scrollbar onto the dialog's right border: the track is a `│` in
+/// the panel border color, so the border stays continuous, and the thumb is a
+/// heavy `┃` that reads as the border thickening under the viewport.
 pub fn render_vertical_scrollbar_in_border(
     frame: &mut Frame,
     inner: Rect,
     content_len: u32,
     position: u32,
 ) {
-    if inner.height <= 2 || inner.right() >= frame.area().width {
+    if inner.height <= 2 {
         return;
     }
     let rail = Rect::new(inner.right(), inner.y + 1, 1, inner.height - 2);
-    render_vertical_scrollbar(frame, rail, content_len, position);
+    let max_scroll = content_len.saturating_sub(u32::from(rail.height));
+    let mut state = ScrollbarState::default()
+        .content_length(max_scroll as usize + 1)
+        .position(position as usize);
+    let scrollbar = scrollbar_widget()
+        .track_symbol(Some(THIN_TRACK))
+        .track_style(theme::current().panel_border)
+        .thumb_symbol(HEAVY_THUMB);
+    frame.render_stateful_widget(scrollbar, rail, &mut state);
 }
 
 fn scrollbar_widget() -> Scrollbar<'static> {

--- a/maki-ui/src/components/usage_modal.rs
+++ b/maki-ui/src/components/usage_modal.rs
@@ -18,7 +18,7 @@ use ratatui::widgets::Paragraph;
 use crate::components::ModalScroll;
 use crate::components::keybindings::key;
 use crate::components::modal::Modal;
-use crate::components::scrollbar::render_vertical_scrollbar;
+use crate::components::scrollbar::render_vertical_scrollbar_in_border;
 use crate::repaint::{Dirty, Watch};
 use crate::theme;
 
@@ -126,7 +126,7 @@ impl UsageModal {
         frame.render_widget(Paragraph::new(lines).scroll((scroll, 0)), inner);
 
         if total > viewport_h {
-            render_vertical_scrollbar(frame, inner, u32::from(total), u32::from(scroll));
+            render_vertical_scrollbar_in_border(frame, inner, u32::from(total), u32::from(scroll));
         }
 
         let hint = Line::from(vec![

--- a/maki-ui/src/selection.rs
+++ b/maki-ui/src/selection.rs
@@ -672,6 +672,21 @@ mod tests {
     }
 
     #[test]
+    fn extract_excludes_scrollbar_rail_column() {
+        let area = Rect::new(0, 0, 10, 3);
+        let mut buf = Buffer::empty(area);
+        buf.set_string(0, 0, "hello     ", Style::default());
+        buf[(9, 0)].set_symbol("▐");
+
+        let region = ContentRegion {
+            area: Rect::new(0, 0, area.width.saturating_sub(1), 3),
+            ..Default::default()
+        };
+        let text = extract_selected_text(&buf, &ss(0, 0, 2, 8), &[region]);
+        assert_eq!(text, "hello");
+    }
+
+    #[test]
     fn extract_skips_uncovered_rows() {
         let area = Rect::new(0, 0, 10, 5);
         let mut buf = Buffer::empty(area);


### PR DESCRIPTION
Closes #917. Relates to #409, #248. Negative prior art: copilot-cli#4009.

## Problem

Overlay-zone copy is cell-based, and modal scrollbars painted `▐` into the last **content** column of the inner area, so any full-width selection in `/btw`, usage modal, or help modal dragged scrollbar glyphs into the clipboard. Chat copy was unaffected (state-based via segment cache).

## Fix

1. `render_vertical_scrollbar_in_border` renders the scrollbar into the border column right of `inner` (ratatui's Scrollbar only paints the rightmost column of its rect, so border placement is the supported pattern). btw/usage/help modals switched; `lua_float` left as-is since its border is conditional on `win.config.border`.
2. Overlay copy region narrowed by 1 column when scrollbars are enabled (`scrollbar::is_enabled()`), mirroring the existing `msg_area()` precedent. Defensive: zones already register the inner rect via `inset_border`.

## Testing

- New unit test `extract_excludes_scrollbar_rail_column`: buffer with `▐` at the rail column asserts extraction excludes it.
- `cargo clippy -p maki-ui --tests -- -D warnings` clean.
- Full `cargo test -p maki-ui`: all green except pre-existing flake `components::messages::tests::live_snapshot_uses_panel_generation`, which reproduces on clean `main` (verified via stash round-trip) and is unrelated.
- Manual: `/btw` → select full width → paste contains no `▐`.