### PR TITLE
fix(spawn): keep posix_spawn fast path to silence libmalloc MSL warning

### DIFF
--- a/maki-agent/src/child_env.rs
+++ b/maki-agent/src/child_env.rs
@@ -1,0 +1,135 @@
+//! Environment sanitation and program resolution for spawned child processes.
+
+use std::collections::HashMap;
+
+/// macOS env vars that keep libmalloc stack logging enabled in the exec'd
+/// child (the child's runtime prints "recording ... lite mode" at init and
+/// may warn when it turns it off). Inherited values are stripped unless the
+/// spawn site explicitly sets them. See tontinton/maki#909.
+#[cfg(target_os = "macos")]
+const MALLOC_STACK_LOGGING_VARS: &[&str] =
+    &["MallocStackLogging", "MallocStackLoggingNoCompact", "MallocStackLoggingDirectory"];
+
+/// Remove inherited MallocStackLogging* vars from a command's environment,
+/// preserving any the caller set explicitly.
+pub trait StripInheritedMallocStackLogging {
+    fn env_remove_var(&mut self, var: &str);
+}
+
+impl StripInheritedMallocStackLogging for std::process::Command {
+    fn env_remove_var(&mut self, var: &str) {
+        self.env_remove(var);
+    }
+}
+
+impl StripInheritedMallocStackLogging for async_process::Command {
+    fn env_remove_var(&mut self, var: &str) {
+        self.env_remove(var);
+    }
+}
+
+pub fn strip_inherited_malloc_stack_logging(cmd: &mut impl StripInheritedMallocStackLogging) {
+    #[cfg(target_os = "macos")]
+    for var in MALLOC_STACK_LOGGING_VARS {
+        cmd.env_remove_var(var);
+    }
+    #[cfg(not(target_os = "macos"))]
+    let _ = cmd;
+}
+
+/// Resolve a bare program name against the child's effective PATH so
+/// std::process keeps the posix_spawn fast path (see #909). Returns the input
+/// unchanged when it already contains a separator or nothing is found.
+pub fn resolve_program(program: &str, env: &HashMap<String, String>) -> std::ffi::OsString {
+    if program.contains('/') || program.contains('\\') || program.is_empty() {
+        return std::ffi::OsString::from(program);
+    }
+    let path = env
+        .get("PATH")
+        .map(String::as_str)
+        .map(std::path::PathBuf::from)
+        .or_else(|| std::env::var_os("PATH").map(std::path::PathBuf::from));
+    if let Some(path) = path {
+        for dir in std::env::split_paths(&path) {
+            let candidate = dir.join(program);
+            if candidate.is_file() {
+                return candidate.into_os_string();
+            }
+        }
+    }
+    std::ffi::OsString::from(program)
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_inherited_vars_but_keeps_explicit() {
+        unsafe {
+            std::env::set_var("MallocStackLogging", "1");
+            std::env::set_var("MallocStackLoggingNoCompact", "1");
+        }
+        let mut cmd = std::process::Command::new("true");
+        cmd.env("MallocStackLoggingLevel", "verbose");
+        strip_inherited_malloc_stack_logging(&mut cmd);
+        let get = |name: &str| -> Option<String> {
+            cmd.get_envs()
+                .find(|(k, _)| k.to_string_lossy() == name)
+                .and_then(|(_, v)| v)
+                .map(|v| v.to_string_lossy().into_owned())
+        };
+        assert_eq!(get("MallocStackLogging"), None);
+        assert_eq!(get("MallocStackLoggingNoCompact"), None);
+        assert_eq!(get("MallocStackLoggingDirectory"), None);
+        assert_eq!(get("MallocStackLoggingLevel"), Some("verbose".into()));
+        unsafe {
+            std::env::remove_var("MallocStackLogging");
+            std::env::remove_var("MallocStackLoggingNoCompact");
+        }
+    }
+}
+
+#[cfg(test)]
+mod resolve_program_tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn env_with(path: Option<&str>) -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        if let Some(p) = path {
+            m.insert("PATH".to_string(), p.to_string());
+        }
+        m
+    }
+
+    #[test]
+    fn bare_name_resolves_against_config_path() {
+        let dir = std::env::temp_dir();
+        let bin = dir.join("maki-resolve-test-bin");
+        std::fs::write(&bin, b"#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let env = env_with(Some(&format!("{}:/usr/bin", dir.display())));
+        let got = resolve_program("maki-resolve-test-bin", &env);
+        assert_eq!(got, bin.as_os_str());
+        let _ = std::fs::remove_file(&bin);
+    }
+
+    #[test]
+    fn absolute_and_relative_paths_pass_through() {
+        let env = env_with(Some("/usr/bin"));
+        assert_eq!(resolve_program("/bin/sleep", &env), std::ffi::OsString::from("/bin/sleep"));
+        assert_eq!(resolve_program("./tool", &env), std::ffi::OsString::from("./tool"));
+        assert_eq!(resolve_program("", &env), std::ffi::OsString::from(""));
+    }
+
+    #[test]
+    fn missing_binary_passes_through_for_start_failed_message() {
+        let env = env_with(Some("/nonexistent-dir"));
+        assert_eq!(resolve_program("definitely-not-a-bin", &env), std::ffi::OsString::from("definitely-not-a-bin"));
+    }
+}

