### PR TITLE
feat(openai): add browser login alongside device auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2946,6 +2946,7 @@ dependencies = [
  "thiserror 2.0.18",
  "toml",
  "tracing",
+ "url",
  "wait-timeout",
 ]
 

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -60,7 +60,9 @@ const XAI_OAUTH_NOTE: &str = r#"OAuth uses the same first-party xAI client as th
 
 If `~/.grok/auth.json` already exists, login offers to reuse it without writing that file."#;
 
-const OPENAI_OAUTH_NOTE: &str = r#"With ChatGPT OAuth (`maki auth login openai`) the model list comes from the Codex backend's own `/models` endpoint, so a model your plan gains shows up without a Maki update, with the context window and reasoning levels the backend declares for it. The table above is the offline fallback. The endpoint hides models newer than the Codex CLI version Maki reports, so a brand new release can lag until that version is bumped."#;
+const OPENAI_OAUTH_NOTE: &str = r#"`maki auth login openai` offers browser login (PKCE, callback on `localhost:1455`) and device code login. Browser is the desktop default; device code is recommended over SSH or in a container. Tokens refresh automatically.
+
+With ChatGPT OAuth the model list comes from the Codex backend's own `/models` endpoint, so a model your plan gains shows up without a Maki update, with the context window and reasoning levels the backend declares for it. The table above is the offline fallback. The endpoint hides models newer than the Codex CLI version Maki reports, so a brand new release can lag until that version is bumped."#;
 
 const OPENCODE_FREE_MODELS_NOTE: &str = r#"By default Maki hides free models from the Opencode catalog. To list free models (they use a public fallback, no API key needed), add this to `~/.config/maki/providers.toml`:
 
