### PR TITLE
Fix for missing global AGENTS.md when ~/.maki exists

### DIFF
--- a/maki-agent/src/agent/instructions.rs
+++ b/maki-agent/src/agent/instructions.rs
@@ -23,6 +23,7 @@ const INSTRUCTION_FILES: &[&str] = &[
 ];
 
 const LOCAL_INSTRUCTION_FILE: &str = "AGENTS.local.md";
+const GLOBAL_INSTRUCTION_FILE: &str = "AGENTS.md";
 
 #[derive(Clone, Default)]
 pub struct LoadedInstructions(Arc<Mutex<HashSet<PathBuf>>>);
@@ -120,7 +121,8 @@ fn collect_instruction_files(
         }
     }
 
-    for path in maki_storage::paths::user_config_dirs(home, xdg_config, "AGENTS.md") {
+    for dir in maki_storage::paths::config_search_dirs_from(home, xdg_config) {
+        let path = dir.join(GLOBAL_INSTRUCTION_FILE);
         if let Some((canonical, content)) = read_instruction(&path, loaded) {
             let label = format!("Global instructions ({})", canonical.display());
             out.push((label, content));
@@ -135,7 +137,7 @@ pub fn load_instruction_text(cwd: &str) -> String {
     load_instruction_text_with_home(
         cwd,
         maki_storage::paths::home().as_deref(),
-        maki_storage::paths::config_dir().ok().as_deref(),
+        maki_storage::paths::xdg_config_dir().ok().as_deref(),
     )
 }
 
@@ -158,7 +160,7 @@ pub fn load_instructions(cwd: &str) -> Instructions {
     load_instructions_with_home(
         cwd,
         maki_storage::paths::home().as_deref(),
-        maki_storage::paths::config_dir().ok().as_deref(),
+        maki_storage::paths::xdg_config_dir().ok().as_deref(),
     )
 }
 
@@ -220,6 +222,8 @@ mod tests {
     use super::*;
 
     const PLAN_PATH: &str = ".maki/plans/123.md";
+    const LEGACY_RULES: &str = "legacy global rules";
+    const XDG_RULES: &str = "xdg global rules";
 
     #[test_case(&AgentMode::Build, false ; "build_excludes_plan")]
     #[test_case(&AgentMode::Plan(PathBuf::from(PLAN_PATH)), true ; "plan_includes_plan")]
@@ -331,6 +335,29 @@ mod tests {
         let text =
             load_instructions_with_home(cwd.path().to_str().unwrap(), Some(home.path()), None).text;
         assert!(text.contains("global rules"));
+    }
+
+    #[test_case(false, XDG_RULES, LEGACY_RULES ; "xdg_is_searched_even_though_legacy_dir_exists")]
+    #[test_case(true, LEGACY_RULES, XDG_RULES ; "legacy_wins_when_both_have_a_file")]
+    fn load_instructions_global_search_order(write_legacy: bool, wanted: &str, unwanted: &str) {
+        let cwd = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let xdg = tempfile::tempdir().unwrap();
+        let legacy = home.path().join(".maki");
+        fs::create_dir(&legacy).unwrap();
+        if write_legacy {
+            fs::write(legacy.join(GLOBAL_INSTRUCTION_FILE), LEGACY_RULES).unwrap();
+        }
+        fs::write(xdg.path().join(GLOBAL_INSTRUCTION_FILE), XDG_RULES).unwrap();
+
+        let text = load_instructions_with_home(
+            cwd.path().to_str().unwrap(),
+            Some(home.path()),
+            Some(xdg.path()),
+        )
+        .text;
+        assert!(text.contains(wanted), "got {text}");
+        assert!(!text.contains(unwanted), "got {text}");
     }
 
     #[test]

--- a/maki-agent/src/command.rs
+++ b/maki-agent/src/command.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 use tracing::{debug, warn};
 
+const COMMANDS_DIR: &str = "commands";
 const PROJECT_COMMAND_DIRS: &[&str] = &[".maki/commands", ".claude/commands"];
 const GLOBAL_THIRD_PARTY_COMMAND_DIRS: &[&str] = &[".claude/commands"];
 const ARGUMENTS_PLACEHOLDER: &str = "$ARGUMENTS";
@@ -84,7 +85,7 @@ pub fn discover_commands(cwd: &Path) -> Vec<CustomCommand> {
     discover_commands_inner(
         cwd,
         maki_storage::paths::home().as_deref(),
-        maki_storage::paths::config_dir().ok().as_deref(),
+        maki_storage::paths::xdg_config_dir().ok().as_deref(),
     )
 }
 
@@ -95,8 +96,8 @@ fn discover_commands_inner(
 ) -> Vec<CustomCommand> {
     let mut commands: HashMap<String, CustomCommand> = HashMap::new();
 
-    for dir in maki_storage::paths::user_config_dirs(home, xdg_config, "commands") {
-        scan_command_dir(&dir, CommandScope::User, &mut commands);
+    for dir in maki_storage::paths::config_search_dirs_from(home, xdg_config) {
+        scan_command_dir(&dir.join(COMMANDS_DIR), CommandScope::User, &mut commands);
     }
     if let Some(home) = home {
         for dir in GLOBAL_THIRD_PARTY_COMMAND_DIRS {

--- a/maki-agent/src/mcp/config.rs
+++ b/maki-agent/src/mcp/config.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use super::error::McpError;
 use crate::tools::is_builtin_tool;
-use maki_config::{expand_env, global_config_dir, is_valid_server_name};
+use maki_config::{expand_env, is_valid_server_name};
 use serde::Deserialize;
 use toml_edit::DocumentMut;
 
@@ -368,8 +368,7 @@ pub fn load_config(cwd: &Path) -> (McpConfig, McpConfigErrors) {
     let mut merged = McpConfig::default();
     let mut errors = McpConfigErrors::new(cwd.to_path_buf());
 
-    if let Some(global_dir) = global_config_dir() {
-        let global_path = global_dir.join(MCP_CONFIG_FILE);
+    if let Some(global_path) = maki_storage::paths::find_config_path(MCP_CONFIG_FILE) {
         merge_config(&mut merged, &mut errors, &global_path);
     }
     let project_path = cwd.join(".maki").join(MCP_CONFIG_FILE);

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -15,6 +15,7 @@ use tracing::warn;
 
 const PROJECT_DIR: &str = ".maki";
 const PERMISSIONS_FILE: &str = "permissions.toml";
+const ENV_FILE: &str = ".env";
 
 pub mod providers;
 
@@ -2005,29 +2006,16 @@ fn build_permissions(
     }
 }
 
-fn global_dir() -> Option<PathBuf> {
-    paths::config_dir().ok()
+pub fn load_env_files(cwd: &Path) {
+    load_env_files_with_global(cwd, paths::find_config_path(ENV_FILE).as_deref());
 }
 
-fn config_search_dirs(global: Option<&Path>) -> Vec<PathBuf> {
-    let mut dirs = Vec::new();
-    if let Some(d) = global {
-        dirs.push(d.to_path_buf());
-    }
-    if let Ok(xdg) = paths::xdg_config_dir()
-        && dirs.first() != Some(&xdg)
-    {
-        dirs.push(xdg);
-    }
-    dirs
-}
-
-fn load_env_files_with_global(cwd: &Path, global: Option<&Path>) {
+fn load_env_files_with_global(cwd: &Path, global_env: Option<&Path>) {
     let mut vars = HashMap::new();
-    if let Some(path) = global {
-        collect_env_vars(&path.join(".env"), &mut vars);
+    if let Some(path) = global_env {
+        collect_env_vars(path, &mut vars);
     }
-    collect_env_vars(&cwd.join(PROJECT_DIR).join(".env"), &mut vars);
+    collect_env_vars(&cwd.join(PROJECT_DIR).join(ENV_FILE), &mut vars);
 
     for (key, value) in vars {
         if std::env::var_os(&key).is_none() {
@@ -2046,13 +2034,8 @@ fn collect_env_vars(path: &Path, vars: &mut HashMap<String, String>) {
     }
 }
 
-pub fn load_env_files(cwd: &Path) {
-    load_env_files_with_global(cwd, global_dir().as_deref());
-}
-
 pub fn load_permissions(cwd: &Path) -> PermissionsConfig {
-    let global_dirs = config_search_dirs(global_dir().as_deref());
-    load_permissions_inner(cwd, &global_dirs)
+    load_permissions_inner(cwd, &paths::config_search_dirs())
 }
 
 fn load_permissions_inner(cwd: &Path, global_dirs: &[PathBuf]) -> PermissionsConfig {
@@ -2237,11 +2220,7 @@ fn read_permissions_file(path: &Path) -> Option<PermissionsFileConfig> {
 }
 
 pub fn global_config_dir() -> Option<PathBuf> {
-    global_dir()
-}
-
-pub fn global_config_dirs() -> Vec<PathBuf> {
-    config_search_dirs(global_dir().as_deref())
+    paths::config_dir().ok()
 }
 
 pub fn append_permission_rule(
@@ -2250,9 +2229,7 @@ pub fn append_permission_rule(
     effect: Effect,
     target: &PermissionTarget,
 ) -> Result<(), String> {
-    let dir = config_search_dirs(global_dir().as_deref())
-        .into_iter()
-        .last();
+    let dir = paths::config_search_dirs().into_iter().last();
     append_permission_rule_with_global(tool, scope, effect, target, dir)
 }
 
@@ -3048,7 +3025,7 @@ mod tests {
             std::env::set_var(PROCESS_WINS, "process");
         }
 
-        load_env_files_with_global(dir.path(), Some(&global));
+        load_env_files_with_global(dir.path(), Some(&global.join(ENV_FILE)));
 
         assert_eq!(std::env::var(GLOBAL_ONLY).unwrap(), "global");
         assert_eq!(std::env::var(PROJECT_SHADOWS).unwrap(), "project");

--- a/maki-config/src/providers.rs
+++ b/maki-config/src/providers.rs
@@ -271,10 +271,14 @@ impl ProvidersConfig {
     }
 }
 
+/// The `providers.toml` we already read, or where a fresh one goes. Both share
+/// this path so `save` cannot leave a second copy behind in the other dir.
 fn providers_file_path() -> PathBuf {
-    paths::config_dir()
-        .unwrap_or_else(|_| PathBuf::from("."))
-        .join(PROVIDERS_FILE)
+    paths::find_config_path(PROVIDERS_FILE).unwrap_or_else(|| {
+        paths::config_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(PROVIDERS_FILE)
+    })
 }
 
 pub fn builtin_provider(slug: &str) -> Option<&'static BuiltInProvider> {

--- a/maki-lua/src/docs_render.rs
+++ b/maki-lua/src/docs_render.rs
@@ -90,7 +90,7 @@ reference is at the end of this document.
 Plugins live in the maki config dir. There are two of them, same layout:
 
 - `~/.config/maki/` - global, every project (if `~/.maki/` exists, maki reads
-  that one instead)
+  that one first)
 - `<project>/.maki/` - this project only
 
 ```

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -302,7 +302,7 @@ impl PluginHost {
     ) -> Result<Option<RawConfig>, PluginError> {
         let mut merged: Option<RawConfig> = None;
 
-        for global_dir in maki_config::global_config_dirs() {
+        for global_dir in maki_storage::paths::config_search_dirs() {
             self.run_init_file(
                 &global_dir.join("init.lua"),
                 ConfigScope::Global,

--- a/maki-lua/src/pack.rs
+++ b/maki-lua/src/pack.rs
@@ -92,14 +92,14 @@ pub struct DiscoveredPackage {
 
 /// `pack-lock.json`, beside the user's configuration so it can be committed.
 ///
-/// `global_config_dirs` returns several candidates in the order `init.lua` is
-/// searched for, so the first that exists is the one whose `maki.pack.add`
-/// declared these packages, and a custom config directory keeps its lockfile
-/// rather than leaving it behind in XDG. With none of them created yet there is
-/// nothing to sit beside, and the last candidate is the one
-/// `append_permission_rule` already treats as writable.
+/// `config_search_dirs` returns candidates in the order `init.lua` is searched
+/// for, so the first that exists is the one whose `maki.pack.add` declared
+/// these packages, and a custom config directory keeps its lockfile rather than
+/// leaving it behind in XDG. With none of them created yet there is nothing to
+/// sit beside, and the last candidate is the one `append_permission_rule`
+/// already treats as writable.
 pub fn lockfile_path() -> Option<PathBuf> {
-    let dirs = maki_config::global_config_dirs();
+    let dirs = maki_storage::paths::config_search_dirs();
     dirs.iter()
         .find(|dir| dir.is_dir())
         .cloned()

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -145,9 +145,7 @@ fn builtin_slugs() -> Vec<String> {
 }
 
 fn providers_dir() -> Option<PathBuf> {
-    maki_storage::paths::config_dir()
-        .ok()
-        .map(|d| d.join(PROVIDERS_DIR))
+    maki_storage::paths::find_config_path(PROVIDERS_DIR)
 }
 
 fn run_script(path: &Path, subcommand: &str, timeout: Duration) -> Result<String, AgentError> {

--- a/maki-storage/src/paths.rs
+++ b/maki-storage/src/paths.rs
@@ -291,18 +291,30 @@ pub fn legacy_home_dir() -> Option<PathBuf> {
         .filter(|d| d.is_dir())
 }
 
-/// Candidate config directories for `subdir` from `home` and `xdg_config`.
-/// Pure: no env reads, no process-home fallback. Production callers pass
-/// `config_dir().ok()` as `xdg_config` (which honors `XDG_CONFIG_HOME`, the
-/// `~/.maki` fallback, and the Windows `AppData\Roaming` strategy via
-/// `resolve()`); tests pass tempdirs.
-pub fn user_config_dirs(
-    home: Option<&Path>,
-    xdg_config: Option<&Path>,
-    subdir: &str,
-) -> Vec<PathBuf> {
-    let legacy = home.map(|h| h.join(FALLBACK_DIR).join(subdir));
-    let xdg = xdg_config.map(|d| d.join(subdir));
+/// Where to look for user config, best match first. Writes still go to
+/// `config_dir()`.
+///
+/// The two are not the same: `config_dir()` collapses to `~/.maki` the moment
+/// that directory exists, so anything that reads it alone goes blind to
+/// `~/.config/maki`, which is where the docs tell people to put their files.
+pub fn config_search_dirs() -> Vec<PathBuf> {
+    config_search_dirs_from(home().as_deref(), xdg_config_dir().ok().as_deref())
+}
+
+pub fn find_config_path(name: &str) -> Option<PathBuf> {
+    config_search_dirs()
+        .into_iter()
+        .map(|dir| dir.join(name))
+        .find(|path| path.exists())
+}
+
+/// Pure core of `config_search_dirs`: no env reads, no process-home fallback,
+/// so tests can hand it tempdirs.
+pub fn config_search_dirs_from(home: Option<&Path>, xdg_config: Option<&Path>) -> Vec<PathBuf> {
+    let legacy = home.map(|h| h.join(FALLBACK_DIR)).filter(|d| d.is_dir());
+    let xdg = xdg_config
+        .map(Path::to_path_buf)
+        .filter(|d| Some(d) != legacy.as_ref());
     [legacy, xdg].into_iter().flatten().collect()
 }
 
@@ -427,38 +439,55 @@ mod tests {
     }
 
     #[test]
-    fn user_config_dirs_returns_legacy_and_xdg() {
+    fn search_dirs_returns_legacy_and_xdg() {
+        let home = tempfile::tempdir().unwrap();
+        let legacy = home.path().join(FALLBACK_DIR);
+        let xdg = home.path().join(".config").join(APP_NAME);
+        fs::create_dir(&legacy).unwrap();
+
+        let dirs = config_search_dirs_from(Some(home.path()), Some(&xdg));
+        assert_eq!(dirs, vec![legacy, xdg]);
+    }
+
+    #[test]
+    fn search_dirs_omits_legacy_when_it_does_not_exist() {
         let home = tempfile::tempdir().unwrap();
         let xdg = home.path().join(".config").join(APP_NAME);
 
-        let dirs = user_config_dirs(Some(home.path()), Some(&xdg), "AGENTS.md");
-        assert_eq!(
-            dirs,
-            vec![
-                home.path().join(FALLBACK_DIR).join("AGENTS.md"),
-                xdg.join("AGENTS.md"),
-            ]
-        );
+        let dirs = config_search_dirs_from(Some(home.path()), Some(&xdg));
+        assert_eq!(dirs, vec![xdg]);
     }
 
     #[test]
-    fn user_config_dirs_omits_legacy_when_home_none() {
+    fn search_dirs_omits_legacy_when_home_none() {
         let xdg = tempfile::tempdir().unwrap();
 
-        let dirs = user_config_dirs(None, Some(xdg.path()), "AGENTS.md");
-        assert_eq!(dirs, vec![xdg.path().join("AGENTS.md")]);
+        let dirs = config_search_dirs_from(None, Some(xdg.path()));
+        assert_eq!(dirs, vec![xdg.path().to_path_buf()]);
     }
 
     #[test]
-    fn user_config_dirs_omits_xdg_when_xdg_none() {
+    fn search_dirs_omits_xdg_when_xdg_none() {
         let home = tempfile::tempdir().unwrap();
+        let legacy = home.path().join(FALLBACK_DIR);
+        fs::create_dir(&legacy).unwrap();
 
-        let dirs = user_config_dirs(Some(home.path()), None, "AGENTS.md");
-        assert_eq!(dirs, vec![home.path().join(FALLBACK_DIR).join("AGENTS.md")]);
+        let dirs = config_search_dirs_from(Some(home.path()), None);
+        assert_eq!(dirs, vec![legacy]);
     }
 
     #[test]
-    fn user_config_dirs_neither_depends_on_process_env() {
+    fn search_dirs_does_not_repeat_the_same_dir() {
+        let home = tempfile::tempdir().unwrap();
+        let legacy = home.path().join(FALLBACK_DIR);
+        fs::create_dir(&legacy).unwrap();
+
+        let dirs = config_search_dirs_from(Some(home.path()), Some(&legacy));
+        assert_eq!(dirs, vec![legacy]);
+    }
+
+    #[test]
+    fn search_dirs_neither_depends_on_process_env() {
         let home_a = tempfile::tempdir().unwrap();
         let xdg_a = home_a.path().join(".config").join(APP_NAME);
 
@@ -468,7 +497,7 @@ mod tests {
         // SAFETY: tests run single-threaded within a process nextest invokes once.
         unsafe { std::env::set_var("XDG_CONFIG_HOME", hostile.path()) };
 
-        let dirs = user_config_dirs(Some(home_a.path()), Some(&xdg_a), "AGENTS.md");
+        let dirs = config_search_dirs_from(Some(home_a.path()), Some(&xdg_a));
 
         // SAFETY: same single-threaded assumption as above.
         unsafe {

--- a/maki-ui/src/theme.rs
+++ b/maki-ui/src/theme.rs
@@ -14,6 +14,7 @@ use syntect::highlighting::{
 };
 
 const DEFAULT_THEME: &str = "dracula";
+const THEMES_DIR: &str = "themes";
 const RESERVED_KEYS: &[&str] = &["palette", "ui", "inherits"];
 
 const HELIX_TO_TEXTMATE: &[(&str, &str)] = &[
@@ -289,7 +290,9 @@ pub fn generation() -> u64 {
 }
 
 pub fn load_by_name(name: &str) -> Result<Theme, String> {
-    if let Some(path) = user_themes_dir().map(|d| d.join(format!("{name}.toml")))
+    if let Some(path) = user_themes_dirs()
+        .map(|dir| dir.join(format!("{name}.toml")))
+        .find(|path| path.is_file())
         && let Ok(toml) = std::fs::read_to_string(&path)
     {
         return Theme::from_toml(&toml).map_err(|e| format!("{}: {e}", path.display()));
@@ -301,16 +304,15 @@ pub fn load_by_name(name: &str) -> Result<Theme, String> {
         .unwrap_or_else(|| Err(format!("unknown theme: {name}")))
 }
 
-fn user_themes_dir() -> Option<PathBuf> {
-    maki_storage::paths::config_dir()
-        .ok()
-        .map(|d| d.join("themes"))
+fn user_themes_dirs() -> impl Iterator<Item = PathBuf> {
+    maki_storage::paths::config_search_dirs()
+        .into_iter()
+        .map(|dir| dir.join(THEMES_DIR))
 }
 
 pub fn all_theme_names() -> Vec<String> {
-    let user_names = user_themes_dir()
-        .and_then(|dir| std::fs::read_dir(dir).ok())
-        .into_iter()
+    let user_names = user_themes_dirs()
+        .filter_map(|dir| std::fs::read_dir(dir).ok())
         .flatten()
         .flatten()
         .filter_map(|e| {

--- a/site/docs/content/plugins/_index.md
+++ b/site/docs/content/plugins/_index.md
@@ -17,7 +17,7 @@ reference is at the end of this document.
 Plugins live in the maki config dir. There are two of them, same layout:
 
 - `~/.config/maki/` - global, every project (if `~/.maki/` exists, maki reads
-  that one instead)
+  that one first)
 - `<project>/.maki/` - this project only
 
 ```


### PR DESCRIPTION
Fixes #933.