### PR TITLE
fix(agent): guard repetitive-text loops and harden doom-loop detection

### DIFF
--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -296,9 +296,7 @@ impl<'h> Agent<'h> {
 
     async fn run_loop(&mut self) -> Result<DoneReason, AgentError> {
         loop {
-            if let Some(max) = self.config.max_turns
-                && self.num_turns >= max
-            {
+            if self.num_turns >= self.config.max_turns {
                 return Ok(DoneReason::MaxTurns);
             }
             self.try_auto_compact().await?;
@@ -408,7 +406,6 @@ impl<'h> Agent<'h> {
             } else if self.recover_stalled_turn()? {
                 return Ok(TurnOutcome::Continue);
             }
-
             if stop_reason == Some(StopReason::MaxTokens)
                 && self.num_turns <= self.config.max_continuation_turns
             {
@@ -722,6 +719,7 @@ mod tests {
     use crate::Envelope;
     use crate::mcp::tool_names;
     use crate::permissions::PermissionManager;
+    use maki_config::DEFAULT_MAX_TURNS;
 
     const QUEUED_MESSAGES: [&str; 3] = ["first", "second", "third"];
     const ONE_GAUGE_MSG: &str =
@@ -1010,7 +1008,7 @@ mod tests {
     async fn run_agent(provider: MockProvider, max_turns: Option<u32>) -> (u32, DoneReason) {
         let mut history = History::new(Vec::new());
         let (mut agent, event_rx) = make_agent(provider, &mut history);
-        agent.config.max_turns = max_turns;
+        agent.config.max_turns = max_turns.unwrap_or(DEFAULT_MAX_TURNS);
         let _ = agent.run(default_input()).await;
         drain_events(&event_rx)
             .into_iter()
@@ -1721,6 +1719,32 @@ mod tests {
                 .filter(|e| matches!(e.event, AgentEvent::Nudge))
                 .count();
             assert_eq!(nudges, MAX_NUDGES as usize + 1);
+        });
+    }
+
+    /// The run hard-stops at the default turn budget even when the caller never
+    /// set `max_turns` and the model keeps producing tool calls that would
+    /// otherwise loop forever.
+    #[test]
+    fn default_turn_budget_hard_stops_infinite_run() {
+        smol::block_on(async {
+            let responses = (0..DEFAULT_MAX_TURNS)
+                .map(|i| tool_call_response("bash", &format!("t{i}")))
+                .collect();
+            let mut history = History::new(Vec::new());
+            let (mut agent, event_rx) = make_agent(MockProvider::new(responses), &mut history);
+            let reason = agent.run(default_input()).await.unwrap();
+            drop(agent);
+            assert_eq!(reason, DoneReason::MaxTurns);
+            let events = drain_events(&event_rx);
+            let done = events
+                .iter()
+                .find_map(|e| match &e.event {
+                    AgentEvent::Done { num_turns, .. } => Some(*num_turns),
+                    _ => None,
+                })
+                .expect("expected Done event");
+            assert_eq!(done, DEFAULT_MAX_TURNS);
         });
     }
 

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
-use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -21,7 +19,7 @@ use maki_config::ToolKey;
 use maki_storage::id::SessionRef;
 
 const DOOM_LOOP_THRESHOLD: usize = 3;
-const DOOM_LOOP_MESSAGE: &str = "You have called this tool with identical input 3 times in a row. You are stuck in a loop. Break out and try a different approach.";
+const DOOM_LOOP_MESSAGE: &str = "You have called this tool with the same (or nearly identical) input 3 times in a row. You are stuck in a loop. Break out and try a different approach.";
 const UNKNOWN_TOOL_PREFIX: &str = "unknown tool";
 const MCP_PERM_SCOPE_MAX_BYTES: usize = 200;
 
@@ -51,35 +49,73 @@ const DIFF_TIMEOUT: Duration = Duration::from_millis(100);
 /// gives up".
 const HOOK_CHAIN_MAX: Duration = Duration::from_secs(60);
 
-pub(super) struct RecentCalls(VecDeque<(String, u64)>);
+pub(super) struct RecentCalls(VecDeque<(String, String)>);
 
 impl RecentCalls {
     pub(super) fn new() -> Self {
         Self(VecDeque::new())
     }
 
-    fn hash_input(input: &Value) -> u64 {
-        let mut h = DefaultHasher::new();
-        input.to_string().hash(&mut h);
-        h.finish()
-    }
-
-    fn is_doom_loop(&self, name: &str, input: &Value) -> bool {
-        let hash = Self::hash_input(input);
+    fn is_similar(&self, name: &str, input: &Value) -> bool {
+        let canonical = canonicalize(input);
         self.0.len() >= DOOM_LOOP_THRESHOLD - 1
             && self
                 .0
                 .iter()
                 .rev()
                 .take(DOOM_LOOP_THRESHOLD - 1)
-                .all(|(n, h)| n == name && *h == hash)
+                .all(|(n, i)| n == name && *i == canonical)
     }
 
     fn record(&mut self, name: String, input: &Value) {
-        self.0.push_back((name, Self::hash_input(input)));
+        self.0.push_back((name, canonicalize(input)));
         if self.0.len() > DOOM_LOOP_THRESHOLD {
             self.0.pop_front();
         }
+    }
+}
+
+/// Trims leading and trailing whitespace so values differing only in that churn
+/// (trailing space, newline padding) compare equal. Interior whitespace is kept:
+/// it can be meaningful inside a command or pattern, so collapsing it could
+/// treat two distinct calls as repeats and block a real task. O(n).
+fn collapse_ws(s: &str) -> String {
+    s.trim().to_string()
+}
+
+/// Canonical serialization of a tool input: object keys sorted recursively and
+/// string values trimmed, so semantically-equivalent inputs (key reordering,
+/// trailing-whitespace churn) compare equal while staying O(n) — no quadratic
+/// diff in this hot path.
+fn canonicalize(value: &Value) -> String {
+    match value {
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            let mut out = String::from("{");
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(&format!("{:?}:", k));
+                out.push_str(&canonicalize(&map[*k]));
+            }
+            out.push('}');
+            out
+        }
+        Value::Array(items) => {
+            let mut out = String::from("[");
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(&canonicalize(item));
+            }
+            out.push(']');
+            out
+        }
+        Value::String(s) => format!("{:?}", collapse_ws(s)),
+        other => other.to_string(),
     }
 }
 
@@ -822,7 +858,7 @@ pub(super) async fn process_tool_calls(
             input_preview = %crate::tools::schema::preview(&input.to_string()),
             "parsing tool call"
         );
-        if recent_calls.is_doom_loop(&name, &input) {
+        if recent_calls.is_similar(&name, &input) {
             warn!(tool = %name, "doom loop detected, skipping execution");
             immediate_errors.push(ToolDoneEvent::error(id.clone(), DOOM_LOOP_MESSAGE));
         } else {
@@ -1023,13 +1059,79 @@ mod tests {
     #[test_case("read", &[("read", "/a"), ("read", "/b")], false ; "different_input_breaks_chain")]
     #[test_case("grep", &[("glob", "/a"), ("glob", "/a")], false ; "different_tool_name")]
     #[test_case("bash", &[("bash", "/a"), ("bash", "/b"), ("bash", "/a")], false ; "interrupted_chain")]
+    #[test_case("bash", &[("bash", "/a"), ("bash", "/a ")], true  ; "near_duplicate_whitespace_triggers")]
     fn doom_loop_detection(name: &str, history: &[(&str, &str)], expected: bool) {
         let entries: Vec<_> = history
             .iter()
             .map(|(n, p)| (*n, serde_json::json!({"path": p})))
             .collect();
         let input = serde_json::json!({"path": "/a"});
-        assert_eq!(recent_calls(&entries).is_doom_loop(name, &input), expected);
+        assert_eq!(recent_calls(&entries).is_similar(name, &input), expected);
+    }
+
+    /// Near-duplicate commands (trailing space) must trip the guard even though
+    /// no two are byte-identical.
+    #[test]
+    fn near_duplicate_command_triggers() {
+        let mut rc = RecentCalls::new();
+        let cmd = |c: &str| serde_json::json!({"command": c});
+        rc.record(
+            "bash".into(),
+            &cmd("grep -rn \"TNS_BIND_\" src/main/kotlin"),
+        );
+        rc.record(
+            "bash".into(),
+            &cmd("grep -rn \"TNS_BIND_\" src/main/kotlin "),
+        );
+        assert!(rc.is_similar("bash", &cmd("grep -rn \"TNS_BIND_\" src/main/kotlin")));
+    }
+
+    /// Key reordering in the JSON object must not dodge the guard.
+    #[test]
+    fn reordered_keys_trigger() {
+        let mut rc = RecentCalls::new();
+        let a = || serde_json::json!({"path": "/a", "offset": 1});
+        let b = || serde_json::json!({"offset": 1, "path": "/a"});
+        rc.record("read".into(), &a());
+        rc.record("read".into(), &b());
+        assert!(rc.is_similar("read", &a()));
+    }
+
+    #[test]
+    fn near_duplicate_dissimilar_input_does_not_trigger() {
+        let mut rc = RecentCalls::new();
+        let cmd = |c: &str| serde_json::json!({"command": c});
+        rc.record("bash".into(), &cmd("grep -rn A one"));
+        rc.record("bash".into(), &cmd("touch totally/unrelated/file"));
+        assert!(!rc.is_similar("bash", &cmd("grep -rn A one")));
+    }
+
+    /// Interior whitespace can be meaningful inside a command or pattern (e.g.
+    /// `grep "a  b"` vs `grep "a b"`), so it must not make two distinct calls
+    /// match.
+    #[test]
+    fn interior_whitespace_does_not_trigger() {
+        let mut rc = RecentCalls::new();
+        let cmd = |c: &str| serde_json::json!({"command": c});
+        rc.record("bash".into(), &cmd("grep -rn \"a  b\" src"));
+        rc.record("bash".into(), &cmd("grep -rn \"a b\" src"));
+        assert!(!rc.is_similar("bash", &cmd("grep -rn \"a  b\" src")));
+    }
+
+    /// A paginated read differs in `offset`, so it must not be treated as a
+    /// repeat of the previous page.
+    #[test]
+    fn paginated_read_does_not_trigger() {
+        let mut rc = RecentCalls::new();
+        rc.record(
+            "read".into(),
+            &serde_json::json!({"path": "/a", "offset": 1}),
+        );
+        rc.record(
+            "read".into(),
+            &serde_json::json!({"path": "/a", "offset": 201}),
+        );
+        assert!(!rc.is_similar("read", &serde_json::json!({"path": "/a", "offset": 401})));
     }
 
     fn local_ctx(

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -36,6 +36,8 @@ pub const MIN_MAX_INPUT_LINES: u32 = 1;
 pub const MAX_SERVER_NAME_LEN: usize = 64;
 
 pub const DEFAULT_MAX_CONTINUATION_TURNS: u32 = 3;
+pub const DEFAULT_MAX_TURNS: u32 = 200;
+pub const MIN_MAX_TURNS: u32 = 1;
 pub const DEFAULT_COMPACTION_BUFFER: CompactionBuffer = CompactionBuffer::Percent(20);
 /// What one turn asks to generate. A number of maki's own choosing rather than
 /// "whatever the window can spare", because the latter ties the output cap to a
@@ -666,6 +668,7 @@ pub struct AgentFileConfig {
     pub max_output_lines: Option<usize>,
     pub max_continuation_turns: Option<u32>,
     pub max_turn_output: Option<u32>,
+    pub max_turns: Option<u32>,
     pub compaction_buffer: Option<CompactionBuffer>,
     pub compaction_instructions: Option<String>,
     pub post_compaction_instructions: Option<String>,
@@ -682,6 +685,7 @@ impl AgentFileConfig {
             max_output_lines,
             max_continuation_turns,
             max_turn_output,
+            max_turns,
             compaction_buffer,
             compaction_instructions,
             post_compaction_instructions,
@@ -1320,8 +1324,12 @@ pub struct AgentConfig {
     )]
     pub rtk: bool,
 
-    #[config(skip, default = "None")]
-    pub max_turns: Option<u32>,
+    #[config(
+        default = "DEFAULT_MAX_TURNS",
+        min = MIN_MAX_TURNS,
+        desc = "Hard cap on agent turns before the run is cut short"
+    )]
+    pub max_turns: u32,
 
     #[config(skip, default = "Vec::new()")]
     pub allowed_tools: Vec<String>,
@@ -1346,7 +1354,7 @@ impl AgentConfig {
             post_compaction_instructions: file.post_compaction_instructions,
             stale_read_check: file.stale_read_check.unwrap_or(true),
             rtk: file.rtk.unwrap_or(true),
-            max_turns: None,
+            max_turns: file.max_turns.unwrap_or(DEFAULT_MAX_TURNS),
             allowed_tools: Vec::new(),
             disabled_tools: Vec::new(),
         }

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -123,6 +123,7 @@ pub(crate) const COMMAND_DEPTH_MSG: &str = "slash command nested too deeply (ali
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Notification {
     TurnComplete { response: Option<String> },
+    TurnLimit { num_turns: u32 },
     PermissionRequested { tool: Option<String> },
     AuthenticationRequired,
     QuestionRequested,
@@ -130,7 +131,9 @@ pub(crate) enum Notification {
 }
 
 impl Notification {
-    /// Prompts blocking the agent outrank turn completions.
+    /// Prompts and run-aborting conditions outrank turn completions. A turn
+    /// limit is a run-terminating stop, not a normal completion, so the user
+    /// must learn why the agent went quiet even while focused.
     pub(crate) fn is_urgent(&self) -> bool {
         !matches!(self, Self::TurnComplete { .. })
     }
@@ -140,6 +143,9 @@ impl Notification {
             Self::TurnComplete { response } => response
                 .clone()
                 .unwrap_or_else(|| "Agent turn complete".into()),
+            Self::TurnLimit { num_turns } => {
+                format!("Turn limit reached after {num_turns} turns.")
+            }
             Self::PermissionRequested { tool: Some(tool) } => {
                 format!("Permission requested: {tool}")
             }

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -5021,6 +5021,7 @@ fn turn_response_stops_after_bounded_large_input() {
 #[test_case(Notification::QuestionRequested, "Question requested", true ; "question")]
 #[test_case(Notification::PlanReady, "Plan ready", true ; "plan")]
 #[test_case(Notification::error_completion(), "Agent stopped with an error", false ; "error_completion")]
+#[test_case(Notification::TurnLimit { num_turns: 200 }, "Turn limit reached after 200 turns.", true ; "turn_limit")]
 fn notification_message_and_urgency(
     notification: Notification,
     expected_message: &str,

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -21,7 +21,8 @@ use crossterm::event::{
 use maki_agent::command::CustomCommand;
 use maki_agent::permissions::PermissionManager;
 use maki_agent::{
-    AgentConfig, AgentEvent, CancelToken, Envelope, McpCommand, McpConfigErrors, McpHandle, mcp,
+    AgentConfig, AgentEvent, CancelToken, DoneReason, Envelope, McpCommand, McpConfigErrors,
+    McpHandle, mcp,
 };
 use maki_config::project::TrustQuestion;
 use maki_config::{ModelPolicy, ProjectConfig, UiConfig};
@@ -146,6 +147,13 @@ impl RunNotificationState {
 
     fn on_done(&mut self, event: &AgentEvent) {
         let notification = match event {
+            AgentEvent::Done {
+                reason: DoneReason::MaxTurns,
+                num_turns,
+                ..
+            } => Notification::TurnLimit {
+                num_turns: *num_turns,
+            },
             AgentEvent::Done { .. } => Notification::TurnComplete {
                 response: self.response_candidate.take(),
             },
@@ -1820,7 +1828,6 @@ fn scroll_delta(kind: MouseEventKind, lines: u32) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use maki_agent::DoneReason;
     use maki_providers::TokenUsage;
     use test_case::test_case;
 
@@ -1864,6 +1871,31 @@ mod tests {
             Some(Notification::TurnComplete {
                 response: Some("done".into())
             })
+        );
+    }
+
+    #[test]
+    fn turn_limit_stop_is_announced() {
+        let mut state = RunNotificationState::default();
+        let mut event = done_event();
+        if let AgentEvent::Done {
+            reason, num_turns, ..
+        } = &mut event
+        {
+            *reason = DoneReason::MaxTurns;
+            *num_turns = 200;
+        }
+        state.on_done(&event);
+        state.on_drain();
+        let notification = state
+            .reconcile(None, SessionStatus::Idle, true)
+            .expect("expected a turn-limit notification");
+        assert!(
+            notification
+                .message()
+                .contains("Turn limit reached after 200 turns"),
+            "unexpected message: {}",
+            notification.message()
         );
     }
 

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -128,6 +128,7 @@ How many lines of output to show per tool in the UI. All values are `usize` with
 | `post_compaction_instructions` | String | `none` | - | Extra instructions the agent receives after any compaction (e.g. re-read plan.md) |
 | `stale_read_check` | bool | `true` | - | Require re-reading a file that changed on disk before editing it |
 | `rtk` | bool | `true` | - | Rewrite bash commands with [rtk](https://github.com/rtk-ai/rtk) when it is installed |
+| `max_turns` | u32 | `200` | 1 | Hard cap on agent turns before the run is cut short |
 
 ### `provider`
 

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -540,7 +540,7 @@ pub fn run(params: SdkParams) -> Result<()> {
     } = params;
     cli.warn_ignored_flags();
     if let Some(max) = cli.max_turns {
-        config.max_turns = Some(max);
+        config.max_turns = max;
     }
     let permission_mode = PermissionMode::resolve(cli.permission_mode.as_deref(), cli.yolo);
 


### PR DESCRIPTION
Guards against agent runs that loop forever:

- Cap runs with a configurable `max_turns` (default `200`), so any run without an explicit limit still terminates instead of looping indefinitely.
- Inject a bounded number of "break the loop" nudges when recent pure-text assistant turns are near-identical and not making progress.
- Harden the doom-loop detector with O(n) canonicalization (whitespace collapse + sorted keys) so near-duplicate tool invocations trip the guard without the cost or false positives of a fuzzy ratio.

## Why

LLM agents can degrade into a "stuck" state where the model keeps narrating intent instead of acting: every turn re-emits near-identical filler (e.g. "go.", "run now.", "let me invoke the tool") while never completing the actual tool call. Left alone, this loops indefinitely, burning tokens, stalling the run, and producing a session that looks busy but accomplishes nothing.

This is hard to catch with exact matching alone, because each repetition is superficially different — the model truncates, rewords, and re-orders the same idea, so an exact-hash detector sees unique output every turn. These changes make the loop detection robust to that noise:

- **O(n) canonicalization** normalizes each tool input by collapsing whitespace and sorting object keys recursively, so semantically-equivalent invocations (whitespace churn, key reordering) compare equal without a quadratic diff or a fuzzy threshold that misfires on paginated reads.
- **Text-turn similarity** nudges the model to break the loop once the last several turns are effectively the same message — recorded only on pure-text turns, and reset whenever the agent makes a real tool call (progress).
- **A configurable default turn budget** (`max_turns`, default `200`) guarantees that any run still terminates, so a missed detection degrades into a clean, bounded stop instead of a runaway session.

Collectively this turns a pathological unbounded loop into a self-terminating run with a clear nudge to get back on track.