@@ -389,7 +391,10 @@ fn build_sections() -> Vec<ProviderSection> {
                 sections.push(ProviderSection {
                     kind,
                     name: kind.display_name(),
-                    auth_line: format!("{} (also supports OAuth device flow)", format_auth(kind)),
+                    auth_line: format!(
+                        "{} (also supports OAuth via `maki auth login openai`)",
+                        format_auth(kind)
+                    ),
                     urls: vec![kind.base_url()],
                     features: kind.features(),
                     entries: ManifestRegistry::get(&kind.to_string()).unwrap().models,
@@ -550,16 +555,16 @@ fn write_section(out: &mut String, section: &ProviderSection) {
         let _ = writeln!(out, "\n{BEDROCK_NOTE}");
     }
 
+    if section.kind == ProviderKind::OpenAi {
+        let _ = writeln!(out, "\n{OPENAI_OAUTH_NOTE}");
+    }
+
     if section.kind == ProviderKind::Opencode {
         let _ = writeln!(out, "\n{OPENCODE_FREE_MODELS_NOTE}");
     }
 
     if section.kind == ProviderKind::Xai {
         let _ = writeln!(out, "\n{XAI_OAUTH_NOTE}");
-    }
-
-    if section.kind == ProviderKind::OpenAi {
-        let _ = writeln!(out, "\n{OPENAI_OAUTH_NOTE}");
     }
 }
 

--- a/maki-providers/Cargo.toml
+++ b/maki-providers/Cargo.toml
@@ -27,6 +27,7 @@ jiff = { workspace = true }
 getrandom = { workspace = true }
 open = { workspace = true }
 keyring = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -27,6 +27,7 @@ pub(crate) mod google;
 pub(crate) mod llama_cpp;
 pub(crate) mod local;
 pub(crate) mod mistral;
+pub(crate) mod oauth_loopback;
 pub(crate) mod ollama;
 pub(crate) mod openai;
 pub(crate) mod openai_compat;

--- a/maki-providers/src/providers/oauth_loopback.rs
+++ b/maki-providers/src/providers/oauth_loopback.rs
@@ -1,0 +1,545 @@
+use std::io::{self, IsTerminal, Read, Write};
+use std::net::{Ipv4Addr, Ipv6Addr, TcpListener, TcpStream};
+use std::sync::mpsc::{self, Receiver};
+use std::time::{Duration, Instant};
+use std::{env, thread};
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use sha2::{Digest, Sha256};
+
+use crate::AgentError;
+
+const ACCEPT_POLL: Duration = Duration::from_millis(100);
+const REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(2);
+const READ_CHUNK: usize = 1024;
+const MAX_REQUEST_SIZE: usize = 8192;
+const HEADER_TERMINATOR: &[u8] = b"\r\n\r\n";
+const TOKEN_BYTES: usize = 32;
+const MIN_RAW_CODE_LEN: usize = 20;
+
+const SUCCESS_HTML: &str =
+    "<html><body><h1>Authentication successful</h1><p>You can close this tab.</p></body></html>";
+const FAILURE_HTML: &str =
+    "<html><body><h1>Authentication failed</h1><p>Return to Maki and try again.</p></body></html>";
+const NOT_FOUND_HTML: &str = "<html><body><h1>Not found</h1></body></html>";
+
+const STATE_MISMATCH: &str = "OAuth authorization failed: state mismatch";
+const CALLBACK_TIMEOUT_MSG: &str = "timed out waiting for the OAuth callback";
+const RAW_CODE_MSG: &str = "raw authorization codes are not accepted; paste the complete redirect URL containing both code and state";
+const EMPTY_PASTE_MSG: &str = "empty OAuth callback";
+const INCOMPLETE_PASTE_MSG: &str =
+    "ignored pasted OAuth input because it was not a complete redirect URL";
+const INVALID_METHOD_MSG: &str = "invalid login method";
+
+#[derive(Clone, Copy)]
+enum Status {
+    Ok,
+    BadRequest,
+    Forbidden,
+    NotFound,
+}
+
+impl Status {
+    fn line(self) -> &'static str {
+        match self {
+            Self::Ok => "200 OK",
+            Self::BadRequest => "400 Bad Request",
+            Self::Forbidden => "403 Forbidden",
+            Self::NotFound => "404 Not Found",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct CallbackResult {
+    pub code: Option<String>,
+    pub error: Option<String>,
+}
+
+/// Loopback redirect server for the OAuth authorization code flow.
+pub(crate) struct Loopback {
+    /// Preferred port. Providers that register a fixed redirect URI must get this one.
+    pub port: u16,
+    /// Retry on an ephemeral port when `port` is taken. Only safe when the provider
+    /// accepts any loopback port in the redirect URI.
+    pub fallback_to_ephemeral: bool,
+    pub path: &'static str,
+    pub timeout: Duration,
+    /// Also accept the redirect URL pasted on stdin, for when the browser runs elsewhere.
+    pub paste_fallback: bool,
+}
+
+pub(crate) struct Server {
+    listeners: Vec<TcpListener>,
+    port: u16,
+    config: Loopback,
+}
+
+impl Loopback {
+    pub(crate) fn bind(self) -> Result<Server, AgentError> {
+        let bound = bind_localhost(self.port).or_else(|e| {
+            if self.fallback_to_ephemeral {
+                bind_localhost(0)
+            } else {
+                Err(e)
+            }
+        });
+        let (listeners, port) = bound.map_err(|e| AgentError::Config {
+            message: format!(
+                "OAuth callback could not listen on port {} ({e}); another login may already be running, otherwise pick device login",
+                self.port
+            ),
+        })?;
+        Ok(Server {
+            listeners,
+            port,
+            config: self,
+        })
+    }
+}
+
+impl Server {
+    pub(crate) fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub(crate) fn wait(&self, expected_state: &str) -> Result<CallbackResult, AgentError> {
+        let deadline = Instant::now() + self.config.timeout;
+        let pastes = self.config.paste_fallback.then(spawn_paste_reader);
+
+        while Instant::now() < deadline {
+            if let Some(rx) = &pastes
+                && let Ok(pasted) = rx.try_recv()
+            {
+                return parse_callback_input(&pasted, expected_state);
+            }
+
+            let mut accepted = false;
+            for listener in &self.listeners {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        accepted = true;
+                        if let Some(result) = self.serve(stream, expected_state) {
+                            return Ok(result);
+                        }
+                    }
+                    Err(e) if e.kind() == io::ErrorKind::WouldBlock => {}
+                    Err(e) => {
+                        return Err(AgentError::Config {
+                            message: format!("OAuth callback: {e}"),
+                        });
+                    }
+                }
+            }
+            if !accepted {
+                thread::sleep(ACCEPT_POLL);
+            }
+        }
+
+        Err(AgentError::Config {
+            message: CALLBACK_TIMEOUT_MSG.into(),
+        })
+    }
+
+    /// `None` keeps waiting: a stale tab or a stray request must not end the login.
+    fn serve(&self, mut stream: TcpStream, expected_state: &str) -> Option<CallbackResult> {
+        stream.set_nonblocking(false).ok();
+        stream.set_read_timeout(Some(REQUEST_READ_TIMEOUT)).ok();
+        let head = read_request_head(&mut stream).ok()?;
+        let head = String::from_utf8_lossy(&head);
+        let target = head.split_whitespace().nth(1)?;
+
+        if request_path(target) != self.config.path {
+            let _ = write_http(&mut stream, Status::NotFound, NOT_FOUND_HTML);
+            return None;
+        }
+
+        match parse_callback_target(target, expected_state) {
+            Ok(result) => {
+                let complete = result.error.is_none() && result.code.is_some();
+                let status = if complete {
+                    Status::Ok
+                } else {
+                    Status::BadRequest
+                };
+                let body = if complete { SUCCESS_HTML } else { FAILURE_HTML };
+                let _ = write_http(&mut stream, status, body);
+                Some(result)
+            }
+            Err(_) => {
+                let _ = write_http(&mut stream, Status::Forbidden, FAILURE_HTML);
+                None
+            }
+        }
+    }
+}
+
+/// Browsers resolve `localhost` to either stack, so both have to answer.
+fn bind_localhost(port: u16) -> io::Result<(Vec<TcpListener>, u16)> {
+    let v4 = TcpListener::bind((Ipv4Addr::LOCALHOST, port))?;
+    let bound = v4.local_addr()?.port();
+    let mut listeners = vec![v4];
+
+    match TcpListener::bind((Ipv6Addr::LOCALHOST, bound)) {
+        Ok(v6) => listeners.push(v6),
+        // Another process owns the v6 half of the port we were told to use, so a browser
+        // resolving `localhost` to ::1 would hand our code to them and we would hang.
+        Err(e) if e.kind() == io::ErrorKind::AddrInUse && port != 0 => return Err(e),
+        // ipv6 can be disabled outright, then v4 is all there is.
+        Err(_) => {}
+    }
+
+    for listener in &listeners {
+        listener.set_nonblocking(true)?;
+    }
+    Ok((listeners, bound))
+}
+
+fn read_request_head(stream: &mut impl Read) -> io::Result<Vec<u8>> {
+    let mut request = Vec::with_capacity(READ_CHUNK);
+    let mut buffer = [0u8; READ_CHUNK];
+    while request.len() < MAX_REQUEST_SIZE {
+        let size = stream.read(&mut buffer)?;
+        if size == 0 {
+            break;
+        }
+        request.extend_from_slice(&buffer[..size]);
+        if request
+            .windows(HEADER_TERMINATOR.len())
+            .any(|bytes| bytes == HEADER_TERMINATOR)
+        {
+            break;
+        }
+    }
+    Ok(request)
+}
+
+fn write_http(stream: &mut impl Write, status: Status, body: &str) -> io::Result<()> {
+    write!(
+        stream,
+        "HTTP/1.1 {}\r\ncontent-type: text/html; charset=utf-8\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+        status.line(),
+        body.len(),
+    )
+}
+
+fn request_path(target: &str) -> &str {
+    target.split_once('?').map_or(target, |(path, _)| path)
+}
+
+fn spawn_paste_reader() -> Receiver<String> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        loop {
+            let mut line = String::new();
+            match io::stdin().read_line(&mut line) {
+                Ok(0) | Err(_) => return,
+                Ok(_) => {
+                    let pasted = line.trim().to_string();
+                    if !pasted.is_empty() && tx.send(pasted).is_err() {
+                        return;
+                    }
+                }
+            }
+        }
+    });
+    rx
+}
+
+fn parse_callback_target(target: &str, expected_state: &str) -> Result<CallbackResult, AgentError> {
+    parse_callback_query(
+        target.split_once('?').map_or("", |(_, query)| query),
+        expected_state,
+    )
+}
+
+fn parse_callback_input(input: &str, expected_state: &str) -> Result<CallbackResult, AgentError> {
+    let value = input.trim();
+    if value.is_empty() {
+        return Err(AgentError::Config {
+            message: EMPTY_PASTE_MSG.into(),
+        });
+    }
+    if value.len() >= MIN_RAW_CODE_LEN
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(AgentError::Config {
+            message: RAW_CODE_MSG.into(),
+        });
+    }
+    let query = match value.split_once('?') {
+        Some((_, query)) => query,
+        None if value.contains('=') => value,
+        None => {
+            return Err(AgentError::Config {
+                message: INCOMPLETE_PASTE_MSG.into(),
+            });
+        }
+    };
+    parse_callback_query(query, expected_state)
+}
+
+fn parse_callback_query(query: &str, expected_state: &str) -> Result<CallbackResult, AgentError> {
+    let mut code = None;
+    let mut state = None;
+    let mut error = None;
+    for (key, value) in url::form_urlencoded::parse(query.as_bytes()) {
+        match key.as_ref() {
+            "code" => code = Some(value.into_owned()),
+            "state" => state = Some(value.into_owned()),
+            "error_description" => error = Some(value.into_owned()),
+            "error" if error.is_none() => error = Some(value.into_owned()),
+            _ => {}
+        }
+    }
+    if state.as_deref() != Some(expected_state) {
+        return Err(AgentError::Config {
+            message: STATE_MISMATCH.into(),
+        });
+    }
+    Ok(CallbackResult { code, error })
+}
+
+pub(crate) fn pkce_pair() -> Result<(String, String), AgentError> {
+    let verifier = random_token()?;
+    let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+    Ok((verifier, challenge))
+}
+
+pub(crate) fn random_token() -> Result<String, AgentError> {
+    let mut bytes = [0u8; TOKEN_BYTES];
+    getrandom::fill(&mut bytes).map_err(|e| AgentError::Config {
+        message: format!("CSPRNG unavailable: {e}"),
+    })?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+pub(crate) enum LoginMethod {
+    Browser,
+    Device,
+}
+
+/// Browser login needs a browser on this machine and a reachable loopback port.
+fn prefer_device() -> bool {
+    env::var_os("SSH_CONNECTION").is_some()
+        || env::var_os("SSH_CLIENT").is_some()
+        || env::var_os("SSH_TTY").is_some()
+        || env::var_os("WSL_DISTRO_NAME").is_some()
+        || env::var_os("WSL_INTEROP").is_some()
+        || env::var_os("container").is_some()
+        || env::var_os("KUBERNETES_SERVICE_HOST").is_some()
+        || env::var_os("CODESPACES").is_some()
+        || env::var_os("REMOTE_CONTAINERS").is_some()
+        || env::var_os("DEVCONTAINER").is_some()
+        || !io::stdin().is_terminal()
+}
+
+pub(crate) fn select_login_method(provider: &str) -> Result<LoginMethod, AgentError> {
+    let default_device = prefer_device();
+    println!("{provider} login method:");
+    if default_device {
+        println!("  1. Browser login");
+        println!("  2. Device code login (recommended for this session)");
+    } else {
+        println!("  1. Browser login (default)");
+        println!("  2. Device code login (remote/headless)");
+    }
+    match prompt("Select [1-2]: ")?.as_str() {
+        "" if default_device => Ok(LoginMethod::Device),
+        "" | "1" | "browser" => Ok(LoginMethod::Browser),
+        "2" | "device" => Ok(LoginMethod::Device),
+        _ => Err(AgentError::Config {
+            message: INVALID_METHOD_MSG.into(),
+        }),
+    }
+}
+
+pub(crate) fn prompt(message: &str) -> Result<String, AgentError> {
+    print!("{message}");
+    io::stdout().flush().map_err(|e| AgentError::Config {
+        message: format!("prompt: {e}"),
+    })?;
+    let mut line = String::new();
+    io::stdin()
+        .read_line(&mut line)
+        .map_err(|e| AgentError::Config {
+            message: format!("prompt: {e}"),
+        })?;
+    Ok(line.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read as _, Write as _};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, TcpListener, TcpStream};
+    use std::thread;
+
+    use test_case::test_case;
+
+    use super::{
+        CallbackResult, Duration, Loopback, RAW_CODE_MSG, STATE_MISMATCH, bind_localhost,
+        parse_callback_input, parse_callback_query, parse_callback_target, pkce_pair, request_path,
+    };
+
+    // RFC 7636 Appendix B: https://www.rfc-editor.org/rfc/rfc7636.html#appendix-B
+    const RFC7636_CHALLENGE_LEN: usize = 43;
+    const EXPECTED_STATE: &str = "expected";
+
+    fn parse(target: &str) -> CallbackResult {
+        parse_callback_target(target, EXPECTED_STATE).unwrap()
+    }
+
+    #[test]
+    fn callback_requires_matching_state() {
+        let error = parse_callback_target("/callback?code=abc&state=other", EXPECTED_STATE)
+            .unwrap_err()
+            .to_string();
+        assert_eq!(error, STATE_MISMATCH);
+    }
+
+    #[test]
+    fn callback_without_state_is_rejected() {
+        let error = parse_callback_target("/callback?code=abc", EXPECTED_STATE)
+            .unwrap_err()
+            .to_string();
+        assert_eq!(error, STATE_MISMATCH);
+    }
+
+    #[test]
+    fn callback_decodes_code() {
+        let result = parse("/callback?code=abc%2Fdef&state=expected");
+        assert_eq!(result.code.as_deref(), Some("abc/def"));
+        assert!(result.error.is_none());
+    }
+
+    #[test]
+    fn error_description_wins_over_error() {
+        let result =
+            parse("/callback?error=access_denied&error_description=Login+cancelled&state=expected");
+        assert_eq!(result.error.as_deref(), Some("Login cancelled"));
+
+        let reordered =
+            parse("/callback?error_description=Login+cancelled&error=access_denied&state=expected");
+        assert_eq!(reordered.error.as_deref(), Some("Login cancelled"));
+    }
+
+    #[test]
+    fn raw_authorization_codes_are_rejected() {
+        let error = parse_callback_input("Abcdefghijklmnopqrstuvwxyz0123", EXPECTED_STATE)
+            .unwrap_err()
+            .to_string();
+        assert_eq!(error, RAW_CODE_MSG);
+    }
+
+    #[test]
+    fn pasted_redirect_url_is_accepted() {
+        let result = parse_callback_input(
+            "http://127.0.0.1:56121/callback?code=abc&state=expected",
+            EXPECTED_STATE,
+        )
+        .unwrap();
+        assert_eq!(result.code.as_deref(), Some("abc"));
+    }
+
+    #[test_case("/callback", "/callback" ; "bare_path")]
+    #[test_case("/callback?code=abc", "/callback" ; "strips_query")]
+    #[test_case("/favicon.ico", "/favicon.ico" ; "other_path")]
+    fn request_path_strips_query(target: &str, expected: &str) {
+        assert_eq!(request_path(target), expected);
+    }
+
+    #[test]
+    fn pkce_challenge_is_url_safe_base64_sha256() {
+        let (verifier, challenge) = pkce_pair().unwrap();
+        assert_ne!(verifier, challenge);
+        assert_eq!(challenge.len(), RFC7636_CHALLENGE_LEN);
+        assert!(
+            challenge
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        );
+    }
+
+    #[test]
+    fn state_mismatch_is_checked_before_query_contents() {
+        assert!(parse_callback_query("", EXPECTED_STATE).is_err());
+    }
+
+    const TEST_PATH: &str = "/callback";
+    const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+    const TEST_CODE: &str = "authorization-code";
+
+    /// `None` when the host has no listener, which is a valid setup for ipv6.
+    fn callback_over(host: IpAddr) -> Option<CallbackResult> {
+        let server = Loopback {
+            port: 0,
+            fallback_to_ephemeral: false,
+            path: TEST_PATH,
+            timeout: TEST_TIMEOUT,
+            paste_fallback: false,
+        }
+        .bind()
+        .unwrap();
+        let port = server.port();
+        server
+            .listeners
+            .iter()
+            .find(|l| l.local_addr().is_ok_and(|addr| addr.ip() == host))?;
+
+        let redirect = thread::spawn(move || {
+            let mut stream = TcpStream::connect((host, port))?;
+            write!(
+                stream,
+                "GET {TEST_PATH}?code={TEST_CODE}&state={EXPECTED_STATE} HTTP/1.1\r\nhost: localhost\r\n\r\n"
+            )?;
+            let mut response = String::new();
+            stream.read_to_string(&mut response)?;
+            std::io::Result::Ok(response)
+        });
+
+        let result = server.wait(EXPECTED_STATE).unwrap();
+        assert!(
+            redirect
+                .join()
+                .unwrap()
+                .unwrap()
+                .starts_with("HTTP/1.1 200")
+        );
+        Some(result)
+    }
+
+    #[test]
+    fn serves_the_callback_over_ipv4() {
+        let result = callback_over(Ipv4Addr::LOCALHOST.into()).unwrap();
+        assert_eq!(result.code.as_deref(), Some(TEST_CODE));
+    }
+
+    /// `localhost` resolves to `::1` first on some systems, so the v6 socket has to answer too.
+    #[test]
+    fn serves_the_callback_over_ipv6() {
+        if let Some(result) = callback_over(Ipv6Addr::LOCALHOST.into()) {
+            assert_eq!(result.code.as_deref(), Some(TEST_CODE));
+        }
+    }
+
+    #[test]
+    fn ephemeral_bind_reports_the_real_port() {
+        let (listeners, port) = bind_localhost(0).unwrap();
+        assert_ne!(port, 0);
+        for listener in &listeners {
+            assert_eq!(listener.local_addr().unwrap().port(), port);
+        }
+    }
+
+    #[test]
+    fn a_taken_ipv6_half_fails_instead_of_hanging() {
+        let Ok(squatter) = TcpListener::bind((Ipv6Addr::LOCALHOST, 0)) else {
+            return;
+        };
+        let port = squatter.local_addr().unwrap().port();
+        assert!(bind_localhost(port).is_err());
+    }
+}

