### PR TITLE
fix(providers): stop oauth refreshes racing each other

### DIFF
--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -2,13 +2,13 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, UNIX_EPOCH};
 
 use flume::Sender;
 use maki_config::providers::ProvidersConfig;
 use maki_storage::StateDir;
+use maki_storage::auth::lock_exclusive;
 use maki_storage::id::SessionRef;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -43,6 +43,7 @@ const SCRIPT_TIMEOUT: Duration = Duration::from_secs(30);
 const PROVIDERS_DIR: &str = "providers";
 const SCRIPT_CACHE_FILE: &str = "provider-scripts.json";
 const THINKING_FIELDS_KEY: &str = "thinking_fields";
+const RELOAD_SUBCOMMAND: &str = "reload";
 
 struct DynamicProviderMeta {
     slug: String,
@@ -52,6 +53,7 @@ struct DynamicProviderMeta {
     has_auth: bool,
     script_path: PathBuf,
     models: Vec<ScriptModel>,
+    refresh_gate: RefreshGate,
 }
 
 #[derive(Deserialize)]
@@ -204,7 +206,12 @@ fn run_script(path: &Path, subcommand: &str, timeout: Duration) -> Result<String
     })
 }
 
+/// Login writes a brand new token family, so it has to wait for an in flight
+/// refresh instead of racing it: the loser of that race would put the old
+/// family back on top of the new one, and the user would see the same auth
+/// error right after logging in.
 fn run_script_interactive(path: &Path, subcommand: &str) -> Result<(), AgentError> {
+    let _lock = lock_exclusive(path);
     let status = Command::new(path)
         .arg(subcommand)
         .stdin(std::process::Stdio::inherit())
@@ -224,6 +231,9 @@ fn run_script_interactive(path: &Path, subcommand: &str) -> Result<(), AgentErro
 }
 
 fn resolve_auth(meta: &DynamicProviderMeta) -> Result<ResolvedAuth, AgentError> {
+    // A script may refresh under `resolve` when the token is near expiry, and
+    // this runs on every `create`, so it takes the lock too.
+    let _lock = lock_exclusive(&meta.script_path);
     let stdout = run_script(&meta.script_path, "resolve", SCRIPT_TIMEOUT)?;
     let parsed: ScriptResolvedAuth =
         serde_json::from_str(&stdout).map_err(|e| AgentError::Config {
@@ -373,6 +383,7 @@ fn build_meta(
         has_auth: info.has_auth,
         script_path,
         models,
+        refresh_gate: RefreshGate::default(),
     })
 }
 
@@ -602,7 +613,7 @@ pub fn create(slug: &str, timeouts: super::Timeouts) -> Result<Box<dyn Provider>
         inner,
         auth,
         models: &meta.models,
-        refresh_gate: RefreshGate::default(),
+        refresh_gate: &meta.refresh_gate,
     }))
 }
 
@@ -661,20 +672,28 @@ struct DynamicProvider {
     inner: Box<dyn Provider>,
     auth: Arc<Mutex<ResolvedAuth>>,
     models: &'static [ScriptModel],
-    refresh_gate: RefreshGate,
+    refresh_gate: &'static RefreshGate,
 }
 
