### PR TITLE
fix(ui): copy only the rows the selection covers

### DIFF
--- a/maki-ui/src/components/messages/segment.rs
+++ b/maki-ui/src/components/messages/segment.rs
@@ -6,6 +6,7 @@ use super::super::code_view::SectionFlags;
 use super::super::tool_display::{HighlightRequest, ToolLines};
 use ratatui::text::{Line, Span};
 use std::cell::Cell;
+use std::ops::Range;
 
 const INST_SUFFIX: &str = "__inst";
 
@@ -133,14 +134,19 @@ impl Segment {
 
     /// Maps a display row (after wrapping) back to the source line index.
     pub fn source_line_at(&self, rel_row: u16, width: u16) -> Option<usize> {
-        let mut acc = 0u16;
-        for (i, line) in self.lines.iter().enumerate() {
-            acc = acc.saturating_add(wrap::line_rows(line, width));
-            if rel_row < acc {
-                return Some(i);
-            }
-        }
-        None
+        self.rows_from(rel_row, width).line()
+    }
+
+    /// A cursor parked on the source line that covers display row `start_row`.
+    pub fn rows_from(&self, start_row: u16, width: u16) -> RowWalk<'_> {
+        let mut walk = RowWalk {
+            lines: &self.lines,
+            measure: wrap::Measure::new(width),
+            next_line: 0,
+            row: 0,
+        };
+        walk.seek(start_row);
+        walk
     }
 
     /// Maps a source line to a 1-based row in the tool's live buffer, or 0
@@ -260,6 +266,57 @@ impl Segment {
         }
         if let Some(base) = &mut self.snapshot_base {
             shift(base);
+        }
+    }
+}
+
+/// Cursor over a segment's display rows. It only moves forward and measures
+/// each source line once, so re-rendering a tall segment in pieces costs one
+/// measure of it, not one per piece.
+pub struct RowWalk<'a> {
+    lines: &'a [Line<'static>],
+    measure: wrap::Measure,
+    next_line: usize,
+    /// Display row the line at `next_line` starts on.
+    row: u16,
+}
+
+impl<'a> RowWalk<'a> {
+    /// The source line the cursor sits on, or `None` past the last row.
+    pub fn line(&self) -> Option<usize> {
+        (self.next_line < self.lines.len()).then_some(self.next_line)
+    }
+
+    /// The next source lines, covering `max_rows` display rows or the single
+    /// line that overshoots them, and the rows they cover. Wrapping is per
+    /// source line, so drawing this slice at `rows.start` draws exactly what
+    /// the whole segment would draw there.
+    ///
+    /// While a line is left one is always taken, so a loop over this moves and
+    /// ends even at `max_rows` of zero.
+    pub fn next_chunk(&mut self, max_rows: u16) -> Option<(&'a [Line<'static>], Range<u16>)> {
+        let (start, top) = (self.next_line, self.row);
+        while let Some(line) = self.lines.get(self.next_line) {
+            self.next_line += 1;
+            self.row = self.row.saturating_add(self.measure.rows(line));
+            // Rows are u16 everywhere above this, so nothing past the
+            // saturation point can be addressed, selected or copied anyway.
+            if self.row == u16::MAX || self.row - top >= max_rows {
+                break;
+            }
+        }
+        (self.next_line > start).then(|| (&self.lines[start..self.next_line], top..self.row))
+    }
+
+    /// Backs up to the start of the line covering `target`, or off the end.
+    fn seek(&mut self, target: u16) {
+        while let Some(line) = self.lines.get(self.next_line) {
+            let end = self.row.saturating_add(self.measure.rows(line));
+            if end > target {
+                break;
+            }
+            self.next_line += 1;
+            self.row = end;
         }
     }
 }

--- a/maki-ui/src/components/messages/selection.rs
+++ b/maki-ui/src/components/messages/selection.rs
@@ -5,6 +5,11 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::widgets::{Paragraph, Widget, Wrap};
 
