### PR TITLE
fix(todo_write): keep the todo panel updated across steps

### DIFF
--- a/plugins/todo_write/init.lua
+++ b/plugins/todo_write/init.lua
@@ -1,7 +1,7 @@
 local todos = {}
-local popped = {}
 local focused = nil
 local buf, win
+local user_hidden = false
 
 local STATUS_MARKERS = {
   completed = { "[✓]", "todo_completed" },
@@ -46,6 +46,9 @@ end
 
 local function ensure_win(visible)
   if buf and win and win:is_open() then
+    if visible and not user_hidden then
+      win:show()
+    end
     return
   end
   buf = maki.ui.buf()
@@ -56,7 +59,7 @@ local function ensure_win(visible)
     title = " Todos ",
     border = "rounded",
     focus = false,
-    visible = visible,
+    visible = visible and not user_hidden,
     footer = {
       { "Ctrl+T", "to hide" },
     },
@@ -155,12 +158,8 @@ maki.api.register_tool({
     local sid = ctx:session_id() or ""
     local items = input.todos or {}
     todos[sid] = items
-    local pop = #items > 0 and not popped[sid]
-    if pop then
-      popped[sid] = true
-    end
     if is_focused(sid) then
-      sync_panel(items, pop)
+      sync_panel(items, #items > 0)
     end
     return #items == 0 and "Todos cleared" or ""
   end,
@@ -172,9 +171,11 @@ local function toggle()
     return
   end
   if win:is_visible() then
+    user_hidden = true
     win:hide()
     update_hint(items)
   elseif win:is_open() then
+    user_hidden = false
     win:show()
     maki.ui.set_status_hint(nil)
   else
@@ -187,7 +188,8 @@ maki.keymap.set("n", "<C-t>", toggle, { desc = "Toggle todo panel" })
 maki.api.create_autocmd({ "TurnEnd", "SessionReset" }, {
   callback = function(ev)
     local sid = ev.data and ev.data.session_id or ""
-    todos[sid], popped[sid] = nil, nil
+    todos[sid] = nil
+    user_hidden = false
     if is_focused(sid) then
       hide_panel()
     end


### PR DESCRIPTION
## Summary

The Todo panel doesn't always stay current while the model resolves items. `todo_write` updates were being dropped once the panel window was already open but hidden — so a list that the model cleared and then rewrote (or carried across tasks) stayed hidden behind only the `X/Y` status hint.

## Root cause

`ensure_win()` in `plugins/todo_write/init.lua` early-returned whenever the window was already **open**, silently discarding the requested `visible` state. Since `win:hide()` only marks the window hidden (it stays open), the panel never re-appeared on subsequent populated writes.

## Changes

- `ensure_win(visible)` now calls `win:show()` when a show is requested and the window is already open-but-hidden.
- The tool `handler` requests a show on every non-empty write (not just the first per session).
- Added a `user_hidden` flag so a deliberate `Ctrl+T` hide still sticks, reset on `TurnEnd`/`SessionReset` so the next task auto-pops again.
- Dropped the `popped[]` bookkeeping that had no remaining readers.

## Verification

- `luac -p` syntax check passes.
- State-machine reproduction confirms: write → clear → rewrite re-shows the panel, and a user toggle-hide is respected.
- `cargo test -p maki-lua`: no new failures (the 2 `pack::` failures are pre-existing order-dependent flakiness that reproduce on the clean tree; this change touches only a runtime-loaded Lua file, not compiled Rust).

---

*This pull request was created with AI assistance.*