--- a/maki-providers/src/providers/openai/auth.rs
+++ b/maki-providers/src/providers/openai/auth.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 use std::{env, thread};
 
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use isahc::ReadResponseExt;
 use isahc::config::{Configurable, VersionNegotiation};
 use maki_storage::StateDir;
@@ -9,18 +11,26 @@ use serde::Deserialize;
 use tracing::{debug, error, warn};
 
 use crate::AgentError;
+use crate::providers::oauth_loopback::{self, LoginMethod, Loopback};
 use crate::providers::{ResolvedAuth, refreshed_tokens, urlenc};
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 pub(crate) const PROVIDER: &str = "openai";
+const DISPLAY_NAME: &str = "OpenAI";
 const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+const AUTHORIZE_URL: &str = "https://auth.openai.com/oauth/authorize";
 const DEVICE_CODE_URL: &str = "https://auth.openai.com/api/accounts/deviceauth/usercode";
 const DEVICE_TOKEN_URL: &str = "https://auth.openai.com/api/accounts/deviceauth/token";
 const OAUTH_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
 const DEVICE_AUTH_URL: &str = "https://auth.openai.com/codex/device";
-const REDIRECT_URI: &str = "https://auth.openai.com/deviceauth/callback";
+const DEVICE_REDIRECT_URI: &str = "https://auth.openai.com/deviceauth/callback";
+// Registered on the OpenAI client, so the port is not ours to choose.
+const REDIRECT_PORT: u16 = 1455;
+const REDIRECT_PATH: &str = "/auth/callback";
+const SCOPE: &str = "openid profile email offline_access";
 const POLL_SAFETY_MARGIN: Duration = Duration::from_secs(3);
 const TOKEN_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(30);
