### PR TITLE
feat(theme): style diff signs and line numbers separately 🤖🤖🤖

### DIFF
--- a/maki-docgen/src/gen_config.rs
+++ b/maki-docgen/src/gen_config.rs
@@ -124,6 +124,15 @@ fn write_theme_section(out: &mut String) {
     .unwrap();
     writeln!(
         out,
+        "Diff signs use `diff_old_sign` and `diff_new_sign`, which default to \
+         `diff_old` and `diff_new`. These styles are applied after `code_block`, \
+         so their properties take precedence. Diff gutters use \
+         `diff_old_line_nr` and `diff_new_line_nr`, which default to \
+         `diff_line_nr`.\n"
+    )
+    .unwrap();
+    writeln!(
+        out,
         "Themes use 24-bit colors by default, but not every terminal can show \
          them. Maki checks the environment, terminfo, and the terminal itself, \
          and when truecolor is missing it quietly falls back to the closest of \

--- a/maki-lua/tests/batch_policy.rs
+++ b/maki-lua/tests/batch_policy.rs
@@ -1083,16 +1083,16 @@ fn edit_child_body_renders_diff_not_summary() {
         ] })),
     );
     let spans: Vec<(String, SpanStyle)> = lines.into_iter().flatten().collect();
-    let old_span = (
-        "- let a = 1;".to_owned(),
-        SpanStyle::Named("diff_old".into()),
-    );
-    let new_span = (
-        "+ let a = 2;".to_owned(),
-        SpanStyle::Named("diff_new".into()),
-    );
-    assert!(spans.contains(&old_span), "old line in diff_old: {spans:?}");
-    assert!(spans.contains(&new_span), "new line in diff_new: {spans:?}");
+    let expected_spans = [
+        ("- ", "diff_old_sign"),
+        ("let a = 1;", "diff_old"),
+        ("+ ", "diff_new_sign"),
+        ("let a = 2;", "diff_new"),
+    ];
+    for (text, style) in expected_spans {
+        let span = (text.to_owned(), SpanStyle::Named(style.into()));
+        assert!(spans.contains(&span), "{text:?} in {style}: {spans:?}");
+    }
     assert!(
         !spans
             .iter()

--- a/maki-ui/src/components/code_view.rs
+++ b/maki-ui/src/components/code_view.rs
@@ -24,7 +24,11 @@ fn nr_width(max_nr: usize) -> usize {
 }
 
 fn gutter(nr_str: &str) -> Span<'static> {
-    Span::styled(format!("{nr_str} "), theme::current().diff_line_nr)
+    gutter_styled(nr_str, theme::current().diff_line_nr)
+}
+
+fn gutter_styled(nr_str: &str, style: Style) -> Span<'static> {
+    Span::styled(format!("{nr_str} "), style)
 }
 
 fn gap_ellipsis() -> Line<'static> {
@@ -186,8 +190,8 @@ fn render_diff(
     lines
 }
 
-fn numbered_gutter(line_nr: &mut usize, w: usize) -> Span<'static> {
-    let span = gutter(&format!("{line_nr:>w$}"));
+fn numbered_gutter(line_nr: &mut usize, w: usize, style: Style) -> Span<'static> {
+    let span = gutter_styled(&format!("{line_nr:>w$}"), style);
     *line_nr += 1;
     span
 }
@@ -207,17 +211,21 @@ fn render_hunk_line(
                 before.skip();
                 after.highlight_next()
             });
