### PR TITLE
feat(compact): guide one compaction from the command

### DIFF
--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -9,17 +9,35 @@ use tracing::info;
 use super::history::{History, remove_orphaned_tool_results};
 use super::streaming::{StreamError, stream_with_retry};
 use crate::cancel::CancelToken;
+use crate::prompt::COMPACTION_USER;
 use crate::{AgentError, AgentEvent, DoneReason, EventSender, TurnCompleteEvent};
 
 const CONTINUE_AFTER_COMPACT: &str = "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed. If the summary contains a todo list, restore it with todo_write and keep it updated. If you learned important project context during this session, consider saving it to memory before it's lost.";
 const IMAGE_PLACEHOLDER: &str = "[image]";
 
-fn normalize(text: &Option<String>) -> Option<&str> {
-    text.as_deref().map(str::trim).filter(|t| !t.is_empty())
+fn normalize(text: Option<&str>) -> Option<&str> {
+    text.map(str::trim).filter(|t| !t.is_empty())
+}
+
+/// Config instructions steer every compaction, `request` only the one the user
+/// asked for with `/compact <guidance>`, so both are kept and neither wins.
+fn summary_prompt(config: &AgentConfig, request: Option<&str>) -> String {
+    let extras = [
+        normalize(config.compaction_instructions.as_deref()),
+        normalize(request),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>()
+    .join("\n");
+    if extras.is_empty() {
+        return COMPACTION_USER.to_string();
+    }
+    format!("{COMPACTION_USER}\n\nAdditional instructions:\n{extras}")
 }
 
 pub(super) fn continue_message(config: &AgentConfig) -> String {
-    match normalize(&config.post_compaction_instructions) {
+    match normalize(config.post_compaction_instructions.as_deref()) {
         Some(extra) => format!("{CONTINUE_AFTER_COMPACT}\n\n{extra}"),
         None => CONTINUE_AFTER_COMPACT.to_string(),
     }
@@ -32,6 +50,7 @@ pub(super) async fn compact_history(
     event_tx: &EventSender,
     cancel: &CancelToken,
     config: &AgentConfig,
+    instructions: Option<&str>,
 ) -> Result<TokenUsage, AgentError> {
     let compact_start = std::time::Instant::now();
     let mut compaction_history: Vec<Message> = history.as_slice().to_vec();
@@ -39,14 +58,7 @@ pub(super) async fn compact_history(
     strip_images(&mut compaction_history);
     strip_thinking(&mut compaction_history);
     strip_old_tool_results(&mut compaction_history);
-    let summary_prompt = match normalize(&config.compaction_instructions) {
-        Some(extra) => format!(
-            "{}\n\nAdditional instructions:\n{extra}",
-            crate::prompt::COMPACTION_USER
-        ),
-        None => crate::prompt::COMPACTION_USER.to_string(),
-    };
-    compaction_history.push(Message::user(summary_prompt));
+    compaction_history.push(Message::user(summary_prompt(config, instructions)));
 
     let empty_tools = serde_json::json!([]);
     let max_attempts = 3;
@@ -128,10 +140,20 @@ pub async fn compact(
     history: &mut History,
     event_tx: &EventSender,
     config: &AgentConfig,
+    instructions: Option<&str>,
 ) -> Result<(), AgentError> {
     let cancel = CancelToken::none();
-    let usage = compact_history(provider, model, history, event_tx, &cancel, config).await?;
-    if let Some(post) = normalize(&config.post_compaction_instructions) {
+    let usage = compact_history(
+        provider,
+        model,
+        history,
+        event_tx,
+        &cancel,
+        config,
+        instructions,
+    )
+    .await?;
+    if let Some(post) = normalize(config.post_compaction_instructions.as_deref()) {
         history.push(Message::synthetic(post.to_string()));
     }
 
@@ -259,6 +281,10 @@ mod tests {
     use super::*;
     use crate::AgentConfig;
 
+    const CONFIG_EXTRA: &str = "Record anything that belongs in plan.md";
+    const REQUEST_EXTRA: &str = "Keep the failing test names";
+    const POST: &str = "Re-read plan.md and agent.md";
+
     struct MockProvider {
         responses: Mutex<Vec<Result<StreamResponse, AgentError>>>,
         requests: Mutex<Vec<Vec<Message>>>,
@@ -346,6 +372,7 @@ mod tests {
                 &mut history,
                 &EventSender::new(raw_tx, 0),
                 &AgentConfig::default(),
+                None,
             )
             .await
             .unwrap();
@@ -380,6 +407,7 @@ mod tests {
                 &mut history,
                 &EventSender::new(raw_tx, 0),
                 &AgentConfig::default(),
+                None,
             )
             .await
             .expect_err("empty summary must fail");
@@ -390,17 +418,16 @@ mod tests {
         });
     }
 
+    /// `summary_prompt_merges_instructions` covers the merge, this one the
+    /// wiring around it.
     #[test]
-    fn compact_applies_custom_instructions() {
+    fn compact_sends_instructions_and_appends_post() {
         smol::block_on(async {
-            const EXTRA: &str = "Record anything that belongs in plan.md";
-            const POST: &str = "Re-read plan.md and agent.md";
-
             let provider = MockProvider::new(vec![Ok(text_response(StopReason::EndTurn))]);
             let mut history = History::new(vec![Message::user("work".into())]);
             let (raw_tx, _rx) = flume::unbounded();
             let config = AgentConfig {
-                compaction_instructions: Some(EXTRA.into()),
+                compaction_instructions: Some(CONFIG_EXTRA.into()),
                 post_compaction_instructions: Some(POST.into()),
                 ..Default::default()
             };
@@ -411,16 +438,16 @@ mod tests {
                 &mut history,
                 &EventSender::new(raw_tx, 0),
                 &config,
+                Some(REQUEST_EXTRA),
             )
             .await
             .unwrap();
 
             let requests = provider.requests.lock().unwrap();
-            let summary_prompt = requests[0].last().unwrap();
             assert!(matches!(
-                &summary_prompt.content[0],
+                &requests[0].last().unwrap().content[0],
                 ContentBlock::Text { text }
-                    if text.starts_with(crate::prompt::COMPACTION_USER) && text.ends_with(EXTRA)
+                    if text.contains(CONFIG_EXTRA) && text.contains(REQUEST_EXTRA)
             ));
             assert!(matches!(
                 &history.as_slice().last().unwrap().content[0],
@@ -429,10 +456,31 @@ mod tests {
         });
     }
 
-    #[test_case(Some("  \n ".into()), None ; "whitespace_only_is_none")]
-    #[test_case(Some("  keep plan.md ".into()), Some("keep plan.md") ; "trimmed")]
-    fn normalize_instructions(raw: Option<String>, expected: Option<&str>) {
-        assert_eq!(normalize(&raw), expected);
+    #[test_case(None, None, false, false ; "no_instructions")]
+    #[test_case(Some(CONFIG_EXTRA), None, true, false ; "config_only")]
+    #[test_case(None, Some(REQUEST_EXTRA), false, true ; "request_only")]
+    #[test_case(Some(CONFIG_EXTRA), Some(REQUEST_EXTRA), true, true ; "both_kept")]
+    #[test_case(Some(CONFIG_EXTRA), Some("   "), true, false ; "blank_request_ignored")]
+    #[test_case(Some(" \n "), Some(REQUEST_EXTRA), false, true ; "blank_config_ignored")]
+    fn summary_prompt_merges_instructions(
+        config_extra: Option<&str>,
+        request: Option<&str>,
+        has_config: bool,
+        has_request: bool,
+    ) {
+        let config = AgentConfig {
+            compaction_instructions: config_extra.map(str::to_string),
+            ..Default::default()
+        };
+        let prompt = summary_prompt(&config, request);
+
+        assert!(prompt.starts_with(COMPACTION_USER));
+        assert_eq!(
+            prompt.len() > COMPACTION_USER.len(),
+            has_config || has_request
+        );
+        assert_eq!(prompt.contains(CONFIG_EXTRA), has_config);
+        assert_eq!(prompt.contains(REQUEST_EXTRA), has_request);
     }
 
     #[test]
@@ -469,6 +517,7 @@ mod tests {
                 &EventSender::new(raw_tx, 0),
                 &CancelToken::none(),
                 &AgentConfig::default(),
+                None,
             )
             .await
             .unwrap();
@@ -697,6 +746,7 @@ mod tests {
                 &EventSender::new(raw_tx, 0),
                 &CancelToken::none(),
                 &AgentConfig::default(),
+                None,
             )
             .await
             .unwrap();
@@ -739,6 +789,7 @@ mod tests {
                 &EventSender::new(raw_tx, 0),
                 &CancelToken::none(),
                 &AgentConfig::default(),
+                None,
             )
             .await
             .unwrap();

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -540,11 +540,11 @@ impl<'h> Agent<'h> {
             context_size: self.context_size,
             context_window: self.model.context_window,
         })?;
-        self.do_compact().await?;
+        self.do_compact(None).await?;
         Ok(true)
     }
 
-    async fn do_compact(&mut self) -> Result<(), AgentError> {
+    async fn do_compact(&mut self, instructions: Option<&str>) -> Result<(), AgentError> {
         let context_size_before = self.context_size;
         let (compact_provider, compact_model) = resolve_compaction_model(
             &self.provider,
@@ -559,6 +559,7 @@ impl<'h> Agent<'h> {
             &self.event_tx,
             &self.cancel,
             &self.config,
+            instructions,
         )
         .await?;
         // The summariser can be a different model, so price this with
@@ -613,8 +614,8 @@ impl<'h> Agent<'h> {
                     });
                 }
             }
-            ExtractedCommand::Compact => {
-                self.do_compact().await?;
+            ExtractedCommand::Compact(instructions) => {
+                self.do_compact(instructions.as_deref()).await?;
             }
         }
         Ok(true)
@@ -1157,7 +1158,7 @@ mod tests {
 
     #[test_case(
         (0..10).map(|i| Message::user(format!("msg {i}"))).collect(),
-        vec![ExtractedCommand::Compact],
+        vec![ExtractedCommand::Compact(None)],
         vec![tool_call_response("glob", "t1"), text_response(StopReason::EndTurn), text_response(StopReason::EndTurn)]
         ; "compaction_via_interrupt_source"
     )]
@@ -1251,7 +1252,7 @@ mod tests {
                 &mut history,
             );
             agent.config.post_compaction_instructions = Some(POST.into());
-            agent.do_compact().await.unwrap();
+            agent.do_compact(None).await.unwrap();
             drop(agent);
 
             let last = history.as_slice().last().unwrap();

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -65,7 +65,9 @@ pub enum ExtractedCommand {
     /// since a command like `/compact` rewrites the history the later messages
     /// land in.
     Interrupt(Vec<AgentInput>),
-    Compact,
+    /// Carries the guidance typed as `/compact <instructions>`, for this one
+    /// summary.
+    Compact(Option<String>),
 }
 
 pub trait InterruptSource: Send + Sync {

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -126,7 +126,10 @@ impl AgentLoop {
         let event_tx = EventSender::new(self.agent_tx.clone(), run_id);
 
         let result = match run {
-            QueueRun::Compact { .. } => self.do_compact(&event_tx).await,
+            QueueRun::Compact(compaction) => {
+                self.do_compact(&event_tx, compaction.instructions.as_deref())
+                    .await
+            }
             QueueRun::Messages(messages) => {
                 let inputs = messages
                     .into_iter()
@@ -173,7 +176,11 @@ impl AgentLoop {
         !self.init_cancel.is_cancelled()
     }
 
-    async fn do_compact(&mut self, event_tx: &EventSender) -> Result<(), AgentError> {
+    async fn do_compact(
+        &mut self,
+        event_tx: &EventSender,
+        instructions: Option<&str>,
+    ) -> Result<(), AgentError> {
         let slot = self.model_slot.load();
         let (provider, model) = agent::resolve_compaction_model(
             &slot.provider,
@@ -187,6 +194,7 @@ impl AgentLoop {
             &mut self.history,
             event_tx,
             &self.config,
+            instructions,
         )
         .await
     }

--- a/maki-ui/src/agent/shared_queue.rs
+++ b/maki-ui/src/agent/shared_queue.rs
@@ -72,9 +72,23 @@ impl QueuedInput {
     }
 }
 
+pub(crate) struct Compaction {
+    pub(crate) run_id: u64,
+    pub(crate) instructions: Option<String>,
+}
+
+impl Compaction {
+    fn label(&self) -> Cow<'static, str> {
+        match self.instructions {
+            Some(ref extra) => Cow::Owned(format!("{COMPACT_LABEL} {extra}")),
+            None => Cow::Borrowed(COMPACT_LABEL),
+        }
+    }
+}
+
 pub(crate) enum QueueItem {
     Message(QueuedInput),
-    Compact { run_id: u64 },
+    Compact(Compaction),
 }
 
 /// One turn's worth of work. Plain messages typed back to back under the same
@@ -83,7 +97,7 @@ pub(crate) enum QueueItem {
 /// `/compact` rewrites the history the later messages land in.
 pub(crate) enum QueueRun {
     Messages(Vec<QueuedInput>),
-    Compact { run_id: u64 },
+    Compact(Compaction),
 }
 
 impl QueueRun {
@@ -96,7 +110,9 @@ impl QueueRun {
                 messages.retain(|queued| queued.run_id >= min_run_id);
                 Some(messages.last()?.run_id)
             }
-            Self::Compact { run_id } => (*run_id >= min_run_id).then_some(*run_id),
+            Self::Compact(compaction) => {
+                (compaction.run_id >= min_run_id).then_some(compaction.run_id)
+            }
         }
     }
 }
@@ -108,8 +124,8 @@ impl QueueItem {
                 text: Cow::Owned(queued.text.clone()),
                 color: theme::current().foreground,
             },
-            Self::Compact { .. } => QueueEntry {
-                text: Cow::Borrowed(COMPACT_LABEL),
+            Self::Compact(compaction) => QueueEntry {
+                text: compaction.label(),
                 color: theme::current()
                     .queue
                     .fg
@@ -121,7 +137,7 @@ impl QueueItem {
     fn batch_key(&self) -> Option<BatchKey> {
         match self {
             Self::Message(queued) => queued.batch_key(),
-            Self::Compact { .. } => None,
+            Self::Compact(_) => None,
         }
     }
 
@@ -131,7 +147,7 @@ impl QueueItem {
     fn visible_in_panel(&self) -> bool {
         match self {
             Self::Message(queued) => !queued.displayed,
-            Self::Compact { .. } => true,
+            Self::Compact(_) => true,
         }
     }
 }
@@ -192,7 +208,7 @@ impl QueueSender {
             .filter(|item| item.visible_in_panel())
             .filter_map(|item| match item {
                 QueueItem::Message(queued) => Some(queued.text.clone()),
-                QueueItem::Compact { .. } => None,
+                QueueItem::Compact(_) => None,
             })
             .collect()
     }
@@ -219,7 +235,7 @@ impl QueueReceiver {
     pub(crate) fn pop_run(&self) -> Option<QueueRun> {
         let mut items = lock(&self.items);
         let first = match items.pop_front()? {
-            QueueItem::Compact { run_id } => return Some(QueueRun::Compact { run_id }),
+            QueueItem::Compact(compaction) => return Some(QueueRun::Compact(compaction)),
             QueueItem::Message(first) => first,
         };
         let key = first.batch_key();
@@ -250,7 +266,7 @@ impl QueueReceiver {
 impl InterruptSource for QueueReceiver {
     fn poll(&self) -> Option<ExtractedCommand> {
         Some(match self.pop_run()? {
-            QueueRun::Compact { .. } => ExtractedCommand::Compact,
+            QueueRun::Compact(compaction) => ExtractedCommand::Compact(compaction.instructions),
             QueueRun::Messages(run) => {
                 ExtractedCommand::Interrupt(run.into_iter().map(|queued| queued.input).collect())
             }
@@ -298,6 +314,7 @@ mod tests {
     const PROMPT_NAME: &str = "server/review";
     const PLAN_PATH: &str = "plan.md";
     const NOT_AN_INTERRUPT: &str = "expected an interrupt carrying the queued messages";
+    const GUIDANCE: &str = "keep the failing test names";
     /// One image block plus one text block.
     const BLOCKS_PER_MESSAGE: usize = 2;
 
@@ -349,8 +366,11 @@ mod tests {
         QueueItem::Message(queued)
     }
 
-    fn compact() -> QueueItem {
-        QueueItem::Compact { run_id: 0 }
+    fn compact(instructions: Option<&str>) -> QueueItem {
+        QueueItem::Compact(Compaction {
+            run_id: 0,
+            instructions: instructions.map(str::to_string),
+        })
     }
 
     /// Drains the queue and names every run it hands over: the texts of a
@@ -370,7 +390,7 @@ mod tests {
 
     #[test_case(message(FIRST), true  ; "deferred_message_visible")]
     #[test_case(QueueItem::Message(QueuedInput { displayed: true, ..queued(FIRST, 0) }), false ; "displayed_message_hidden")]
-    #[test_case(compact(), true  ; "compact_visible")]
+    #[test_case(compact(None), true  ; "compact_visible")]
     fn panel_visibility(item: QueueItem, visible: bool) {
         let (tx, _rx) = queue();
         tx.push(item);
@@ -412,7 +432,7 @@ mod tests {
     }
 
     #[test_case(vec![message(FIRST), message(SECOND), message(THIRD)], vec![vec![FIRST, SECOND, THIRD]] ; "adjacent_messages_ride_together")]
-    #[test_case(vec![message(FIRST), compact(), message(SECOND)], vec![vec![FIRST], vec![COMPACT_LABEL], vec![SECOND]] ; "compact_splits_the_drain_and_keeps_its_place")]
+    #[test_case(vec![message(FIRST), compact(None), message(SECOND)], vec![vec![FIRST], vec![COMPACT_LABEL], vec![SECOND]] ; "compact_splits_the_drain_and_keeps_its_place")]
     #[test_case(vec![message(FIRST), prompt_message(SECOND), message(THIRD)], vec![vec![FIRST], vec![SECOND], vec![THIRD]] ; "mcp_prompt_runs_alone")]
     #[test_case(vec![message(FIRST)], vec![vec![FIRST]] ; "single_message_unchanged")]
     #[test_case(vec![plan_message(FIRST), plan_message(SECOND)], vec![vec![FIRST, SECOND]] ; "one_mode_rides_together")]
@@ -451,6 +471,16 @@ mod tests {
 
         assert_eq!(messages, [FIRST, SECOND, THIRD]);
         assert!(rx.poll().is_none());
+    }
+
+    #[test]
+    fn poll_carries_compact_guidance() {
+        let (tx, rx) = queue();
+        tx.push(compact(Some(GUIDANCE)));
+
+        assert!(
+            matches!(rx.poll(), Some(ExtractedCommand::Compact(Some(extra))) if extra == GUIDANCE)
+        );
     }
 
     #[test_case(&[FIRST] ; "single_message_stays_alone")]

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -1336,12 +1336,13 @@ impl App {
     fn execute_command(&mut self, cmd: ParsedCommand, depth: u8) -> Vec<Action> {
         match cmd.name.as_str() {
             "/compact" => {
+                let instructions = (!cmd.args.is_empty()).then(|| cmd.args.clone());
                 if self.status == Status::Streaming {
-                    self.queue_compact();
+                    self.queue_compact(instructions);
                     return vec![];
                 }
                 self.status = Status::Streaming;
-                vec![Action::Compact]
+                vec![Action::Compact(instructions)]
             }
             "/help" => {
                 self.help_modal.toggle();

--- a/maki-ui/src/app/queue.rs
+++ b/maki-ui/src/app/queue.rs
@@ -4,7 +4,7 @@ use maki_agent::AgentInput;
 
 use super::{Action, App, Status, format_with_images};
 
-use crate::agent::shared_queue::{QueueItem, QueueSender, QueuedInput};
+use crate::agent::shared_queue::{Compaction, QueueItem, QueueSender, QueuedInput};
 use crate::components::queue_panel::QueueEntry;
 
 pub(crate) use crate::agent::shared_queue::QueuedMessage;
@@ -183,13 +183,14 @@ impl App {
         }
     }
 
-    pub(super) fn queue_compact(&mut self) {
+    pub(super) fn queue_compact(&mut self, instructions: Option<String>) {
         let Some(ref shared) = self.queue.shared else {
             return;
         };
-        shared.push(QueueItem::Compact {
+        shared.push(QueueItem::Compact(Compaction {
             run_id: self.run_id,
-        });
+            instructions,
+        }));
     }
 
     /// Agent reached a deferred message: time to draw the bubble. Restored

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -677,10 +677,15 @@ pub(crate) fn error_app(app: &mut App) {
     }));
 }
 
-fn cmd(name: &str) -> ParsedCommand {
+/// Splits the line the way the palette does, so a test can write what the
+/// user types.
+fn cmd(cmdline: &str) -> ParsedCommand {
+    let (name, args) = cmdline
+        .split_once(char::is_whitespace)
+        .unwrap_or((cmdline, ""));
     ParsedCommand {
         name: name.to_string(),
-        args: String::new(),
+        args: args.trim().to_string(),
         bang: false,
     }
 }
@@ -1546,24 +1551,31 @@ fn overlay_blocks_ctrl_shortcuts(setup: fn(&mut App)) {
     );
 }
 
-#[test]
-fn compact_command_sets_streaming() {
+const COMPACT_GUIDANCE: &str = "keep the failing test names";
+const COMPACT_WITH_GUIDANCE: &str = "/compact keep the failing test names";
+
+#[test_case("/compact", None ; "no_guidance")]
+#[test_case(COMPACT_WITH_GUIDANCE, Some(COMPACT_GUIDANCE) ; "guidance_forwarded")]
+fn compact_command_sets_streaming(cmdline: &str, expected: Option<&str>) {
     let mut app = test_app();
-    let actions = app.execute_command(cmd("/compact"), 0);
-    assert!(matches!(&actions[0], Action::Compact));
+    let actions = app.execute_command(cmd(cmdline), 0);
+    assert!(
+        matches!(&actions[0], Action::Compact(instructions) if instructions.as_deref() == expected)
+    );
     assert_eq!(app.status, Status::Streaming);
 }
 
-#[test]
-fn compact_during_streaming_queues_item() {
+#[test_case("/compact" ; "bare")]
+#[test_case(COMPACT_WITH_GUIDANCE ; "guidance_shown_in_panel")]
+fn compact_during_streaming_queues_item(cmdline: &str) {
     let mut app = test_app();
     app.status = Status::Streaming;
     app.run_id = 1;
 
-    let actions = app.execute_command(cmd("/compact"), 0);
+    let actions = app.execute_command(cmd(cmdline), 0);
     assert!(actions.is_empty());
     assert_eq!(app.queue.len(), 1);
-    assert_eq!(app.queue.panel_entries()[0].text, "/compact");
+    assert_eq!(app.queue.panel_entries()[0].text, cmdline);
 }
 
 #[test]

--- a/maki-ui/src/components/command.rs
+++ b/maki-ui/src/components/command.rs
@@ -29,8 +29,8 @@ pub struct BuiltinCommand {
 pub const BUILTIN_COMMANDS: &[BuiltinCommand] = &[
     BuiltinCommand {
         name: "/compact",
-        description: "Summarize and compact conversation history",
-        max_args: 0,
+        description: "Summarize and compact conversation history (optional guidance)",
+        max_args: usize::MAX,
         bang: false,
     },
     BuiltinCommand {
@@ -145,6 +145,8 @@ pub const BUILTIN_COMMANDS: &[BuiltinCommand] = &[
 
 pub struct ParsedCommand {
     pub name: String,
+    /// Already trimmed, so empty means no args and handlers never re-check
+    /// whitespace.
     pub args: String,
     pub bang: bool,
 }
@@ -748,8 +750,8 @@ mod tests {
         assert_eq!(name, "/cd");
     }
 
-    #[test_case("/compact ", false ; "zero_arg_cmd_with_space")]
     #[test_case("/help ", false     ; "zero_arg_help_with_space")]
+    #[test_case("/compact ", true   ; "compact_stays_active_with_space")]
     #[test_case("/cd ", true        ; "one_arg_cmd_with_space")]
     #[test_case("/cd ~/foo", true   ; "one_arg_cmd_mid_arg")]
     #[test_case("/cd  ~/foo", true  ; "one_arg_cmd_double_space")]
@@ -775,7 +777,7 @@ mod tests {
     #[test_case("/cd", "/cd", ""              ; "no_args")]
     #[test_case("/cd ~/foo", "/cd", "~/foo"   ; "with_args")]
     #[test_case("/CD ~/foo", "/cd", "~/foo"   ; "case_insensitive")]
-    #[test_case("/compact", "/compact", ""    ; "other_command")]
+    #[test_case("/compact ", "/compact", ""   ; "whitespace_only_args_are_empty")]
     #[test_case("/cmp", "/compact", ""    ; "fuzzy-match-1")]
     #[test_case("/cpt", "/compact", ""    ; "fuzzy-match-2")]
     #[test_case("/btw hello world", "/btw", "hello world" ; "btw_multi_word")]

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -202,7 +202,7 @@ pub enum Action {
     UnassignTier(String, ModelTier),
     RefreshModels,
     RefreshUsage,
-    Compact,
+    Compact(Option<String>),
     ToggleMcp(String, bool),
     OpenEditor(PathBuf),
     EditInputInEditor,

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -47,7 +47,7 @@ use tracing::{info, warn};
 use crate::AppSession;
 use crate::agent::{
     AgentCommand, AgentHandles, ModelSlot,
-    shared_queue::{QueueItem, QueuedInput},
+    shared_queue::{Compaction, QueueItem, QueuedInput},
 };
 use crate::app::shell::{ShellEvent, spawn_shell};
 use crate::app::tasks::{TaskStatus, diff_task_states};
@@ -1529,11 +1529,14 @@ impl<'t> EventLoop<'t> {
             Action::UnassignTier(spec, tier) => {
                 maki_providers::model_registry::unset_and_persist(&spec, tier, &self.ctx.storage);
             }
-            Action::Compact => {
+            Action::Compact(instructions) => {
                 let rt = &mut self.sessions[idx];
                 rt.reset_run_notifications();
                 let run_id = rt.app.run_id;
-                rt.handles.queue.push(QueueItem::Compact { run_id });
+                rt.handles.queue.push(QueueItem::Compact(Compaction {
+                    run_id,
+                    instructions,
+                }));
             }
             Action::ToggleMcp(server_name, enabled) => {
                 self.sessions[idx].handles.send_mcp(McpCommand::Toggle {

--- a/site/docs/content/commands/_index.md
+++ b/site/docs/content/commands/_index.md
@@ -13,7 +13,7 @@ Type `/` in the input box to open the command palette.
 
 | Command | Description |
 |---------|-------------|
-| `/compact` | Summarize and compact conversation history |
+| `/compact` | Summarize and compact conversation history (optional guidance) |
 | `/new` | Start a new session |
 | `/help` | Show keybindings |
 | `/usage` | Show token usage breakdown |

--- a/site/docs/content/context/_index.md
+++ b/site/docs/content/context/_index.md
@@ -69,7 +69,7 @@ Rule of thumb: when `AGENTS.md` grows past a screen, the new material probably w
 
 ## When the window fills
 
-Long sessions eventually approach the model's context limit. Maki reserves a slice of the window (`agent.compaction_buffer`, default 20%) and before running out it summarizes the older turns and continues from the summary. `/compact` triggers it early, `/usage` shows where the tokens went, and `agent.compaction_instructions` steers what the summary keeps.
+Long sessions eventually approach the model's context limit. Maki reserves a slice of the window (`agent.compaction_buffer`, default 20%) and before running out it summarizes the older turns and continues from the summary. `/compact` triggers it early, `/compact keep the repro steps` steers that one summary, `/usage` shows where the tokens went, and `agent.compaction_instructions` steers every summary.
 
 Compaction replaces the older turns in the session's on-disk log with the summary. The dropped turns are not lost: before the rewrite, Maki parks the previous log at `sessions/archive/<session-id>/<n>.jsonl` in the [state directory](/docs/configuration/#directory-layout). It keeps the newest three per session, and at most 32 MB of them. The names count up, so the highest number is the newest.
 


### PR DESCRIPTION
`agent.compaction_instructions` steers every summary, but a session often needs guidance only once, like keeping the repro steps of the bug you are chasing.

`/compact` now takes free text and carries it down to the summariser, where it lands under "Additional instructions" next to the config ones, so both apply and neither replaces the other.

The text rides along the whole path, `Action::Compact` to the queue item to `ExtractedCommand::Compact`, so a `/compact keep the failing test names` typed while the agent is busy still arrives with its guidance when the run picks it up.

Auto-compaction passes `None` and behaves exactly as before.

Closes #912.