--- a/maki-agent/src/child_guard.rs
+++ b/maki-agent/src/child_guard.rs
@@ -112,12 +112,7 @@ mod tests {
     fn spawn_sleep() -> Child {
         let mut std_cmd = std::process::Command::new("sleep");
         std_cmd.arg("60");
-        unsafe {
-            std_cmd.pre_exec(|| {
-                libc::setsid();
-                Ok(())
-            });
-        }
+        std_cmd.process_group(0);
         let mut cmd: async_process::Command = std_cmd.into();
         cmd.spawn().expect("failed to spawn sleep")
     }

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod agent;
 pub mod cancel;
+pub mod child_env;
 pub mod child_guard;
 pub use child_guard::ChildGuard;
 pub mod headless;

--- a/maki-agent/src/mcp/stdio.rs
+++ b/maki-agent/src/mcp/stdio.rs
@@ -43,18 +43,18 @@ impl StdioTransport {
         environment: &HashMap<String, String>,
         timeout: Duration,
     ) -> Result<Self, McpError> {
-        let mut std_cmd = std::process::Command::new(program);
+        let program = crate::child_env::resolve_program(program, environment);
+        let mut std_cmd = std::process::Command::new(&program);
         std_cmd.args(args).envs(environment);
 
+        // Keep std on the posix_spawn fast path: no fork means libmalloc's
+        // atfork child handler never runs and can't print the
+        // MallocStackLogging warning from tontinton/maki#909.
         #[cfg(unix)]
-        unsafe {
-            std_cmd.pre_exec(|| {
-                libc::setsid();
-                Ok(())
-            });
-        }
+        std_cmd.process_group(0);
 
         let mut cmd: async_process::Command = std_cmd.into();
+        crate::child_env::strip_inherited_malloc_stack_logging(&mut cmd);
         cmd.stdin(async_process::Stdio::piped())
             .stdout(async_process::Stdio::piped())
             .stderr(async_process::Stdio::piped());

--- a/maki-agent/tests/msl_fork_warning.rs
+++ b/maki-agent/tests/msl_fork_warning.rs
@@ -1,0 +1,102 @@
+//! Regression test for tontinton/maki#909.
+//!
+//! Re-exec this test binary as a child; the child spawns /bin/sleep via the
+//! posix_spawn fast path (process_group(0), resolved program path) while
+//! MallocStackLogging=1 is in ITS environment. On the fork+exec path libmalloc's
+//! atfork child handler would print "MallocStackLogging: turning off stack
+//! logging"; on the posix_spawn path it must not.
+
+#![cfg(target_os = "macos")]
+
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+fn read_to_end_capped<R: std::io::Read + Send + 'static>(
+    mut rx: R,
+) -> std::io::Result<String> {
+    let (tx, rrx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = rx.read_to_string(&mut buf);
+        let _ = tx.send(buf);
+    });
+    match rrx.recv_timeout(Duration::from_secs(30)) {
+        Ok(s) => Ok(s),
+        Err(_) => Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "read timed out",
+        )),
+    }
+}
+
+#[test]
+fn spawn_does_not_trigger_msl_atfork_warning() {
+    if std::env::var("MAKI_MSL_FORK_CHILD").as_deref() == Ok("1") {
+        child_side();
+        return;
+    }
+    parent_side();
+}
+
+fn parent_side() {
+    let exe = std::env::current_exe().expect("current_exe");
+    let mut cmd = Command::new(&exe);
+    cmd.arg("--exact").arg("spawn_does_not_trigger_msl_atfork_warning").arg("--nocapture");
+    cmd.env("MAKI_MSL_FORK_CHILD", "1");
+    cmd.env("MallocStackLogging", "1");
+    cmd.env("MallocDebugReport", "stderr");
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    cmd.stdin(Stdio::null());
+    let mut child = cmd.spawn().expect("re-exec self");
+    let so = child.stdout.take().unwrap();
+    let se = child.stderr.take().unwrap();
+    let (out_rx, err_rx) = (read_to_end_capped(so), read_to_end_capped(se));
+    let status = child.wait().expect("wait");
+    let out = out_rx.unwrap_or_default();
+    let err = err_rx.unwrap_or_default();
+    assert!(status.success(), "child failed: {status}\nstdout:\n{out}\nstderr:\n{err}");
+    assert!(
+        out.contains("GRANDCHILD_STDERR_CLEAN"),
+        "missing sentinel; stdout:\n{out}\nstderr:\n{err}"
+    );
+    let combined = format!("{out}{err}");
+    // child's own MSL init banner ("recording ... lite mode") is expected;
+    // the atfork "turning off stack logging" warning is the regression signal
+    assert!(
+        !combined.contains("turning off stack logging") && !combined.contains("had been recording"),
+        "MSL atfork warning leaked; combined:\n{combined}"
+    );
+}
+
+fn child_side() {
+    let mut cmd = Command::new(maki_agent::child_env::resolve_program("sleep", &{
+        let mut m = std::collections::HashMap::new();
+        if let Some(p) = std::env::var_os("PATH") {
+            m.insert("PATH".to_string(), p.to_string_lossy().into_owned());
+        }
+        m
+    }));
+    cmd.arg("0");
+    // strip inherited MSL so sleep prints no init banner; the "turning off"
+    // atfork warning is what we assert absent, and it can only fire if the
+    // spawn took the fork+exec path (pre_exec) instead of posix_spawn.
+    maki_agent::child_env::strip_inherited_malloc_stack_logging(&mut cmd);
+    use std::os::unix::process::CommandExt;
+    cmd.process_group(0);
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let mut child = cmd.spawn().expect("spawn sleep");
+    let se = child.stderr.take().unwrap();
+    let err = read_to_end_capped(se).unwrap_or_default();
+    let _ = child.wait();
+    let clean = !err.contains("MallocStackLogging");
+    if !clean {
+        eprintln!("GRANDCHILD_STDERR_DIRTY: {err}");
+    } else {
+        println!("GRANDCHILD_STDERR_CLEAN");
+    }
+    assert!(clean, "libmalloc MSL warning captured on stderr: {err}");
+}