+/// Rows re-rendered per pass of the copy path. A `Cell` is 40 bytes, so at a
+/// usual terminal width this holds the scratch buffer near a megabyte however
+/// tall the selected segment is.
+const COPY_CHUNK_ROWS: u16 = 256;
+
 /// Copies the segments the selection spans. The streaming tail lives past the
 /// cache, so text still arriving is not copyable.
 pub(super) fn extract_selection_text(
@@ -27,25 +32,23 @@ pub(super) fn extract_selection_text(
 
         // The rows we copy come from this wrap at the real width, so clamp
         // against it: a reflow can shrink a segment under a stored row.
-        let rows = seg.height(width);
-        let tmp_area = Rect::new(0, 0, width, rows);
-        let mut tmp = Buffer::empty(tmp_area);
-        Paragraph::new(seg.lines().to_vec())
-            .wrap(Wrap { trim: false })
-            .render(tmp_area, &mut tmp);
+        let seg_rows = seg.height(width);
 
         let (rel_start, start_col) = if i == start.seg {
-            (start.row.min(rows), start.col.saturating_sub(msg_area.x))
+            (
+                start.row.min(seg_rows),
+                start.col.saturating_sub(msg_area.x),
+            )
         } else {
             (0, 0)
         };
         let (rel_end, end_col) = if i == end.seg {
             (
-                end.row.saturating_add(1).min(rows),
+                end.row.saturating_add(1).min(seg_rows),
                 end.col.saturating_sub(msg_area.x),
             )
         } else {
-            (rows, width.saturating_sub(1))
+            (seg_rows, width.saturating_sub(1))
         };
 
         let ss = ScreenSelection {
@@ -55,8 +58,116 @@ pub(super) fn extract_selection_text(
             end_col,
         };
 
-        let breaks = LineBreaks::from_lines(seg.lines(), width);
-        selection::append_rows(&tmp, tmp_area, &ss, rel_start, rel_end, &mut out, &breaks);
+        // Only the selected rows are re-rendered, a chunk at a time. The
+        // cursor measures the segment once for all the chunks it hands out.
+        let mut carry = selection::RowCarry::default();
+        let mut walk = seg.rows_from(rel_start, width);
+        while let Some((lines, chunk)) = walk.next_chunk(COPY_CHUNK_ROWS) {
+            if chunk.start >= rel_end {
+                break;
+            }
+            // The buffer sits at the rows it draws, so `ss` keeps talking in
+            // segment rows across every chunk.
+            let area = Rect::new(0, chunk.start, width, chunk.end - chunk.start);
+            // A double width grapheme landing on the last column makes ratatui
+            // write one past the area it wrapped to, so the scratch buffer
+            // holds a spare column for that write. `area` keeps the real width,
+            // which is what decides the wrap and the columns copied.
+            let mut tmp = Buffer::empty(Rect {
+                width: width.saturating_add(1),
+                ..area
+            });
+            Paragraph::new(lines.to_vec())
+                .wrap(Wrap { trim: false })
+                .render(area, &mut tmp);
+
+            // The chunk runs to a line boundary, so it can reach past the
+            // selection on either side. `append_rows` clips to the rows this
+            // buffer actually holds.
+            selection::append_rows(
+                &tmp,
+                area,
+                &ss,
+                rel_start..rel_end,
+                &mut out,
+                &LineBreaks::from_lines(lines, width),
+                &mut carry,
+            );
+        }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::segment::Segment;
+    use super::{COPY_CHUNK_ROWS, SegmentCache, extract_selection_text};
+    use crate::selection::{DocPos, Selection, SelectionZone};
+    use ratatui::layout::Rect;
+    use ratatui::text::Line;
+
+    /// What dragging the mouse over one whole segment copies.
+    fn copy_whole_segment(lines: Vec<Line<'static>>, width: u16) -> String {
+        let area = Rect::new(0, 0, width, 24);
+        let mut cache = SegmentCache::new();
+        cache.push(Segment::with_lines(lines, String::new(), None));
+        let last_row = cache
+            .get(0)
+            .expect("segment")
+            .height(width)
+            .saturating_sub(1);
+
+        let corner = DocPos {
+            seg: 0,
+            row: 0,
+            col: 0,
+        };
+        let mut sel = Selection::start(corner, area, SelectionZone::Messages);
+        sel.update(DocPos {
+            seg: 0,
+            row: last_row,
+            col: width,
+        });
+        extract_selection_text(&cache, width, &sel, area)
+    }
+
+    /// A stale segment can hold a line far wider than the terminal now is, and
+    /// at two columns ratatui writes a double width grapheme one cell past the
+    /// area it wrapped to. The scrape used to hand that write a buffer exactly
+    /// as wide as the area, so releasing the mouse took the whole UI down.
+    ///
+    /// The last grapheme is the one ratatui shoved over the edge, so it is off
+    /// screen and copying it back would not match what the user sees.
+    #[test]
+    fn copying_into_two_columns_gives_back_what_is_on_screen() {
+        assert_eq!(
+            copy_whole_segment(vec![Line::from("a\u{4f60}\u{597d}")], 2),
+            "a\u{4f60}"
+        );
+    }
+
+    /// Blank rows are held back until content follows them, and the first row
+    /// copied never gets a newline in front. Both live in state that only
+    /// survives if it is carried across a chunk boundary, and with this many
+    /// lead lines the boundary falls right between the two blanks.
+    #[test]
+    fn blank_rows_survive_a_chunk_boundary() {
+        const WIDTH: u16 = 40;
+        const LEAD: usize = COPY_CHUNK_ROWS as usize - 1;
+
+        let mut lines: Vec<Line<'static>> =
+            (0..LEAD).map(|i| Line::from(format!("l{i}"))).collect();
+        lines.push(Line::default());
+        lines.push(Line::default());
+        lines.push(Line::from("tail"));
+
+        let body = (0..LEAD)
+            .map(|i| format!("l{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(
+            copy_whole_segment(lines, WIDTH),
+            format!("{body}\n\n\ntail")
+        );
+    }
 }

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -10,6 +10,7 @@ use maki_agent::{
 };
 use ratatui::backend::TestBackend;
 use std::collections::HashSet;
+use std::ops::Range;
 use std::time::Duration;
 use test_case::test_case;
 
@@ -2125,6 +2126,64 @@ fn height_measures_the_width_asked_for_even_while_stale() {
         2,
         "a stale segment must report what its lines really draw as"
     );
+}
+
+const ROW_WALK_WIDTH: u16 = 10;
+
+/// Rows at width 10: `a` on 0, `bbb...` on 1-3, `c` on 4, `ddd...` on 5-6.
+fn wrapped_segment() -> Segment {
+    let seg = Segment::with_lines(
+        vec![
+            Line::from("a"),
+            Line::from("b".repeat(25)),
+            Line::from("c"),
+            Line::from("d".repeat(15)),
+        ],
+        "test".into(),
+        None,
+    );
+    assert_eq!(seg.height(ROW_WALK_WIDTH), 7, "fixture must wrap as above");
+    seg
+}
+
+/// The copy path draws a chunk at the row the cursor reports, so a seek landing
+/// in the middle of a wrapped line has to back up to that line's first row. Off
+/// by one there and the whole chunk lands on the wrong rows.
+#[test_case(0 => Some((0, 0..1)) ; "row_of_its_own")]
+#[test_case(1 => Some((1, 1..4)) ; "first_row_of_a_wrapped_line")]
+#[test_case(3 => Some((1, 1..4)) ; "last_row_backs_up_to_the_line_start")]
+#[test_case(7 => None ; "past_the_last_row")]
+fn row_walk_seeks_to_the_line_covering_a_row(row: u16) -> Option<(usize, Range<u16>)> {
+    let seg = wrapped_segment();
+    let mut walk = seg.rows_from(row, ROW_WALK_WIDTH);
+    let line = walk.line()?;
+    Some((line, walk.next_chunk(1)?.1))
+}
+
+/// Chunking is only invisible to the copy path if the pieces tile the segment:
+/// contiguous rows, each source line in exactly one piece, every row down to
+/// the last covered. No row budget may change that, not even one too small to
+/// fit the tallest line.
+#[test_case(1 ; "one_row_at_a_time")]
+#[test_case(2 ; "budget_shorter_than_the_tallest_line")]
+#[test_case(7 ; "budget_taller_than_the_segment")]
+fn row_walk_tiles_the_segment(max_rows: u16) {
+    let seg = wrapped_segment();
+    let mut walk = seg.rows_from(0, ROW_WALK_WIDTH);
+    let mut covered = 0..0;
+    let mut lines = 0;
+    while let Some((chunk, rows)) = walk.next_chunk(max_rows) {
+        assert_eq!(rows.start, covered.end, "chunks must be contiguous");
+        assert_eq!(
+            wrap::total_rows(chunk, ROW_WALK_WIDTH),
+            rows.end - rows.start,
+            "a chunk must report the rows its lines really draw as"
+        );
+        lines += chunk.len();
+        covered = rows;
+    }
+    assert_eq!(covered.end, seg.height(ROW_WALK_WIDTH), "every row covered");
+    assert_eq!(lines, seg.lines().len(), "every line covered once");
 }
 
 /// The copy path sizes its buffer from `height` and then re-wraps the lines

--- a/maki-ui/src/selection.rs
+++ b/maki-ui/src/selection.rs
@@ -28,6 +28,7 @@
 //! swallowed space, then `append_rows` calls `needs_space()`.
 
 use std::cmp::Ordering;
+use std::ops::Range;
 use std::time::Instant;
 
 use ratatui::buffer::Buffer;
@@ -356,18 +357,21 @@ impl LineBreaks {
         let mut word_wraps = Vec::new();
         let mut row: u16 = 0;
         for line in lines {
-            if is_code_wrap_continuation(line) {
-                row += 1;
-                continue;
+            // Continuation rows belong to the line above, so they set no bits
+            // of their own. They are still walked at their real height: a stale
+            // segment holds code wrapped for a wider terminal, and counting one
+            // row each slides every later bit off its row.
+            let starts_line = !is_code_wrap_continuation(line);
+            if starts_line {
+                set_bit(&mut line_starts, row);
             }
-            set_bit(&mut line_starts, row);
             wrap::breaks(line, width, |kind| {
-                row += 1;
-                if kind == Break::Word {
+                row = row.saturating_add(1);
+                if starts_line && kind == Break::Word {
                     set_bit(&mut word_wraps, row);
                 }
             });
-            row += 1;
+            row = row.saturating_add(1);
         }
         Self::Bitmap {
             line_starts,
@@ -492,16 +496,26 @@ pub(crate) fn strip_code_bar_prefix(
     prefix_len
 }
 
+/// What [`append_rows`] hands to itself when one block of text is copied in
+/// several passes: whether anything was emitted yet, so a later pass does not
+/// mistake its first row for the start of the text, and the blank lines still
+/// held back in case content follows.
+#[derive(Default)]
+pub(crate) struct RowCarry {
+    started: bool,
+    pending_newlines: u16,
+}
+
 /// Trailing whitespace is trimmed per line. Consecutive blank lines are
 /// collapsed so we don't emit a wall of empty newlines.
 pub(crate) fn append_rows(
     buf: &Buffer,
     area: Rect,
     ss: &ScreenSelection,
-    from: u16,
-    to: u16,
+    rows: Range<u16>,
     out: &mut String,
     breaks: &LineBreaks,
+    carry: &mut RowCarry,
 ) {
     let top = area.y;
     let area = clip(buf, area);
@@ -509,10 +523,8 @@ pub(crate) fn append_rows(
         return;
     }
     let right = area.right().saturating_sub(1);
-    let row_start = from.max(area.y);
-    let row_end = to.min(area.bottom());
-    let mut pending_newlines = 0u16;
-    let anchor = out.len();
+    let row_start = rows.start.max(area.y);
+    let row_end = rows.end.min(area.bottom());
     for row in row_start..row_end {
         let rel_row = row - top;
         let is_new_line = breaks.is_line_start(rel_row);
@@ -547,16 +559,17 @@ pub(crate) fn append_rows(
         let trimmed_len = out[line_start..].trim_end().len() + line_start;
         out.truncate(trimmed_len);
         let has_content = out.len() > line_start;
-        let is_first_row = line_start == anchor;
+        let is_first_row = !carry.started;
+        carry.started |= has_content;
 
         if is_new_line {
             if !has_content && !is_first_row {
-                pending_newlines += 1;
+                carry.pending_newlines += 1;
             } else if !is_first_row {
-                for _ in 0..pending_newlines {
+                for _ in 0..carry.pending_newlines {
                     out.insert(line_start, '\n');
                 }
-                pending_newlines = 0;
+                carry.pending_newlines = 0;
                 out.insert(line_start, '\n');
             }
         } else if has_content && !is_first_row && stripped == 0 && breaks.needs_space(rel_row) {
@@ -599,10 +612,10 @@ pub fn extract_selected_text(
                 buf,
                 region.area,
                 ss,
-                row,
-                chunk_end,
+                row..chunk_end,
                 &mut out,
                 &region.line_breaks,
+                &mut RowCarry::default(),
             );
         }
         row = region_end;
@@ -614,6 +627,7 @@ pub fn extract_selected_text(
 mod tests {
     use super::*;
     use ratatui::style::Style;
+    use ratatui::text::Span;
     use test_case::test_case;
 
     fn doc(row: u16, col: u16) -> DocPos {
@@ -1092,17 +1106,24 @@ mod tests {
         assert!(lb.needs_space(1), "word-boundary continuation needs space");
     }
 
-    #[test]
-    fn from_lines_code_wrap_continuation_skipped() {
-        let wrap_line = Line::from(vec![ratatui::text::Span::raw(CODE_BAR_WRAP)]);
-        let lines = vec![Line::from("first"), wrap_line, Line::from("second")];
-        let lb = LineBreaks::from_lines(&lines, 80);
-        assert!(lb.is_line_start(0));
-        assert!(
-            !lb.is_line_start(1),
-            "code wrap continuation is not a line start"
-        );
-        assert!(lb.is_line_start(2));
+    /// A code block wrapped for a wider terminal leaves continuation rows
+    /// behind. They belong to the line above, so they start no line of their
+    /// own, but they still have to be walked at their real height: assume one
+    /// row each and every later start bit slides off its row, which splices
+    /// newlines into the middle of copied prose.
+    #[test_case("" => vec![0, 2] ; "continuation_fits_one_row")]
+    #[test_case("abcdefghij" => vec![0, 3] ; "continuation_wraps_again")]
+    fn from_lines_skips_every_row_a_code_continuation_takes(tail: &str) -> Vec<u16> {
+        const WIDTH: u16 = 6;
+        let lines = vec![
+            Line::from("first"),
+            Line::from(vec![Span::raw(CODE_BAR_WRAP), Span::raw(tail)]),
+            Line::from("second"),
+        ];
+        let lb = LineBreaks::from_lines(&lines, WIDTH);
+        (0..wrap::total_rows(&lines, WIDTH))
+            .filter(|&row| lb.is_line_start(row))
+            .collect()
     }
 
     #[test]
@@ -1139,7 +1160,15 @@ mod tests {
     ) {
         let buf = Buffer::empty(buf_area);
         let mut out = String::new();
-        append_rows(&buf, area, &sel, from, to, &mut out, &LineBreaks::EveryRow);
+        append_rows(
+            &buf,
+            area,
+            &sel,
+            from..to,
+            &mut out,
+            &LineBreaks::EveryRow,
+            &mut RowCarry::default(),
+        );
         assert!(out.is_empty());
     }
 
@@ -1163,7 +1192,6 @@ mod tests {
         assert!(!lb.is_line_start(5));
         assert!(lb.needs_space(5));
     }
-
     #[test]
     fn wrap_extract_two_lines_first_wraps_second_doesnt() {
         use ratatui::widgets::{Paragraph, Widget, Wrap};
@@ -1200,10 +1228,10 @@ mod tests {
             &buf,
             area,
             &ss(0, 1, 0, 3),
-            0,
-            1,
+            0..1,
             &mut out,
             &LineBreaks::EveryRow,
+            &mut RowCarry::default(),
         );
         assert_eq!(out, "好");
     }

--- a/maki-ui/src/wrap.rs
+++ b/maki-ui/src/wrap.rs
@@ -7,7 +7,6 @@
 //! pending whitespace widths, the only scratch we keep.
 
 use std::mem;
-use std::slice;
 
 use ratatui::buffer::CellWidth;
 use ratatui::style::Style;
@@ -26,21 +25,36 @@ pub(crate) enum Break {
 ///
 /// Public so `benches/wrap.rs` can race it against `Paragraph::line_count`.
 pub fn total_rows(lines: &[Line<'_>], width: u16) -> u16 {
-    if width == 0 {
-        return lines.len() as u16;
+    let mut measure = Measure::new(width);
+    lines
+        .iter()
+        .fold(0, |rows, line| rows.saturating_add(measure.rows(line)))
+}
+
+/// Measures one line at a time, keeping the scan machine between them, so a
+/// caller that walks a segment in pieces pays for measuring it once instead of
+/// once per piece.
+pub(crate) struct Measure {
+    /// Absent at zero width, where every line counts as one row.
+    scan: Option<Scan>,
+}
+
+impl Measure {
+    pub(crate) fn new(width: u16) -> Self {
+        Self {
+            scan: (width > 0).then(|| Scan::new(u32::from(width))),
+        }
     }
-    let mut scan = Scan::new(u32::from(width));
-    lines.iter().fold(0, |rows, line| {
-        rows.saturating_add(scan.run(line, &mut |_| {}))
-    })
+
+    pub(crate) fn rows(&mut self, line: &Line<'_>) -> u16 {
+        self.scan
+            .as_mut()
+            .map_or(1, |scan| scan.run(line, &mut |_| {}))
+    }
 }
 
-pub(crate) fn line_rows(line: &Line<'_>, width: u16) -> u16 {
-    total_rows(slice::from_ref(line), width)
-}
-
-/// Calls `on_break` once per row boundary inside `line`, so exactly
-/// `line_rows(line, width) - 1` times.
+/// Calls `on_break` once per row boundary inside `line`, so exactly one less
+/// than the rows the line draws as.
 ///
 /// The scan reports one break too many when a row ends on whitespace the
 /// renderer swallows: that break closes the line instead of opening a row, so a
@@ -210,7 +224,7 @@ impl Scan {
 
 #[cfg(test)]
 mod tests {
-    use super::{Break, breaks, line_rows, total_rows};
+    use super::{Break, breaks, total_rows};
     use ratatui::text::{Line, Span};
     use ratatui::widgets::{Paragraph, Wrap};
     use std::slice;
@@ -269,7 +283,7 @@ mod tests {
         let lines = corpus_lines();
         for width in (1..=40).chain([80, 200]) {
             for line in &lines {
-                let rows = line_rows(line, width);
+                let rows = total_rows(slice::from_ref(line), width);
                 assert_eq!(
                     rows,
                     ratatui_rows(slice::from_ref(line), width),


### PR DESCRIPTION
Releasing the mouse could hang the UI for seconds, because the copy path re-rendered every segment it touched in full, even when two rows were selected: a `Cell` is 40 bytes, so one expanded tool output of 60k rows cost 826ms and about 290MB.

`Segment::rows_from` now walks the display rows forward and hands the copy path one chunk of source lines at a time, and the temp buffer starts at the chunk's display row so `append_rows` keeps lining up with a `LineBreaks` built from the same lines.

Wrapping is per source line, so a chunk cut on a line boundary draws exactly what the whole segment would have drawn there, and `RowCarry` carries the blank lines held back at the cut.

It has to be a forward cursor: a lines-for-rows lookup re-measures every line behind it, which on a 60k row segment adds up to more than the full render it replaced.

Same 60k rows: 26ms for two of them, 750ms for all.