+const CALLBACK_TIMEOUT: Duration = Duration::from_secs(300);
 const POLL_TIMEOUT: Duration = Duration::from_secs(300);
 
 #[derive(Deserialize)]
@@ -62,8 +72,6 @@ fn extract_account_id(token: &str) -> Option<String> {
     if parts.len() != 3 {
         return None;
     }
-    use base64::Engine;
-    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     let payload = URL_SAFE_NO_PAD.decode(parts[1]).ok()?;
     let claims: serde_json::Value = serde_json::from_slice(&payload).ok()?;
 
@@ -167,7 +175,11 @@ fn poll_device_token(device: &DeviceCodeResponse) -> Result<DeviceTokenResponse,
     }
 }
 
-fn exchange_device_token(device_token: &DeviceTokenResponse) -> Result<TokenResponse, AgentError> {
+fn exchange_authorization_code(
+    code: &str,
+    verifier: &str,
+    redirect_uri: &str,
+) -> Result<TokenResponse, AgentError> {
     let client = http_client(TOKEN_EXCHANGE_TIMEOUT)?;
 
     let form_body = format!(
@@ -176,10 +188,10 @@ fn exchange_device_token(device_token: &DeviceTokenResponse) -> Result<TokenResp
          &redirect_uri={}\
          &client_id={}\
          &code_verifier={}",
-        urlenc(&device_token.authorization_code),
-        urlenc(REDIRECT_URI),
+        urlenc(code),
+        urlenc(redirect_uri),
         urlenc(CLIENT_ID),
-        urlenc(&device_token.code_verifier),
+        urlenc(verifier),
     );
 
     let request = isahc::Request::builder()
@@ -201,6 +213,21 @@ fn exchange_device_token(device_token: &DeviceTokenResponse) -> Result<TokenResp
 
     let body_text = resp.text()?;
     serde_json::from_str(&body_text).map_err(Into::into)
+}
+
+fn redirect_uri() -> String {
+    format!("http://localhost:{REDIRECT_PORT}{REDIRECT_PATH}")
+}
+
+fn authorization_url(redirect_uri: &str, challenge: &str, state: &str) -> String {
+    format!(
+        "{AUTHORIZE_URL}?response_type=code&client_id={}&redirect_uri={}&scope={}&code_challenge={}&code_challenge_method=S256&state={}&id_token_add_organizations=true&codex_cli_simplified_flow=true&originator=maki",
+        urlenc(CLIENT_ID),
+        urlenc(redirect_uri),
+        urlenc(SCOPE),
+        urlenc(challenge),
+        urlenc(state),
+    )
 }
 
 fn into_oauth_tokens(resp: TokenResponse) -> OAuthTokens {
@@ -299,26 +326,69 @@ pub fn resolve(dir: &StateDir) -> Result<ResolvedAuth, AgentError> {
 }
 
 pub fn login(dir: &StateDir) -> Result<(), AgentError> {
-    let device = request_device_code()?;
+    let token_response = match oauth_loopback::select_login_method(DISPLAY_NAME)? {
+        LoginMethod::Browser => browser_login()?,
+        LoginMethod::Device => device_login()?,
+    };
+    let tokens = into_oauth_tokens(token_response);
+    save_tokens(dir, PROVIDER, &tokens)?;
+    println!("Authenticated successfully.");
+    Ok(())
+}
 
+fn device_login() -> Result<TokenResponse, AgentError> {
+    let device = request_device_code()?;
     println!("Open this URL in your browser:\n\n  {DEVICE_AUTH_URL}\n");
     println!("Enter code: {}\n", device.user_code);
     println!("Waiting for authorization...");
-
     let device_token = poll_device_token(&device).map_err(|e| {
         error!(error = %e, "OpenAI device authorization failed");
         e
     })?;
+    exchange_authorization_code(
+        &device_token.authorization_code,
+        &device_token.code_verifier,
+        DEVICE_REDIRECT_URI,
+    )
+}
 
-    let token_resp = exchange_device_token(&device_token).map_err(|e| {
-        error!(error = %e, "OpenAI token exchange failed");
+fn browser_login() -> Result<TokenResponse, AgentError> {
+    let (verifier, challenge) = oauth_loopback::pkce_pair()?;
+    let state = oauth_loopback::random_token()?;
+    let server = Loopback {
+        port: REDIRECT_PORT,
+        fallback_to_ephemeral: false,
+        path: REDIRECT_PATH,
+        timeout: CALLBACK_TIMEOUT,
+        paste_fallback: false,
+    }
+    .bind()?;
+
+    let redirect_uri = redirect_uri();
+    let authorize_url = authorization_url(&redirect_uri, &challenge, &state);
+    println!("Open this URL in your browser:\n\n  {authorize_url}\n");
+    if let Err(e) = open::that(&authorize_url) {
+        warn!(error = %e, "failed to open browser");
+    }
+    println!("Waiting for OpenAI OAuth callback on {redirect_uri}...");
+
+    let callback = server.wait(&state).map_err(|e| {
+        error!(error = %e, "OpenAI browser authorization failed");
         e
     })?;
+    if let Some(error) = callback.error {
+        return Err(AgentError::Config {
+            message: format!("OpenAI authorization failed: {error}"),
+        });
+    }
+    let code = callback.code.ok_or_else(|| AgentError::Config {
+        message: "OpenAI authorization failed: no authorization code returned".into(),
+    })?;
 
-    let tokens = into_oauth_tokens(token_resp);
-    save_tokens(dir, PROVIDER, &tokens)?;
-    println!("Authenticated successfully.");
-    Ok(())
+    exchange_authorization_code(&code, &verifier, &redirect_uri).map_err(|e| {
+        error!(error = %e, "OpenAI token exchange failed");
+        e
+    })
 }
 
 pub fn logout(dir: &StateDir) -> Result<(), AgentError> {
@@ -336,9 +406,6 @@ mod tests {
 
     #[test]
     fn extract_account_id_from_jwt() {
-        use base64::Engine;
-        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-
         let header = URL_SAFE_NO_PAD.encode(b"{}");
         let payload = URL_SAFE_NO_PAD.encode(
             serde_json::json!({"chatgpt_account_id": "acct_123"})
@@ -350,5 +417,15 @@ mod tests {
 
         assert_eq!(extract_account_id("not.a.jwt"), None);
         assert_eq!(extract_account_id("invalid"), None);
+    }
+
+    #[test]
+    fn authorization_uses_the_registered_loopback_redirect() {
+        let url = authorization_url(&redirect_uri(), "challenge", "state");
+        assert!(url.starts_with(AUTHORIZE_URL));
+        assert!(url.contains("redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback"));
+        assert!(url.contains("code_challenge=challenge&code_challenge_method=S256"));
+        assert!(url.contains("state=state"));
+        assert!(!url.contains("device"));
     }
 }

--- a/maki-providers/src/providers/xai/auth.rs
+++ b/maki-providers/src/providers/xai/auth.rs
@@ -1,22 +1,18 @@
-use std::io::{self, Write};
-use std::net::TcpListener;
+use std::io;
 use std::path::PathBuf;
 use std::str;
-use std::sync::mpsc;
 use std::time::{Duration, Instant};
 use std::{env, fs, thread};
 
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use isahc::ReadResponseExt;
 use isahc::config::{Configurable, RedirectPolicy, VersionNegotiation};
 use maki_storage::StateDir;
 use maki_storage::auth::{OAuthTokens, delete_tokens, load_tokens, now_millis, save_tokens};
 use serde::Deserialize;
-use sha2::{Digest, Sha256};
 use tracing::{debug, error, warn};
 
 use crate::AgentError;
+use crate::providers::oauth_loopback::{self, LoginMethod, Loopback};
 use crate::providers::{KeyPool, ResolvedAuth, refreshed_tokens, urlenc};
 
 use super::catalog;
@@ -25,12 +21,12 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const TOKEN_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(30);
 const POLL_TIMEOUT: Duration = Duration::from_secs(300);
 const CALLBACK_TIMEOUT: Duration = Duration::from_secs(180);
-const ACCEPT_POLL: Duration = Duration::from_millis(100);
 const DEFAULT_EXPIRES_SECS: u64 = 3600;
 const GROK_CLI_DEFAULT_TTL_MS: u64 = 6 * 60 * 60 * 1000;
 const MS_THRESHOLD: f64 = 10_000_000_000.0;
 
 pub(crate) const PROVIDER: &str = "xai";
+const DISPLAY_NAME: &str = "xAI";
 pub(crate) const API_KEY_ENV: &str = "XAI_API_KEY";
 pub(crate) const TOKEN_AUTH: &str = "xai-grok-cli";
 pub(crate) const AUTHENTICATE_RESPONSE: &str = "authenticate-response";
@@ -62,9 +58,6 @@ const NOT_AUTHENTICATED: &str = "not authenticated, run `maki auth login xai` or
 const DEVICE_TIMEOUT: &str = "xAI device authorization timed out";
 const DEVICE_DENIED: &str = "xAI device authorization was denied";
 const DEVICE_EXPIRED: &str = "xAI device authorization expired; run `maki auth login xai` again";
-const CALLBACK_TIMEOUT_MSG: &str = "timed out waiting for xAI OAuth callback";
-const STATE_MISMATCH: &str = "xAI authorization failed: state mismatch";
-const RAW_CODE_MSG: &str = "raw xAI authorization codes are not accepted; paste the complete redirect URL containing both code and state";
 
 #[derive(Deserialize)]
 struct TokenResponse {
@@ -245,7 +238,7 @@ pub fn resolve(dir: &StateDir) -> Result<ResolvedAuth, AgentError> {
 pub fn login(dir: &StateDir) -> Result<(), AgentError> {
     if let Some(existing) = grok_cli_credentials() {
         println!("Found official Grok CLI credentials in ~/.grok/auth.json.");
-        let answer = prompt("Use them instead of a new xAI OAuth login? [Y/n] ")?;
+        let answer = oauth_loopback::prompt("Use them instead of a new xAI OAuth login? [Y/n] ")?;
         if answer.is_empty() || answer.to_ascii_lowercase().starts_with('y') {
             match ensure_fresh(existing) {
                 Ok(tokens) => return finish_login(dir, tokens),
@@ -259,7 +252,7 @@ pub fn login(dir: &StateDir) -> Result<(), AgentError> {
         }
     }
 
-    let method = select_login_method()?;
+    let method = oauth_loopback::select_login_method(DISPLAY_NAME)?;
     let tokens = match method {
         LoginMethod::Device => device_login()?,
         LoginMethod::Browser => browser_login()?,
@@ -301,60 +294,6 @@ fn ensure_fresh(tokens: OAuthTokens) -> Result<OAuthTokens, AgentError> {
         return Ok(tokens);
     }
     refresh_tokens(&tokens)
-}
-
-enum LoginMethod {
-    Browser,
-    Device,
-}
-
-fn prefer_device() -> bool {
-    env::var_os("SSH_CONNECTION").is_some()
-        || env::var_os("SSH_CLIENT").is_some()
-        || env::var_os("SSH_TTY").is_some()
-        || env::var_os("WSL_DISTRO_NAME").is_some()
-        || env::var_os("WSL_INTEROP").is_some()
-        || env::var_os("container").is_some()
-        || env::var_os("KUBERNETES_SERVICE_HOST").is_some()
-        || env::var_os("CODESPACES").is_some()
-        || env::var_os("REMOTE_CONTAINERS").is_some()
-        || env::var_os("DEVCONTAINER").is_some()
-        || !io::IsTerminal::is_terminal(&io::stdin())
-}
-
-fn select_login_method() -> Result<LoginMethod, AgentError> {
-    let default_device = prefer_device();
-    println!("xAI login method:");
-    if default_device {
-        println!("  1. Browser login");
-        println!("  2. Device code login (recommended for this session)");
-    } else {
-        println!("  1. Browser login (default)");
-        println!("  2. Device code login (remote/headless)");
-    }
-    let answer = prompt("Select [1-2]: ")?;
-    match answer.as_str() {
-        "" if default_device => Ok(LoginMethod::Device),
-        "" | "1" | "browser" => Ok(LoginMethod::Browser),
-        "2" | "device" => Ok(LoginMethod::Device),
-        _ => Err(AgentError::Config {
-            message: "invalid xAI login method".into(),
-        }),
-    }
-}
-
-fn prompt(message: &str) -> Result<String, AgentError> {
-    print!("{message}");
-    io::stdout().flush().map_err(|e| AgentError::Config {
-        message: format!("prompt: {e}"),
-    })?;
-    let mut line = String::new();
-    io::stdin()
-        .read_line(&mut line)
-        .map_err(|e| AgentError::Config {
-            message: format!("prompt: {e}"),
-        })?;
-    Ok(line.trim().to_string())
 }
 
 fn device_login() -> Result<OAuthTokens, AgentError> {
@@ -518,12 +457,18 @@ fn poll_device_token(device: &DeviceCodeResponse) -> Result<OAuthTokens, AgentEr
 }
 
 fn browser_login() -> Result<OAuthTokens, AgentError> {
-    let (verifier, challenge) = pkce_pair()?;
-    let state = random_token()?;
-    let nonce = random_token()?;
-    let listener = bind_callback()?;
-    let port = listener.local_addr()?.port();
-    let redirect_uri = format!("http://{REDIRECT_HOST}:{port}{REDIRECT_PATH}");
+    let (verifier, challenge) = oauth_loopback::pkce_pair()?;
+    let state = oauth_loopback::random_token()?;
+    let nonce = oauth_loopback::random_token()?;
+    let server = Loopback {
+        port: REDIRECT_PORT,
+        fallback_to_ephemeral: true,
+        path: REDIRECT_PATH,
+        timeout: CALLBACK_TIMEOUT,
+        paste_fallback: true,
+    }
+    .bind()?;
+    let redirect_uri = format!("http://{REDIRECT_HOST}:{}{REDIRECT_PATH}", server.port());
 
     let authorize_url = format!(
         "{AUTHORIZE_URL}?response_type=code&client_id={}&redirect_uri={}&scope={}&code_challenge={}&code_challenge_method=S256&state={}&nonce={}",
@@ -542,7 +487,7 @@ fn browser_login() -> Result<OAuthTokens, AgentError> {
     println!("Waiting for xAI OAuth callback on {redirect_uri}...");
     println!("If the redirect cannot reach this process, paste the complete redirect URL below.");
 
-    let callback = wait_for_callback(listener, &state)?;
+    let callback = server.wait(&state)?;
     if let Some(error) = callback.error {
         return Err(AgentError::Config {
             message: format!("xAI authorization failed: {error}"),
@@ -567,215 +512,6 @@ fn browser_login() -> Result<OAuthTokens, AgentError> {
     }
     let token_resp: TokenResponse = serde_json::from_str(&body_text)?;
     into_oauth_tokens(token_resp, None)
-}
-
-#[derive(Debug)]
-struct CallbackResult {
-    code: Option<String>,
-    error: Option<String>,
-}
-
-fn bind_callback() -> Result<TcpListener, AgentError> {
-    TcpListener::bind((REDIRECT_HOST, REDIRECT_PORT))
-        .or_else(|_| TcpListener::bind((REDIRECT_HOST, 0)))
-        .and_then(|listener| {
-            listener.set_nonblocking(true)?;
-            Ok(listener)
-        })
-        .map_err(|e| AgentError::Config {
-            message: format!("xAI OAuth callback server: {e}"),
-        })
-}
-
-fn wait_for_callback(
-    listener: TcpListener,
-    expected_state: &str,
-) -> Result<CallbackResult, AgentError> {
-    let deadline = Instant::now() + CALLBACK_TIMEOUT;
-    let paste_rx = spawn_paste_reader();
-    loop {
-        if Instant::now() >= deadline {
-            return Err(AgentError::Config {
-                message: CALLBACK_TIMEOUT_MSG.into(),
-            });
-        }
-        if let Ok(pasted) = paste_rx.try_recv() {
-            return parse_callback_input(&pasted, expected_state);
-        }
-
-        match listener.accept() {
-            Ok((mut stream, _)) => {
-                let mut buf = [0u8; 4096];
-                stream.set_nonblocking(false).ok();
-                stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
-                let n = std::io::Read::read(&mut stream, &mut buf).unwrap_or(0);
-                let request = String::from_utf8_lossy(&buf[..n]);
-                let Some(target) = request.split_whitespace().nth(1) else {
-                    continue;
-                };
-                if !target.starts_with(REDIRECT_PATH) {
-                    let _ = write_http(&mut stream, 404, "text/plain; charset=utf-8", "Not found");
-                    continue;
-                }
-                match parse_callback_target(target, expected_state) {
-                    Ok(result) => {
-                        let html = if result.error.is_some() {
-                            "<html><body><h1>xAI authorization failed.</h1>You can close this tab.</body></html>"
-                        } else {
-                            "<html><body><h1>xAI authorization received.</h1>You can close this tab.</body></html>"
-                        };
-                        let _ = write_http(&mut stream, 200, "text/html; charset=utf-8", html);
-                        return Ok(result);
-                    }
-                    Err(_) => {
-                        let _ = write_http(
-                            &mut stream,
-                            400,
-                            "text/html; charset=utf-8",
-                            "<html><body><h1>xAI authorization state mismatch.</h1>Please return to maki and try again.</body></html>",
-                        );
-                    }
-                }
-            }
-            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
-                thread::sleep(ACCEPT_POLL);
-            }
-            Err(e) => {
-                return Err(AgentError::Config {
-                    message: format!("xAI OAuth callback: {e}"),
-                });
-            }
-        }
-    }
-}
-
-fn spawn_paste_reader() -> mpsc::Receiver<String> {
-    let (tx, rx) = mpsc::channel();
-    thread::spawn(move || {
-        loop {
-            let mut line = String::new();
-            match io::stdin().read_line(&mut line) {
-                Ok(0) | Err(_) => return,
-                Ok(_) => {
-                    let pasted = line.trim().to_string();
-                    if !pasted.is_empty() && tx.send(pasted).is_err() {
-                        return;
-                    }
-                }
-            }
-        }
-    });
-    rx
-}
-
-fn write_http(
-    stream: &mut impl Write,
-    status: u16,
-    content_type: &str,
-    body: &str,
-) -> io::Result<()> {
-    write!(
-        stream,
-        "HTTP/1.1 {status} {}\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
-        if status == 200 {
-            "OK"
-        } else if status == 404 {
-            "Not Found"
-        } else {
-            "Bad Request"
-        },
-        body.len(),
-    )
-}
-
-fn parse_callback_target(target: &str, expected_state: &str) -> Result<CallbackResult, AgentError> {
-    let query = target.split_once('?').map(|(_, q)| q).unwrap_or("");
-    parse_callback_query(query, expected_state)
-}
-
-fn parse_callback_input(input: &str, expected_state: &str) -> Result<CallbackResult, AgentError> {
-    let value = input.trim();
-    if value.is_empty() {
-        return Err(AgentError::Config {
-            message: "empty xAI OAuth callback".into(),
-        });
-    }
-    if value
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-        && value.len() >= 20
-    {
-        return Err(AgentError::Config {
-            message: RAW_CODE_MSG.into(),
-        });
-    }
-    let query = if let Some(idx) = value.find('?') {
-        &value[idx + 1..]
-    } else if value.contains('=') {
-        value
-    } else {
-        return Err(AgentError::Config {
-            message: "ignored pasted xAI OAuth input because it was not a complete redirect URL"
-                .into(),
-        });
-    };
-    parse_callback_query(query, expected_state)
-}
-
-fn parse_callback_query(query: &str, expected_state: &str) -> Result<CallbackResult, AgentError> {
-    let mut code = None;
-    let mut state = None;
-    let mut error = None;
-    for pair in query.split('&') {
-        let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
-        let decoded = percent_decode(value);
-        match key {
-            "code" => code = Some(decoded),
-            "state" => state = Some(decoded),
-            "error" => error = Some(decoded),
-            _ => {}
-        }
-    }
-    if state.as_deref() != Some(expected_state) {
-        return Err(AgentError::Config {
-            message: STATE_MISMATCH.into(),
-        });
-    }
-    Ok(CallbackResult { code, error })
-}
-
-fn percent_decode(input: &str) -> String {
-    let bytes = input.as_bytes();
-    let mut out = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%'
-            && let Some(hex) = bytes.get(i + 1..i + 3).and_then(|b| str::from_utf8(b).ok())
-            && let Ok(value) = u8::from_str_radix(hex, 16)
-        {
-            out.push(value);
-            i += 3;
-            continue;
-        }
-        out.push(if bytes[i] == b'+' { b' ' } else { bytes[i] });
-        i += 1;
-    }
-    String::from_utf8_lossy(&out).into_owned()
-}
-
-fn pkce_pair() -> Result<(String, String), AgentError> {
-    let verifier = random_token()?;
-    let digest = Sha256::digest(verifier.as_bytes());
-    let challenge = URL_SAFE_NO_PAD.encode(digest);
-    Ok((verifier, challenge))
-}
-
-fn random_token() -> Result<String, AgentError> {
-    let mut buf = [0u8; 32];
-    getrandom::fill(&mut buf).map_err(|e| AgentError::Config {
-        message: format!("CSPRNG unavailable: {e}"),
-    })?;
-    Ok(URL_SAFE_NO_PAD.encode(buf))
 }
 
 pub(crate) fn grok_cli_credentials() -> Option<OAuthTokens> {
@@ -925,33 +661,6 @@ mod tests {
     #[test_case("https://auth.x.ai/device?code=secret-code", "secret-code", false)]
     fn verification_uri_validation(uri: &str, secret: &str, expected: bool) {
         assert_eq!(valid_verification_uri(uri, secret), expected);
-    }
-
-    #[test]
-    fn callback_query_requires_matching_state() {
-        let err = parse_callback_query("code=abc&state=other", "expected").unwrap_err();
-        assert_eq!(err.to_string(), STATE_MISMATCH);
-    }
-
-    #[test]
-    fn callback_query_accepts_code_and_state() {
-        let result = parse_callback_query("code=abc%2Fdef&state=expected", "expected").unwrap();
-        assert_eq!(result.code.as_deref(), Some("abc/def"));
-        assert!(result.error.is_none());
-    }
-
-    #[test_case("a%20b", "a b" ; "decodes_percent_escape")]
-    #[test_case("%41", "A" ; "decodes_escape_at_end")]
-    #[test_case("%\u{20ac}", "%\u{20ac}" ; "keeps_multibyte_after_percent")]
-    #[test_case("a+b", "a b" ; "decodes_plus_as_space")]
-    fn percent_decode_handles_edge_cases(input: &str, expected: &str) {
-        assert_eq!(percent_decode(input), expected);
-    }
-
-    #[test]
-    fn raw_authorization_codes_are_rejected() {
-        let err = parse_callback_input("Abcdefghijklmnopqrstuvwxyz0123", "state").unwrap_err();
-        assert_eq!(err.to_string(), RAW_CODE_MSG);
     }
 
     #[test]

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -80,7 +80,7 @@ You can override the model with `ANTHROPIC_MODEL` and the endpoint with `ANTHROP
 
 ### OpenAI
 
-- **Env var**: `OPENAI_API_KEY` (also supports OAuth device flow)
+- **Env var**: `OPENAI_API_KEY` (also supports OAuth via `maki auth login openai`)
 - **API**: `https://api.openai.com/v1`
 
 | Tier | Models | Pricing (in/out per 1M tokens) | Context |
@@ -106,7 +106,9 @@ You can override the model with `ANTHROPIC_MODEL` and the endpoint with `ANTHROP
 
 Defaults: gpt-5.6-luna (weak), gpt-5.6-terra (medium), gpt-5.6-sol (strong)
 
-With ChatGPT OAuth (`maki auth login openai`) the model list comes from the Codex backend's own `/models` endpoint, so a model your plan gains shows up without a Maki update, with the context window and reasoning levels the backend declares for it. The table above is the offline fallback. The endpoint hides models newer than the Codex CLI version Maki reports, so a brand new release can lag until that version is bumped.
+`maki auth login openai` offers browser login (PKCE, callback on `localhost:1455`) and device code login. Browser is the desktop default; device code is recommended over SSH or in a container. Tokens refresh automatically.
+
+With ChatGPT OAuth the model list comes from the Codex backend's own `/models` endpoint, so a model your plan gains shows up without a Maki update, with the context window and reasoning levels the backend declares for it. The table above is the offline fallback. The endpoint hides models newer than the Codex CLI version Maki reports, so a brand new release can lag until that version is bumped.
 
 ### Google
 


### PR DESCRIPTION
Adds browser authentication method for openai. Some organizations disable device code auth so this will help then.

Presents an option to use the existing device code auth or this new browser auth:
```sh
❯ maki auth login openai
OpenAI login method:
  1. Browser login
  2. Device code login (default)
Select [1-2]: 1
Open this URL in your browser:

  https://auth.openai.com/oauth/authorize?response_type=code&client_id=<client_id>&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback&scope=openid%20profile%20email%20offline_access&code_challenge=<code_challenge>&code_challenge_method=S256&state=<state>&id_token_add_organizations=true&codex_cli_simplified_flow=true&originator=maki

Waiting for OpenAI OAuth callback on http://localhost:1455/auth/callback...
Authenticated successfully.
```