### PR TITLE
fix(lua): stop every window from opening invisible

### DIFF
--- a/maki-lua/src/api/fs.rs
+++ b/maki-lua/src/api/fs.rs
@@ -8,6 +8,7 @@ use std::time::UNIX_EPOCH;
 use maki_lua_macro::{lua_fn, lua_table};
 use mlua::{Buffer, Lua, Result as LuaResult, Table, Value};
 
+use crate::api::util::convert::opt_bool;
 use crate::api::util::pair::{Pair, err_pair, pair, try_pair};
 use crate::plugin_permissions::PluginPermissions;
 
@@ -476,11 +477,11 @@ async fn rm(_lua: Lua, path: String, opts: Option<Table>) -> LuaResult<Pair<bool
     let abs = make_absolute(&path)?;
     let recursive = opts
         .as_ref()
-        .and_then(|t| t.get::<bool>("recursive").ok())
+        .and_then(|t| opt_bool(t, "recursive"))
         .unwrap_or(false);
     let force = opts
         .as_ref()
-        .and_then(|t| t.get::<bool>("force").ok())
+        .and_then(|t| opt_bool(t, "force"))
         .unwrap_or(false);
     let result = smol::unblock(move || -> std::io::Result<()> {
         let meta = match std::fs::symlink_metadata(&abs) {
@@ -519,7 +520,7 @@ async fn mkdir(_lua: Lua, path: String, opts: Option<Table>) -> LuaResult<Pair<b
     let abs = make_absolute(&path)?;
     let parents = opts
         .as_ref()
-        .and_then(|t| t.get::<bool>("parents").ok())
+        .and_then(|t| opt_bool(t, "parents"))
         .unwrap_or(false);
     let result = if parents {
         smol::fs::create_dir_all(&abs).await
@@ -562,7 +563,7 @@ async fn glob(lua: Lua, pattern: Value, opts: Option<Table>) -> LuaResult<Pair<T
     let limit = opts.as_ref().and_then(|t| t.get::<usize>("limit").ok());
     let gitignore = opts
         .as_ref()
-        .and_then(|t| t.get::<bool>("gitignore").ok())
+        .and_then(|t| opt_bool(t, "gitignore"))
         .unwrap_or(true);
     let sort = opts.as_ref().and_then(|t| t.get::<String>("sort").ok());
     let sort_mtime = sort.as_deref() == Some("mtime");
@@ -709,6 +710,7 @@ mod tests {
     use crate::plugin_permissions::PluginPermissions;
     use mlua::Lua;
     use tempfile::TempDir;
+    use test_case::test_case;
 
     const FIRST_CONTENT: &str = "first";
     const REPLACEMENT_CONTENT: &str = "replacement";
@@ -1370,6 +1372,33 @@ mod tests {
             smol::block_on(glob.call_async::<(Table, mlua::Value)>(("*.rs", opts))).unwrap();
         assert!(matches!(err, mlua::Value::Nil));
         assert_eq!(result.len().unwrap(), 2);
+    }
+
+    /// The fixture ignores through `.ignore` so the walker needs no git repo,
+    /// and hides a directory rather than a file because the glob patterns turn
+    /// into whitelist overrides that outrank a file-level ignore rule.
+    #[test_case(None, 0 ; "omitted_key_keeps_the_true_default")]
+    #[test_case(Some(false), 1 ; "false_includes_ignored_files")]
+    fn glob_gitignore_option(gitignore: Option<bool>, expected_hits: i64) {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".ignore"), "sub/\n").unwrap();
+        std::fs::create_dir(tmp.path().join("sub")).unwrap();
+        std::fs::write(tmp.path().join("sub/ignored.log"), "").unwrap();
+
+        let lua = Lua::new();
+        let tbl = create_fs_table(&lua, &PluginPermissions::trusted()).unwrap();
+        let glob: mlua::Function = tbl.get("glob").unwrap();
+
+        let opts = lua.create_table().unwrap();
+        opts.set("path", tmp.path().to_str().unwrap()).unwrap();
+        if let Some(gitignore) = gitignore {
+            opts.set("gitignore", gitignore).unwrap();
+        }
+
+        let (result, err): (Table, mlua::Value) =
+            smol::block_on(glob.call_async::<(Table, mlua::Value)>(("**/*.log", opts))).unwrap();
+        assert!(matches!(err, mlua::Value::Nil));
+        assert_eq!(result.len().unwrap(), expected_hits);
     }
 
     #[test]

--- a/maki-lua/src/api/ui/mod.rs
+++ b/maki-lua/src/api/ui/mod.rs
@@ -13,6 +13,7 @@ use crate::api::util::command::{
     Anchor, Border, BuiltinAction, Dimension, FloatConfig, HintEntries, HintWriter, Split,
     TitlePos, UiAction, WinCommand, WinEvent, ui_send,
 };
+use crate::api::util::convert::opt_bool;
 use crate::api::util::pair::{Pair, try_pair};
 use crate::docs::{FnDoc, ParamDoc};
 pub(crate) mod blit;
@@ -95,10 +96,7 @@ pub(crate) fn parse_footer(tbl: &Table) -> LuaResult<Vec<(String, String)>> {
 /// toast:line("copied!")
 #[lua_fn]
 fn buf(lua: &Lua, opts: Option<Table>) -> LuaResult<buf::BufHandle> {
-    let scratch = match opts {
-        Some(t) => t.get::<Option<bool>>("scratch")?.unwrap_or(false),
-        None => false,
-    };
+    let scratch = opts.and_then(|t| opt_bool(&t, "scratch")).unwrap_or(false);
     Ok(with_task_bufs(lua, |store| {
         if scratch {
             store.create()
@@ -155,7 +153,7 @@ fn theme_color(lua: &Lua, name: String) -> LuaResult<mlua::Value> {
 async fn highlight(lua: Lua, code: String, lang: String, opts: Option<Table>) -> LuaResult<Table> {
     let independent = opts
         .as_ref()
-        .and_then(|t| t.get::<bool>("independent").ok())
+        .and_then(|t| opt_bool(t, "independent"))
         .unwrap_or(false);
     let prefix = opts
         .and_then(|t| t.get::<String>("prefix").ok())
@@ -409,15 +407,11 @@ fn open_win(
 ) -> LuaResult<WinHandle> {
     let buf_handle = buf.borrow::<buf::BufHandle>()?;
     let title: String = opts.get("title").unwrap_or_default();
-    let cursor_line: bool = opts.get("cursor_line").unwrap_or(false);
+    let cursor_line = opt_bool(&opts, "cursor_line").unwrap_or(false);
     let footer = parse_footer(&opts)?;
     let reserved_bottom: usize = opts.get("reserved_bottom").unwrap_or(0);
     let reserved_top: usize = opts.get("reserved_top").unwrap_or(0);
-    let focus: bool = opts
-        .get::<Option<bool>>("focus")
-        .ok()
-        .flatten()
-        .unwrap_or(true);
+    let focus = opt_bool(&opts, "focus").unwrap_or(true);
     let zindex: u16 = opts.get("zindex").unwrap_or(50);
 
     let width = parse_dimension(&opts, "width", Dimension::Percent(60));
@@ -429,9 +423,9 @@ fn open_win(
     let title_pos = parse_title_pos(&opts);
     let split = parse_split(&opts);
     let order: u16 = opts.get("order").unwrap_or(50);
-    let visible: bool = opts.get("visible").unwrap_or(true);
-    let needs_input: bool = opts.get("needs_input").unwrap_or(false);
-    let stack: bool = opts.get("stack").unwrap_or(false);
+    let visible = opt_bool(&opts, "visible").unwrap_or(true);
+    let needs_input = opt_bool(&opts, "needs_input").unwrap_or(false);
+    let stack = opt_bool(&opts, "stack").unwrap_or(false);
 
     let config = FloatConfig {
         width,

--- a/maki-lua/src/api/ui/win.rs
+++ b/maki-lua/src/api/ui/win.rs
@@ -8,6 +8,7 @@ use super::{parse_footer, try_parse_dimension};
 use crate::api::util::command::{
     Anchor, Border, FloatConfigPatch, Split, TitlePos, WinCommand, WinEvent,
 };
+use crate::api::util::convert::opt_bool;
 use crate::docs::{FnDoc, ParamDoc};
 
 /// All mutable state is in `Cell`s so every Lua method takes a shared
@@ -209,9 +210,7 @@ fn set_config(_lua: &Lua, this: &WinHandle, opts: Table) -> LuaResult<()> {
     if let Ok(z) = opts.get::<u16>("zindex") {
         patch.zindex = Some(z);
     }
-    if let Ok(Some(cl)) = opts.get::<Option<bool>>("cursor_line") {
-        patch.cursor_line = Some(cl);
-    }
+    patch.cursor_line = opt_bool(&opts, "cursor_line");
     if let Ok(rt) = opts.get::<usize>("reserved_top") {
         patch.reserved_top = Some(rt);
     }
@@ -221,9 +220,7 @@ fn set_config(_lua: &Lua, this: &WinHandle, opts: Table) -> LuaResult<()> {
     if let Ok(o) = opts.get::<u16>("order") {
         patch.order = Some(o);
     }
-    if let Ok(Some(ni)) = opts.get::<Option<bool>>("needs_input") {
-        patch.needs_input = Some(ni);
-    }
+    patch.needs_input = opt_bool(&opts, "needs_input");
     patch.width = try_parse_dimension(&opts, "width");
     patch.height = try_parse_dimension(&opts, "height");
     // A missing key leaves the window where it is. Lua has no way to say

--- a/maki-lua/src/api/util/convert.rs
+++ b/maki-lua/src/api/util/convert.rs
@@ -1,4 +1,4 @@
-use mlua::{Lua, LuaSerdeExt, Result as LuaResult, Value};
+use mlua::{Lua, LuaSerdeExt, Result as LuaResult, Table, Value};
 use serde_json::Value as JsonValue;
 
 pub(crate) const NIL_TOOL_RESULT_ERR: &str = "tool returned nil without an error message";
@@ -9,6 +9,14 @@ pub(crate) const NIL_TOOL_RESULT_ERR: &str = "tool returned nil without an error
 /// Past this the table is a sparse map, not an array, and the object encoding
 /// keeps every key while allocating per entry.
 const MAX_ARRAY_HOLES: usize = 4096;
+
+/// mlua reads `bool` by Lua truthiness and never fails, so `get::<bool>`
+/// answers `Ok(false)` for a missing key and quietly kills whatever
+/// `unwrap_or(true)` sat behind it. `Option<bool>` keeps absent apart from
+/// an explicit `false`.
+pub(crate) fn opt_bool(tbl: &Table, key: &str) -> Option<bool> {
+    tbl.get::<Option<bool>>(key).ok().flatten()
+}
 
 pub(crate) fn lua_tool_result(values: mlua::MultiValue) -> Result<String, String> {
     let mut iter = values.into_iter();
@@ -180,11 +188,25 @@ mod tests {
     use serde_json::Value as JsonValue;
     use test_case::test_case;
 
-    use super::{MAX_ARRAY_HOLES, json_to_lua, lua_to_json, lua_to_json_within};
+    use super::{MAX_ARRAY_HOLES, json_to_lua, lua_to_json, lua_to_json_within, opt_bool};
+
+    const FLAG_KEY: &str = "flag";
 
     /// The name `LAYER_CASES` snippets edit through, standing in for the
     /// `value` argument a real hook layer is handed.
     const LAYER_GLOBAL: &str = "value";
+
+    #[test_case(None ; "missing_key_is_none")]
+    #[test_case(Some(true) ; "explicit_true")]
+    #[test_case(Some(false) ; "explicit_false_is_not_absent")]
+    fn opt_bool_distinguishes_absent_from_false(value: Option<bool>) {
+        let lua = Lua::new();
+        let tbl = lua.create_table().unwrap();
+        if let Some(value) = value {
+            tbl.raw_set(FLAG_KEY, value).unwrap();
+        }
+        assert_eq!(opt_bool(&tbl, FLAG_KEY), value);
+    }
 
     #[test_case(Value::Nil, JsonValue::Null ; "nil_to_null")]
     #[test_case(Value::Boolean(true), JsonValue::Bool(true) ; "bool_true")]


### PR DESCRIPTION
`Table::get::<bool>` converts by Lua truthiness instead of failing, so a missing key answers `Ok(false)` and the `unwrap_or(true)` behind `open_win`'s `visible` never ran.

Nobody noticed because `FloatManager::view` paints floats whatever `visible` says, but `needs_input()` checks it, so the question tool parked the agent without ever setting the attention flag and the OSC 9 notification never fired.

A shared `parse_bool` now reads these options through `Option<bool>`, which also gets `split = "panel"` windows back into the layout.