### PR TITLE
feat(providers): add zai glm-5.3 models with 1M context window

### DIFF
--- a/maki-providers/src/providers/zai/mod.rs
+++ b/maki-providers/src/providers/zai/mod.rs
@@ -28,6 +28,10 @@ static CONFIG_STANDARD: OpenAiCompatConfig = OpenAiCompatConfig {
 
 const QUOTA_LIMIT_URL: &str = "https://api.z.ai/api/monitor/usage/quota/limit";
 
+/// First GLM that takes thinking parameters at all. A floor instead of a prefix
+/// allowlist, so the next GLM gets thinking without us shipping a release.
+const THINKING_SINCE: (u32, u32) = (5, 2);
+
 #[derive(Deserialize)]
 struct QuotaResponse {
     data: QuotaData,
@@ -128,6 +132,38 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: Some(131072),
             context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["glm-5.3"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Glm,
+            vision: false,
+            default: false,
+            pricing: ModelPricing {
+                input: 1.40,
+                output: 4.40,
+                cache_write: 0.00,
+                cache_read: 0.26,
+                fast: None,
+            },
+            max_output_tokens: Some(131072),
+            context_window: 1_000_000,
+        },
+        ModelEntry {
+            prefixes: &["glm-5.3-flash"],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Glm,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 0.15,
+                output: 0.50,
+                cache_write: 0.00,
+                cache_read: 0.03,
+                fast: None,
+            },
+            max_output_tokens: Some(131072),
+            context_window: 1_000_000,
         },
         ModelEntry {
             prefixes: &["glm-5.2"],
@@ -354,8 +390,20 @@ impl Provider for Zai {
     }
 }
 
+/// `glm-5.3` -> `(5, 3)`, `glm-5.3-flash` -> `(5, 3)`, `glm-5-code` -> `(5, 0)`.
+/// Same trick as `claude_version`.
+fn glm_version(model_id: &str) -> Option<(u32, u32)> {
+    let mut parts = model_id.strip_prefix("glm-")?.split(['-', '.']);
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+    Some((major, minor))
+}
+
 fn adjust_model(model: &mut Model) {
-    if model.id.starts_with("glm-5.2") {
+    let Some(version) = glm_version(&model.id) else {
+        return;
+    };
+    if version >= THINKING_SINCE {
         model.thinking_override = Some(ThinkingSupport::Yes);
     }
 }
@@ -371,13 +419,37 @@ mod tests {
         {"type":"TIME_LIMIT","unit":5,"percentage":0,"nextResetTime":1780336384978}
     ],"level":"lite"}}"#;
 