-/// Gate around the auth script's `refresh`. Parallel 401s, say from sub-agents
-/// sharing one provider, would each spend the script's rotating refresh token,
-/// so callers queue on the lock and whoever arrives late reuses what the winner
-/// fetched. A refresh may hand back byte-identical credentials, so the
-/// generation counter, not the auth bytes, is what tells a parked caller that a
-/// peer already did the work. The lock orders that bump against the load, which
-/// is why `Relaxed` is enough.
+/// Gate around the auth script's `refresh`. Every `create` mints a fresh
+/// `DynamicProvider`, so sub-agents running their own model would each spend
+/// the script's rotating refresh token, and a spent one taken twice costs the
+/// whole token family. They queue here instead, and the late arrival takes the
+/// credentials the winner brought back. That is why the gate hangs off the
+/// `'static` per-slug metadata rather than the provider.
 #[derive(Default)]
 struct RefreshGate {
     lock: smol::lock::Mutex<()>,
-    generation: AtomicU64,
+    winner: Mutex<Winner>,
+}
+
+/// A refresh can hand back byte-identical credentials, so the count, not the
+/// bytes, is what tells a parked caller the work is already done. Both live
+/// under one lock so they cannot be read apart.
+#[derive(Default, Clone)]
+struct Winner {
+    refreshes: u64,
+    auth: Option<ResolvedAuth>,
 }
 
 impl RefreshGate {
@@ -684,14 +703,21 @@ impl RefreshGate {
         script_path: &Path,
         auth: &Arc<Mutex<ResolvedAuth>>,
     ) -> Result<(), AgentError> {
-        let before = self.generation.load(Ordering::Relaxed);
+        let before = self.winner.lock().unwrap().refreshes;
         let _guard = self.lock.lock().await;
-        if self.generation.load(Ordering::Relaxed) != before {
+        let winner = self.winner.lock().unwrap().clone();
+        if winner.refreshes != before {
             debug!("peer refreshed while we waited, skipping script run");
+            if let Some(fresh) = winner.auth {
+                *auth.lock().unwrap() = fresh;
+            }
             return Ok(());
         }
         run_auth_script(slug, script_path, auth, "refresh").await?;
-        self.generation.fetch_add(1, Ordering::Relaxed);
+        *self.winner.lock().unwrap() = Winner {
+            refreshes: before + 1,
+            auth: Some(auth.lock().unwrap().clone()),
+        };
         Ok(())
     }
 }
@@ -706,6 +732,9 @@ async fn run_auth_script(
     let auth = auth.clone();
     let slug = slug.to_string();
     smol::unblock(move || {
+        // `reload` only re-reads what a login wrote, so it spends no token and
+        // must not park the ui behind someone else's refresh.
+        let _lock = (subcommand != RELOAD_SUBCOMMAND).then(|| lock_exclusive(&script_path));
         let stdout = run_script(&script_path, subcommand, SCRIPT_TIMEOUT)?;
         let parsed: ScriptResolvedAuth =
             serde_json::from_str(&stdout).map_err(|e| AgentError::Config {
@@ -824,7 +853,7 @@ impl Provider for DynamicProvider {
             self.slug,
             self.script_path,
             &self.auth,
-            "reload",
+            RELOAD_SUBCOMMAND,
         ))
     }
 
@@ -1042,6 +1071,10 @@ esac
         fs::read_to_string(counter).unwrap().trim().parse().unwrap()
     }
 
+    /// Two auth slots, because sub-agents on one slug each build their own
+    /// provider and only the gate is shared. Both have to come out holding the
+    /// winner's token, since a second run would spend the rotating refresh
+    /// token again.
     #[cfg(unix)]
     #[test_case(true, "Bearer refreshed-2" ; "rotating_token")]
     #[test_case(false, CONSTANT_TOKEN ; "unchanged_token")]
@@ -1049,31 +1082,36 @@ esac
         let tmp = TempDir::new().unwrap();
         let counter = tmp.path().join("count");
         let script = write_counting_refresh_script(tmp.path(), &counter, rotating);
-        let auth = Arc::new(Mutex::new(ResolvedAuth::for_test(
-            None,
-            vec![("authorization".into(), STALE_TOKEN.into())],
-        )));
+        let stale = || {
+            Arc::new(Mutex::new(ResolvedAuth::for_test(
+                None,
+                vec![("authorization".into(), STALE_TOKEN.into())],
+            )))
+        };
+        let (first, second) = (stale(), stale());
         let gate = RefreshGate::default();
 
         smol::block_on(async {
-            let (first, second) = futures_lite::future::zip(
-                gate.refresh(TEST_SLUG, &script, &auth),
-                gate.refresh(TEST_SLUG, &script, &auth),
+            let (a, b) = futures_lite::future::zip(
+                gate.refresh(TEST_SLUG, &script, &first),
+                gate.refresh(TEST_SLUG, &script, &second),
             )
             .await;
-            first.unwrap();
-            second.unwrap();
+            a.unwrap();
+            b.unwrap();
 
             assert_eq!(
                 script_runs(&counter),
                 1,
                 "concurrent 401s share one script run"
             );
-            assert_ne!(auth.lock().unwrap().headers[0].1, STALE_TOKEN);
+            let winner = first.lock().unwrap().headers[0].1.clone();
+            assert_ne!(winner, STALE_TOKEN);
+            assert_eq!(second.lock().unwrap().headers[0].1, winner);
 
-            // The late caller snapshots the bumped generation before locking, so
-            // a refresh that doesn't overlap anyone still runs the script.
-            gate.refresh(TEST_SLUG, &script, &auth).await.unwrap();
+            // The late caller snapshots the count before locking, so a refresh
+            // that overlaps nobody still runs the script.
+            gate.refresh(TEST_SLUG, &script, &first).await.unwrap();
         });
 
         assert_eq!(
@@ -1081,7 +1119,7 @@ esac
             2,
             "a refresh that overlaps nobody runs the script again"
         );
-        assert_eq!(auth.lock().unwrap().headers[0].1, final_token);
+        assert_eq!(first.lock().unwrap().headers[0].1, final_token);
     }
 
     #[cfg(unix)]

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -11,6 +11,9 @@ use serde::Deserialize;
 use serde_json::Value;
 use tracing::debug;
 
+use maki_storage::StateDir;
+use maki_storage::auth::{OAuthTokens, load_tokens, lock_tokens, save_tokens};
+
 use crate::AgentError;
 
 pub(crate) mod anthropic;
@@ -37,6 +40,7 @@ pub(crate) mod zai;
 
 const LOW_SPEED_BYTES_PER_SEC: u32 = 1;
 const UNMAPPED_SSE_ERROR_STATUS: u16 = 400;
+const UNAUTHORIZED_STATUS: u16 = 401;
 const AUTHORIZATION_HEADER: &str = "authorization";
 
 fn bearer_value(api_key: &str) -> String {
@@ -67,6 +71,28 @@ impl Default for Timeouts {
             low_speed: Duration::from_secs(30),
         }
     }
+}
+
+/// Reading, refreshing and writing tokens has to happen as one turn. Whoever
+/// queued behind a peer here is holding a copy the peer already spent, and
+/// replaying a rotated refresh token gets the whole family revoked, so the
+/// tokens are loaded again once the lock is in hand.
+pub(crate) fn refreshed_tokens(
+    dir: &StateDir,
+    provider: &str,
+    refresh: impl FnOnce(&OAuthTokens) -> Result<OAuthTokens, AgentError>,
+) -> Result<OAuthTokens, AgentError> {
+    let _lock = lock_tokens(dir, provider);
+    let current = load_tokens(dir, provider).ok_or_else(|| AgentError::Api {
+        status: UNAUTHORIZED_STATUS,
+        message: format!("{provider} OAuth tokens not found on disk"),
+    })?;
+    if !current.is_expired() {
+        return Ok(current);
+    }
+    let fresh = refresh(&current)?;
+    save_tokens(dir, provider, &fresh)?;
+    Ok(fresh)
 }
 
 #[derive(Clone)]

--- a/maki-providers/src/providers/openai/auth.rs
+++ b/maki-providers/src/providers/openai/auth.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use tracing::{debug, error, warn};
 
 use crate::AgentError;
-use crate::providers::{ResolvedAuth, urlenc};
+use crate::providers::{ResolvedAuth, refreshed_tokens, urlenc};
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 pub(crate) const PROVIDER: &str = "openai";
@@ -271,9 +271,8 @@ pub fn resolve(dir: &StateDir) -> Result<ResolvedAuth, AgentError> {
             debug!("using OpenAI OAuth authentication");
             return build_oauth_resolved(&tokens);
         }
-        match refresh_tokens(&tokens) {
+        match refreshed_tokens(dir, PROVIDER, refresh_tokens) {
             Ok(fresh) => {
-                save_tokens(dir, PROVIDER, &fresh)?;
                 debug!("using OpenAI OAuth authentication (refreshed)");
                 return build_oauth_resolved(&fresh);
             }

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -16,8 +16,8 @@ use crate::{
 };
 
 use super::auth;
-use crate::providers::ResolvedAuth;
 use crate::providers::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
+use crate::providers::{ResolvedAuth, refreshed_tokens};
 
 static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     slug: "openai",
@@ -150,18 +150,8 @@ impl OpenAi {
             message: "OAuth refresh not available for externally-managed auth".into(),
         })?;
         let resolved = smol::unblock(move || {
-            let tokens =
-                maki_storage::auth::load_tokens(&storage, auth::PROVIDER).ok_or_else(|| {
-                    AgentError::Api {
-                        status: 401,
-                        message: "OpenAI OAuth tokens not found on disk".into(),
-                    }
-                })?;
-            match auth::refresh_tokens(&tokens) {
-                Ok(fresh) => {
-                    maki_storage::auth::save_tokens(&storage, auth::PROVIDER, &fresh)?;
-                    auth::build_oauth_resolved(&fresh)
-                }
+            match refreshed_tokens(&storage, auth::PROVIDER, auth::refresh_tokens) {
+                Ok(fresh) => auth::build_oauth_resolved(&fresh),
                 Err(e) => {
                     warn!(error = %e, "OpenAI OAuth refresh failed, clearing stale tokens");
                     let _ = maki_storage::auth::delete_tokens(&storage, auth::PROVIDER);

--- a/maki-providers/src/providers/xai/auth.rs
+++ b/maki-providers/src/providers/xai/auth.rs
@@ -17,7 +17,7 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, error, warn};
 
 use crate::AgentError;
-use crate::providers::{KeyPool, ResolvedAuth, urlenc};
+use crate::providers::{KeyPool, ResolvedAuth, refreshed_tokens, urlenc};
 
 use super::catalog;
 
@@ -219,9 +219,8 @@ pub fn resolve(dir: &StateDir) -> Result<ResolvedAuth, AgentError> {
             debug!("using xAI OAuth authentication");
             return build_oauth_resolved(&tokens);
         }
-        match refresh_tokens(&tokens) {
+        match refreshed_tokens(dir, PROVIDER, refresh_tokens) {
             Ok(fresh) => {
-                save_tokens(dir, PROVIDER, &fresh)?;
                 debug!("using xAI OAuth authentication (refreshed)");
                 return build_oauth_resolved(&fresh);
             }

--- a/maki-providers/src/providers/xai/platform.rs
+++ b/maki-providers/src/providers/xai/platform.rs
@@ -8,9 +8,9 @@ use tracing::{debug, warn};
 
 use crate::model::Model;
 use crate::provider::{BoxFuture, Provider};
-use crate::providers::ResolvedAuth;
 use crate::providers::openai::responses;
 use crate::providers::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
+use crate::providers::{ResolvedAuth, refreshed_tokens};
 use crate::{
     AgentError, Message, ProviderEvent, ProviderUsage, RequestOptions, StreamResponse, dialect,
 };
@@ -77,18 +77,8 @@ impl Xai {
             message: "OAuth refresh not available for externally-managed auth".into(),
         })?;
         let resolved = smol::unblock(move || {
-            let tokens =
-                maki_storage::auth::load_tokens(&storage, auth::PROVIDER).ok_or_else(|| {
-                    AgentError::Api {
-                        status: 401,
-                        message: "xAI OAuth tokens not found on disk".into(),
-                    }
-                })?;
-            match auth::refresh_tokens(&tokens) {
-                Ok(fresh) => {
-                    maki_storage::auth::save_tokens(&storage, auth::PROVIDER, &fresh)?;
-                    auth::build_oauth_resolved(&fresh)
-                }
+            match refreshed_tokens(&storage, auth::PROVIDER, auth::refresh_tokens) {
+                Ok(fresh) => auth::build_oauth_resolved(&fresh),
                 Err(e) => {
                     warn!(error = %e, "xAI OAuth refresh failed, clearing stale tokens");
                     let _ = maki_storage::auth::delete_tokens(&storage, auth::PROVIDER);

--- a/maki-storage/src/auth.rs
+++ b/maki-storage/src/auth.rs
@@ -1,6 +1,7 @@
-use std::fs;
+use std::fs::{self, File, OpenOptions, TryLockError};
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::thread::sleep;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -11,6 +12,9 @@ use crate::{StateDir, StorageError, atomic_write_permissions};
 const AUTH_DIR: &str = "auth";
 const AUTH_FILE_MODE: u32 = 0o600;
 const REFRESH_BUFFER_SECS: u64 = 60;
+const LOCK_SUFFIX: &str = ".lock";
+const LOCK_WAIT: Duration = Duration::from_secs(30);
+const LOCK_POLL: Duration = Duration::from_millis(50);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct OAuthTokens {
@@ -47,7 +51,7 @@ pub struct McpAuthData {
     pub token_endpoint: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ProviderCredentials {
     pub api_key: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -66,6 +70,41 @@ impl ProviderCredentials {
             "****".to_string()
         }
     }
+}
+
+/// Refresh tokens rotate and a rotated one is single use, so two processes
+/// refreshing at once leave the loser replaying a spent token, which providers
+/// answer by revoking the whole family instead of failing the one call. Waiting
+/// forever would be worse than the race though, since this runs on the ui
+/// thread too, so a lock that does not arrive in time is given up and the
+/// caller carries on as before.
+pub fn lock_exclusive(path: &Path) -> Option<File> {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(_) => {
+            fs::create_dir_all(path.parent()?).ok()?;
+            OpenOptions::new()
+                .write(true)
+                .truncate(false)
+                .create(true)
+                .open(path)
+                .ok()?
+        }
+    };
+    let deadline = Instant::now() + LOCK_WAIT;
+    loop {
+        match file.try_lock() {
+            Ok(()) => return Some(file),
+            Err(TryLockError::WouldBlock) if Instant::now() < deadline => sleep(LOCK_POLL),
+            Err(_) => return None,
+        }
+    }
+}
+
+/// Every write replaces the token file, so the lock sits beside it under a name
+/// no loader reads.
+pub fn lock_tokens(dir: &StateDir, provider: &str) -> Option<File> {
+    lock_exclusive(&auth_path(dir, &format!("{provider}{LOCK_SUFFIX}")))
 }
 
 pub fn now_millis() -> u64 {


### PR DESCRIPTION
A rotating refresh token is single use, and providers answer a replayed one by revoking the whole family instead of failing the one call, so the log showed two refreshes 300ms apart and then `OAuth access token has been revoked` on a token with eight hours left. `RefreshGate` was meant to stop that, but it sat on `DynamicProvider` while every `create` mints a fresh one, so sub-agents, compaction and model switches each got a private gate and raced each other, and it now hangs off the `'static` per-slug metadata with the winner leaving its credentials there for whoever parked behind it.

Peers in other terminals cannot see the gate at all, so anything that can spend a token takes an advisory file lock first, waiting up to 30s before giving up rather than freezing the ui behind someone else. For scripts that lock is the script file, and `resolve` and `login` take it too since a script may refresh when the token is near expiry and a login landing mid refresh would put the old family back over the new one, while `reload` stays out because it only re-reads what a login wrote.

The built in OpenAI and xAI providers had the same hole and now share one `refreshed_tokens` helper that locks, re-reads whatever a peer just rotated, then refreshes and saves.