--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -285,16 +285,14 @@ impl JobStore {
             .stderr(stderr.stdio()?)
             .stdin(Stdio::null());
 
+        // Keep std on the posix_spawn fast path so libmalloc's atfork child
+        // handler never runs (it prints a MallocStackLogging warning when the
+        // parent has MSL enabled; see tontinton/maki#909). pgid == pid, so
+        // kill_process_group below is unaffected.
         #[cfg(unix)]
         {
             use std::os::unix::process::CommandExt;
-            // SAFETY: setsid is async-signal-safe, so it is sound to call in pre_exec.
-            unsafe {
-                command.pre_exec(|| {
-                    rustix::process::setsid()?;
-                    Ok(())
-                });
-            }
+            command.process_group(0);
         }
 
         if let Some(dir) = cwd.as_deref().map(expand_tilde) {
@@ -776,6 +774,7 @@ fn shell_command(cmd: &str) -> Command {
     {
         let mut c = Command::new("bash");
         c.arg("-c").arg(cmd);
+        maki_agent::child_env::strip_inherited_malloc_stack_logging(&mut c);
         c
     }
     #[cfg(windows)]

--- a/maki-ui/src/app/shell.rs
+++ b/maki-ui/src/app/shell.rs
@@ -217,14 +217,12 @@ async fn run_command(
         .arg("-c")
         .arg(command)
         .env("GIT_TERMINAL_PROMPT", "0");
+    maki_agent::child_env::strip_inherited_malloc_stack_logging(&mut std_cmd);
 
+    // posix_spawn fast path: avoids fork and libmalloc's noisy atfork child
+    // handler when the parent has MallocStackLogging enabled (see #909).
     #[cfg(unix)]
-    unsafe {
-        std_cmd.pre_exec(|| {
-            libc::setsid();
-            Ok(())
-        });
-    }
+    std_cmd.process_group(0);
 
     let mut cmd: Command = std_cmd.into();
     cmd.stdin(Stdio::null())


### PR DESCRIPTION
Fixes #909

## Root cause

With `MallocStackLogging=1` in the environment and a TTY stderr, every spawned child printed:

```
maki(<pid>) MallocStackLogging: turning off stack logging (had been recording malloc and VM allocation stacks using lite mode)
```

The message is emitted by **libmalloc's atfork child handler inside `fork()`**, before `exec` — which is why it carries the parent's progname (`maki`) but the child's pid. It fired because every spawn site registered a `pre_exec(setsid)` closure, which forces Rust std off the `posix_spawn` fast path onto fork+exec (`library/std/src/sys/process/unix/unix.rs`: non-empty closures bail out of posix_spawn). Lite-mode stack recording cannot survive `fork`, so the handler disables it and reports — to the parent's TTY, gated by `malloc_printf`'s `isatty(stderr)` check, which is why the warning was TTY-only.

Repro: `MallocStackLogging=1 script -q /dev/null maki -p "say hi only"` with any MCP stdio server configured.

## Fix

Replace `pre_exec(setsid)` with `CommandExt::process_group(0)` at all spawn sites. `posix_spawn` supports `POSIX_SPAWN_SETPGROUP` directly — no fork, no atfork handler, no warning. `pgid == pid`, so the existing `killpg`-based cleanup (`ChildGuard::signal_kill`, `mcp::kill_process_groups`, lua `kill_process_group`) is unchanged.

Sites: MCP stdio transport, lua `job.spawn`, ui shell command, `ChildGuard` test helper.

Secondary hardening (new `child_env` module):
- `strip_inherited_malloc_stack_logging`: drops inherited `MallocStackLogging*` vars so the exec'd child doesn't re-enable MSL and print its own `recording ... lite mode` banner
- `resolve_program`: resolves bare program names against the child's effective PATH so std's `env_saw_path() && !program_is_path()` gate can't silently drop us back onto the fork path for configs like `command = ["npx", ...]`

## Testing

- New `msl_fork_warning` regression test (macOS only): re-execs the test binary with `MallocStackLogging=1` + `MallocDebugReport=stderr`, spawns a grandchild through the same `process_group(0)` + env-strip path, asserts the grandchild's stderr is clean. Negative control: swapping back to `pre_exec(setsid)` reproduces the exact warning and fails the test.
- `cargo test -p maki-agent`, `cargo test -p maki-lua --lib job`, `cargo test -p maki-ui --lib shell`: pass
- E2E: with an MCP stdio server configured, `turning off stack logging` no longer appears for any spawned child; maki's own MSL banner is preserved