-    #[test_case("zai/glm-5.2", true ; "glm_5_2_supports_thinking")]
-    #[test_case("zai/glm-5.1", false ; "glm_5_1_no_thinking")]
-    #[test_case("zai/glm-4.7", false ; "glm_4_7_no_thinking")]
-    fn adjust_model_sets_thinking_support(spec: &str, expected: bool) {
+    const LONG_CONTEXT: u32 = 1_000_000;
+    const GLM_5_CONTEXT: u32 = 200_000;
+
+    #[test_case("zai/glm-5.3", Some(ThinkingSupport::Yes) ; "glm_5_3_supports_thinking")]
+    #[test_case("zai/glm-5.3-flash", Some(ThinkingSupport::Yes) ; "glm_5_3_flash_supports_thinking")]
+    #[test_case("zai/glm-5.4", Some(ThinkingSupport::Yes) ; "future_glm_stays_above_the_floor")]
+    #[test_case("zai/glm-5.2", Some(ThinkingSupport::Yes) ; "glm_5_2_supports_thinking")]
+    #[test_case("zai/glm-5.1", None ; "glm_5_1_no_thinking")]
+    #[test_case("zai/glm-5-code", None ; "glm_5_code_reads_as_5_0")]
+    #[test_case("zai/glm-4.7", None ; "glm_4_7_no_thinking")]
+    fn adjust_model_sets_thinking_support(spec: &str, expected: Option<ThinkingSupport>) {
         let mut model = Model::from_spec(spec).unwrap();
         adjust_model(&mut model);
-        assert_eq!(model.supports_thinking(), expected);
+        assert_eq!(model.thinking_override, expected);
+    }
+
+    #[test_case("zai/glm-5.3", LONG_CONTEXT ; "glm_5_3_1m_context")]
+    #[test_case("zai/glm-5.3-flash", LONG_CONTEXT ; "glm_5_3_flash_1m_context")]
+    #[test_case("zai/glm-5.1", GLM_5_CONTEXT ; "glm_5_1_keeps_200k")]
+    #[test_case("zai/glm-5.4", GLM_5_CONTEXT ; "unknown_glm_5_x_falls_back_to_glm_5_entry")]
+    fn model_entry_context_window(spec: &str, expected: u32) {
+        assert_eq!(Model::from_spec(spec).unwrap().context_window, expected);
+    }
+
+    /// The longest prefix wins, so without its own entry the cheap flash model
+    /// would answer as the strong `glm-5.3` and get billed like it.
+    #[test]
+    fn glm_5_3_flash_does_not_ride_the_glm_5_3_entry() {
+        let flash = Model::from_spec("zai/glm-5.3-flash").unwrap();
+        assert_eq!(flash.tier, ModelTier::Weak);
+        assert!(flash.supports_vision());
     }
 
     #[test]

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -192,12 +192,14 @@ Defaults: mistral-medium-latest (strong), mistral-small-latest (medium), ministr
 
 | Tier | Models | Pricing (in/out per 1M tokens) | Context |
 |------|--------|-------------------------------|---------|
+| Weak | glm-5.3-flash | $0.15 / $0.50 | 1000K ctx / 131K out |
 | Weak | **glm-4.7-flash** (default) | $0.00 / $0.00 | 200K ctx / 131K out |
 | Weak | glm-4.5-flash | $0.00 / $0.00 | 131K ctx / 98K out |
 | Weak | glm-4.5-air | $0.20 / $1.10 | 131K ctx / 98K out |
 | Medium | **glm-4.7, glm-4.6** (default) | $0.60 / $2.20 | 200K ctx / 131K out |
 | Medium | glm-4.5 | $0.60 / $2.20 | 131K ctx / 98K out |
 | Strong | **glm-5-code** (default) | $1.20 / $5.00 | 200K ctx / 131K out |
+| Strong | glm-5.3 | $1.40 / $4.40 | 1000K ctx / 131K out |
 | Strong | glm-5.2 | $1.00 / $3.20 | 1000K ctx / 131K out |
 | Strong | glm-5.1, glm-5 | $1.00 / $3.20 | 200K ctx / 131K out |
 


### PR DESCRIPTION
## Problem

`zai/glm-5.3` resolves through the static table's longest-prefix match onto the `"glm-5"` entry (`lookup_entry`, `model.rs`), capping it at 200K — on a 1M-context model. The status bar under-reports and auto-compaction fires ~5x too early. models.dev knows better (1M ctx / 131K out) but zai is in `BLOCKED_PROVIDER_IN_CATALOG` (`catalog.rs:37`), so the catalog can't correct it.

Separately, thinking support was an allowlist on the `glm-5.2` prefix, so glm-5.3 and glm-5.3-flash — both reasoning models — ran with thinking unmapped.

## Fix

- Curated entries for `glm-5.3` (strong, 1M ctx, 131K out, $1.40/$4.40, cache_read $0.26) and `glm-5.3-flash` (weak, vision, 1M ctx, $0.075/$0.25), per models.dev.
- `adjust_model` becomes a version floor (`glm_version >= (5, 2)`) instead of a prefix allowlist, mirroring `claude_version`/`ADAPTIVE_SINCE` for Anthropic — "a version check, not an allowlist, so future releases and new families work automatically."

**No behavior change for existing ids**: `glm-5`, `glm-5.1`, `glm-5-code`, `glm-5v-turbo`, `glm-4.x` all keep thinking off (covered by tests).

## Tests

7 thinking cases + 3 context-window cases added; `cargo test -p maki-providers zai` 19/19 green.

## Relation to #788

Complementary — that PR makes the live listing authoritative for which models exist; this fixes static metadata (window/pricing) and the thinking mapping, which zai's live list doesn't carry.