-            let mut spans = vec![numbered_gutter(line_nr, w), Span::raw("  ")];
+            let mut spans = vec![
+                numbered_gutter(line_nr, w, theme.diff_line_nr),
+                Span::raw("  "),
+            ];
             spans.extend(syntax_to_spans(after_spans, t));
             Line::from(spans)
         }
         DiffLine::Removed(ds) => {
             let before_spans = walkers.and_then(|(before, _)| before.highlight_next());
-            let mut spans = vec![numbered_gutter(line_nr, w)];
+            let mut spans = vec![numbered_gutter(line_nr, w, theme.diff_old_line_nr)];
             spans.extend(diff_change_spans(
                 "- ",
                 ds,
                 before_spans,
+                theme.diff_old_sign,
                 theme.diff_old,
                 theme.diff_old_emphasis,
             ));
@@ -225,11 +233,12 @@ fn render_hunk_line(
         }
         DiffLine::Added(ds) => {
             let after_spans = walkers.and_then(|(_, after)| after.highlight_next());
-            let mut spans = vec![gutter(&" ".repeat(w))];
+            let mut spans = vec![gutter_styled(&" ".repeat(w), theme.diff_new_line_nr)];
             spans.extend(diff_change_spans(
                 "+ ",
                 ds,
                 after_spans,
+                theme.diff_new_sign,
                 theme.diff_new,
                 theme.diff_new_emphasis,
             ));
@@ -249,12 +258,13 @@ fn diff_change_spans(
     prefix: &'static str,
     ds: &[DiffSpan],
     syntax: Option<Vec<Span<'static>>>,
+    sign: Style,
     base: Style,
     emph: Style,
 ) -> Vec<Span<'static>> {
     let mut spans = vec![Span::styled(
         prefix,
-        base.patch(theme::current().code_block),
+        theme::current().code_block.patch(sign),
     )];
     match syntax {
         Some(syn) => spans.extend(merge_syntax_with_diff(&syn, ds, base, emph)),
@@ -701,6 +711,86 @@ mod tests {
         let diff = vec![plain("ab")];
         let result = merge_syntax_with_diff(&syn, &diff, base, Style::default());
         assert_eq!(spans_text(&result), "abcd");
+    }
+
+    #[test]
+    fn diff_change_spans_uses_sign_style_for_prefix_only() {
+        theme::set(
+            theme::Theme::from_toml(
+                r##"
+[palette]
+foreground = "#ffffff"
+
+[ui]
+code_block = { fg = "foreground" }
+"##,
+            )
+            .expect("theme must parse"),
+        );
+        let sign = Style::new().fg(Color::Red);
+        let base = Style::new().bg(Color::Blue);
+        let emph = Style::new().bg(Color::Green);
+        let ds = vec![plain("x")];
+        let result = diff_change_spans("- ", &ds, None, sign, base, emph);
+        assert_eq!(result[0].content.as_ref(), "- ");
+        assert_eq!(result[0].style.fg, Some(Color::Red));
+        assert_eq!(result[1].style.bg, Some(Color::Blue));
+    }
+
+    #[test]
+    fn numbered_gutter_applies_given_style_and_advances_counter() {
+        let style = Style::new().bg(Color::Magenta);
+        let mut nr = 5;
+        let span = numbered_gutter(&mut nr, 2, style);
+        assert_eq!(span.content.as_ref(), " 5 ");
+        assert_eq!(span.style.bg, Some(Color::Magenta));
+        assert_eq!(nr, 6);
+    }
+
+    const DIFF_GUTTER_TEST_THEME: &str = r##"
+[palette]
+old_sign = "#111111"
+old_code = "#222222"
+old_nr = "#333333"
+new_sign = "#444444"
+new_code = "#555555"
+new_nr = "#666666"
+
+[ui]
+diff_old = { fg = "old_code" }
+diff_new = { fg = "new_code" }
+diff_old_sign = { fg = "old_sign" }
+diff_new_sign = { fg = "new_sign" }
+diff_old_line_nr = { fg = "old_nr" }
+diff_new_line_nr = { fg = "new_nr" }
+"##;
+
+    #[test]
+    fn render_diff_wires_dedicated_sign_and_line_nr_styles() {
+        theme::set(theme::Theme::from_toml(DIFF_GUTTER_TEST_THEME).expect("theme must parse"));
+
+        let before = "keep\nold\n";
+        let after = "keep\nnew\n";
+        let lines = render_diff(None, before, after);
+
+        let old_sign_fg = Some(Color::Rgb(0x11, 0x11, 0x11));
+        let old_nr_fg = Some(Color::Rgb(0x33, 0x33, 0x33));
+        let new_sign_fg = Some(Color::Rgb(0x44, 0x44, 0x44));
+        let new_nr_fg = Some(Color::Rgb(0x66, 0x66, 0x66));
+
+        let unchanged = &lines[0];
+        assert_eq!(unchanged.spans[0].style, theme::current().diff_line_nr);
+
+        let removed = &lines[1];
+        assert_eq!(removed.spans[0].style.fg, old_nr_fg);
+        assert_eq!(removed.spans[1].content.as_ref(), "- ");
+        assert_eq!(removed.spans[1].style.fg, old_sign_fg);
+
+        let added = &lines[2];
+        assert_eq!(added.spans[0].content.as_ref().trim(), "");
+        assert_eq!(added.spans[0].style.fg, new_nr_fg);
+        assert_eq!(added.spans[1].content.as_ref(), "+ ");
+        assert_eq!(added.spans[1].style.fg, new_sign_fg);
     }
 
     fn grep_entries(files: &[(&str, &[usize])]) -> Vec<GrepFileEntry> {

--- a/maki-ui/src/theme.rs
+++ b/maki-ui/src/theme.rs
@@ -383,6 +383,11 @@ pub fn style_by_name(name: &str) -> Style {
         "line_nr" | "index_line_nr" => t.index_line_nr,
         "diff_old" => t.diff_old,
         "diff_new" => t.diff_new,
+        "diff_old_sign" => t.diff_old_sign,
+        "diff_new_sign" => t.diff_new_sign,
+        "diff_line_nr" => t.diff_line_nr,
+        "diff_old_line_nr" => t.diff_old_line_nr,
+        "diff_new_line_nr" => t.diff_new_line_nr,
         "item" => t.item,
         "item_desc" => t.item_desc,
         "item_selected" | "selected" => t.item_selected,
@@ -436,9 +441,13 @@ pub struct Theme {
     pub table_border: Style,
     pub diff_old: Style,
     pub diff_new: Style,
+    pub diff_old_sign: Style,
+    pub diff_new_sign: Style,
     pub diff_old_emphasis: Style,
     pub diff_new_emphasis: Style,
     pub diff_line_nr: Style,
+    pub diff_old_line_nr: Style,
+    pub diff_new_line_nr: Style,
     pub todo_completed: Style,
     pub todo_in_progress: Style,
     pub todo_pending: Style,
@@ -756,6 +765,7 @@ impl Theme {
                 .map(|d| resolve_style(d, &palette))
                 .unwrap_or_default()
         };
+        let style_or = |key: &str, fallback: &str| -> Style { style(fallback).patch(style(key)) };
 
         let derived_color = |ui_key: &str, scopes: &[&str]| -> Color {
             if let Some(c) = palette.get(ui_key) {
@@ -850,9 +860,13 @@ impl Theme {
             table_border: style("table_border"),
             diff_old: style("diff_old"),
             diff_new: style("diff_new"),
+            diff_old_sign: style_or("diff_old_sign", "diff_old"),
+            diff_new_sign: style_or("diff_new_sign", "diff_new"),
             diff_old_emphasis: style("diff_old_emphasis"),
             diff_new_emphasis: style("diff_new_emphasis"),
             diff_line_nr: style("diff_line_nr"),
+            diff_old_line_nr: style_or("diff_old_line_nr", "diff_line_nr"),
+            diff_new_line_nr: style_or("diff_new_line_nr", "diff_line_nr"),
             todo_completed: style("todo_completed"),
             todo_in_progress: style("todo_in_progress"),
             todo_pending: style("todo_pending"),
@@ -1233,6 +1247,87 @@ mode_build = "#112233"
     }
 
     #[test]
+    fn diff_sign_and_line_nr_fall_back_to_legacy_keys_when_unset() {
+        let toml = r##"
+[palette]
+foreground = "#f8f8f2"
+background = "#282a36"
+red = "#ff5555"
+green = "#50fa7b"
+grey = "#6272a4"
+
+[ui]
+diff_old = { fg = "red" }
+diff_new = { fg = "green" }
+diff_line_nr = { fg = "grey" }
+"##;
+        let t = Theme::from_toml(toml).unwrap();
+        assert_eq!(t.diff_old_sign, t.diff_old);
+        assert_eq!(t.diff_new_sign, t.diff_new);
+        assert_eq!(t.diff_old_line_nr, t.diff_line_nr);
+        assert_eq!(t.diff_new_line_nr, t.diff_line_nr);
+    }
+
+    #[test]
+    fn diff_sign_and_line_nr_keys_override_legacy_fallback() {
+        let toml = r##"
+[palette]
+foreground = "#f8f8f2"
+background = "#282a36"
+red = "#ff5555"
+green = "#50fa7b"
+grey = "#6272a4"
+old_sign = "#aa1111"
+new_sign = "#11aa11"
+old_nr = "#222222"
+new_nr = "#333333"
+
+[ui]
+diff_old = { fg = "red" }
+diff_new = { fg = "green" }
+diff_line_nr = { fg = "grey" }
+diff_old_sign = { fg = "old_sign" }
+diff_new_sign = { fg = "new_sign" }
+diff_old_line_nr = { fg = "old_nr" }
+diff_new_line_nr = { fg = "new_nr" }
+"##;
+        let t = Theme::from_toml(toml).unwrap();
+        assert_eq!(t.diff_old_sign.fg, Some(Color::Rgb(0xaa, 0x11, 0x11)));
+        assert_ne!(t.diff_old_sign, t.diff_old);
+        assert_eq!(t.diff_new_sign.fg, Some(Color::Rgb(0x11, 0xaa, 0x11)));
+        assert_ne!(t.diff_new_sign, t.diff_new);
+        assert_eq!(t.diff_old_line_nr.fg, Some(Color::Rgb(0x22, 0x22, 0x22)));
+        assert_ne!(t.diff_old_line_nr, t.diff_line_nr);
+        assert_eq!(t.diff_new_line_nr.fg, Some(Color::Rgb(0x33, 0x33, 0x33)));
+        assert_ne!(t.diff_new_line_nr, t.diff_line_nr);
+    }
+
+    #[test]
+    fn diff_sign_and_line_nr_keys_merge_over_legacy_fallback() {
+        let toml = r##"
+[palette]
+foreground = "#f8f8f2"
+background = "#282a36"
+red = "#ff5555"
+old_bg = "#4d1f1f"
+new_bg = "#1f4d1f"
+grey_bg = "#333333"
+
+[ui]
+diff_old = { bg = "old_bg" }
+diff_new = { bg = "new_bg" }
+diff_line_nr = { bg = "grey_bg" }
+diff_old_sign = { fg = "red" }
+diff_new_line_nr = { fg = "red" }
+"##;
+        let t = Theme::from_toml(toml).unwrap();
+        assert_eq!(t.diff_old_sign.fg, Some(Color::Rgb(0xff, 0x55, 0x55)));
+        assert_eq!(t.diff_old_sign.bg, t.diff_old.bg);
+        assert_eq!(t.diff_new_line_nr.fg, Some(Color::Rgb(0xff, 0x55, 0x55)));
+        assert_eq!(t.diff_new_line_nr.bg, t.diff_line_nr.bg);
+    }
+
+    #[test]
     fn style_by_name_resolves() {
         set(dracula());
         let t = current();
@@ -1253,6 +1348,11 @@ mode_build = "#112233"
         assert_eq!(style_by_name("bold_italic"), t.bold_italic);
         assert_eq!(style_by_name("diff_old"), t.diff_old);
         assert_eq!(style_by_name("diff_new"), t.diff_new);
+        assert_eq!(style_by_name("diff_old_sign"), t.diff_old_sign);
+        assert_eq!(style_by_name("diff_new_sign"), t.diff_new_sign);
+        assert_eq!(style_by_name("diff_line_nr"), t.diff_line_nr);
+        assert_eq!(style_by_name("diff_old_line_nr"), t.diff_old_line_nr);
+        assert_eq!(style_by_name("diff_new_line_nr"), t.diff_new_line_nr);
         assert_eq!(style_by_name("item_selected"), t.item_selected);
         assert_eq!(style_by_name("item"), t.item);
         assert_eq!(style_by_name("item_desc"), t.item_desc);

--- a/plugins/edit/init.lua
+++ b/plugins/edit/init.lua
@@ -8,6 +8,9 @@ local preserve_line_endings = require("edit_helpers").preserve_line_endings
 local SNIPPET_MAX_CHARS = 32
 local FALLBACK_VIEW_LINES = 10
 
+local DIFF_OLD = { style = "diff_old", prefix = "- ", sign = "diff_old_sign", nr = "diff_old_line_nr" }
+local DIFF_NEW = { style = "diff_new", prefix = "+ ", sign = "diff_new_sign", nr = "diff_new_line_nr" }
+
 local EDIT_LINES_DESCRIPTION =
   [[Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new_string`. Use empty `new_string` to delete a range. Do not use with the batch tool.]]
 
@@ -99,11 +102,11 @@ end
 -- The one gutter builder both render passes share: the plain render and
 -- the async highlight rewrite must produce byte-identical gutters or the
 -- columns shift when highlights land.
-local function nr_span(fmt, start_nr, i)
-  return { string.format(fmt, start_nr and (start_nr + i - 1) or ""), "line_nr" }
+local function nr_span(fmt, start_nr, i, style)
+  return { string.format(fmt, start_nr and (start_nr + i - 1) or ""), style }
 end
 
-local function append_diff_lines(view, text, style, prefix, nr_fmt, start_nr, jobs)
+local function append_diff_lines(view, text, side, nr_fmt, start_nr, jobs)
   local lines = split_lines(text or "")
   if #lines == 0 then
     return
@@ -111,16 +114,16 @@ local function append_diff_lines(view, text, style, prefix, nr_fmt, start_nr, jo
   jobs[#jobs + 1] = {
     first = #view.all_lines + 1,
     text = table.concat(lines, "\n"),
-    style = style,
-    prefix = prefix,
+    side = side,
     start_nr = start_nr,
   }
   for i, line in ipairs(lines) do
     local spans = {}
     if nr_fmt then
-      spans[#spans + 1] = nr_span(nr_fmt, start_nr, i)
+      spans[#spans + 1] = nr_span(nr_fmt, start_nr, i, side.nr)
     end
-    spans[#spans + 1] = { prefix .. line, style }
+    spans[#spans + 1] = { side.prefix, side.sign }
+    spans[#spans + 1] = { line, side.style }
     view:append(spans)
   end
 end
@@ -130,7 +133,7 @@ end
 local function apply_highlights(view, fmt, jobs, ext)
   maki.async.run(function()
     for _, job in ipairs(jobs) do
-      local bg = maki.ui.theme_color(job.style)
+      local bg = maki.ui.theme_color(job.side.style)
       local highlighted = bg and maki.ui.highlight(job.text, ext)
       for i, hl_line in ipairs(highlighted or {}) do
         local idx = job.first + i - 1
@@ -139,9 +142,9 @@ local function apply_highlights(view, fmt, jobs, ext)
         end
         local spans = {}
         if fmt then
-          spans[#spans + 1] = nr_span(fmt, job.start_nr, i)
+          spans[#spans + 1] = nr_span(fmt, job.start_nr, i, job.side.nr)
         end
-        spans[#spans + 1] = { job.prefix, { bg = bg } }
+        spans[#spans + 1] = { job.side.prefix, job.side.sign }
         for _, seg in ipairs(hl_line) do
           local s = type(seg[2]) == "table" and seg[2] or {}
           s.bg = bg
@@ -164,16 +167,16 @@ local function diff_view(blocks, path)
   local w = gutter_width(blocks)
   local fmt = w > 0 and ("%" .. w .. "s ") or nil
   local jobs = {}
-  local function append(text, style, prefix, start_nr)
-    append_diff_lines(view, text, style, prefix, fmt, start_nr, jobs)
+  local function append(text, side, start_nr)
+    append_diff_lines(view, text, side, fmt, start_nr, jobs)
   end
   for i, block in ipairs(blocks) do
     if i > 1 then
       view:append({})
     end
     local has_old = (block.old or "") ~= ""
-    append(block.old, "diff_old", "- ", block.nr)
-    append(block.new, "diff_new", "+ ", not has_old and block.nr or nil)
+    append(block.old, DIFF_OLD, block.nr)
+    append(block.new, DIFF_NEW, not has_old and block.nr or nil)
   end
   view:finish()
   local ext = (path or ""):match("%.([^%.]+)$")

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -87,6 +87,8 @@ Available themes: `ayu_dark`, `ayu_light`, `ayu_mirage`, `carbonfox`, `catppucci
 
 You can add your own themes too. Drop a `<name>.toml` file into `themes/` inside your Maki config directory, for example `~/.config/maki/themes/`. If it reuses a built-in name, yours wins.
 
+Diff signs use `diff_old_sign` and `diff_new_sign`, which default to `diff_old` and `diff_new`. These styles are applied after `code_block`, so their properties take precedence. Diff gutters use `diff_old_line_nr` and `diff_new_line_nr`, which default to `diff_line_nr`.
+
 Themes use 24-bit colors by default, but not every terminal can show them. Maki checks the environment, terminfo, and the terminal itself, and when truecolor is missing it quietly falls back to the closest of the 256 classic terminal colors. If detection gets it wrong, set `MAKI_TRUECOLOR=1` to force truecolor or `MAKI_TRUECOLOR=0` to force the fallback.
 
 Theme files can also name terminal colors instead of giving hex values, using the same names as Helix: `default`, `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `gray`, `light-red`, `light-green`, `light-yellow`, `light-blue`, `light-magenta`, `light-cyan`, `light-gray`, and `white`. Write them exactly as listed. `lightgray`, `light_gray` and `LIGHT-GRAY` are all rejected. `default` means the terminal default. Maki also takes a number from `0` to `255` to pick a palette entry by index, which Helix does not.


### PR DESCRIPTION
## Summary

- add separate theme keys for old/new diff signs
- add separate theme keys for old/new diff line-number gutters
- preserve existing themes by falling back to `diff_old`, `diff_new`, and `diff_line_nr`
- apply sign styles after `code_block`, so sign properties take precedence; existing themes remain valid, though themes with conflicting `code_block` and diff properties may show a visual change on signs
- plumb the new sign and gutter styles through edit/write diffs

## Testing

- `cargo check -p maki-ui --tests`
- `cargo test -p maki-ui --lib theme::`
- `cargo test -p maki-ui --lib components::code_view`
- `cargo fmt --all -- --check`
- `git diff --check`

`just ci` could not complete because this environment has neither `stylua` nor `nix`; it stopped at `stylua --check plugins/` before running the remaining steps.

## AI use

I used an AI coding agent to inspect the diff renderer and theme parser, implement the new theme keys and compatibility fallbacks, add focused tests, review the generated diff, and run the checks listed above. The implementation was tested interactively after installing the resulting binary.