### PR TITLE
fix(agent): give the session event stream a real end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,7 +2629,6 @@ dependencies = [
  "clap",
  "color-eyre",
  "flume 0.11.1",
- "futures-lite",
  "isahc",
  "libc",
  "maki-acp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 smol = { workspace = true }
-futures-lite = { workspace = true }
 tempfile = { workspace = true }
 isahc = { workspace = true }
 thiserror = { workspace = true }

--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -16,14 +16,16 @@ use agent_client_protocol_schema::{
     ToolCallUpdate, ToolCallUpdateFields,
 };
 use color_eyre::eyre::Context;
-use flume::{Receiver, Sender, WeakSender};
+use flume::{Sender, WeakSender};
 use maki_agent::headless::{self, InteractiveHandle, InteractiveParams};
 use maki_agent::mcp::config::{RawHttpFields, RawStdioFields, RawTransport};
 use maki_agent::mcp::{self, McpHandle};
 use maki_agent::permissions::PermissionAnswer;
 use maki_agent::tools::{LocalTool, LocalTools, QUESTION_TOOL_NAME, ToolAudience, local_tool};
 use maki_agent::types::AgentEvent;
-use maki_agent::{AgentInput, AgentMode, Envelope, ImageMediaType, ImageSource, SessionEndReason};
+use maki_agent::{
+    AgentInput, AgentMode, Envelope, ImageMediaType, ImageSource, SessionEndReason, SessionEvents,
+};
 use maki_config::{MAX_SERVER_NAME_LEN, ModelPolicy};
 use maki_providers::model::Model;
 use maki_providers::provider::{available_model_specs, fetch_all_models};
@@ -32,6 +34,7 @@ use maki_storage::id::{MakiId, SessionRef};
 use maki_storage::sessions::StoredTokenUsage;
 use serde::Serialize;
 use serde_json::Value;
+use smol::Task;
 use smol::io::AsyncBufReadExt;
 use tracing::{debug, warn};
 
@@ -259,16 +262,11 @@ async fn new_session(
     let req: NewSessionRequest = parse_params(raw)?;
     close_session(srv, SessionEndReason::Replaced).await;
     let mcp = start_mcp(&req.cwd, &req.mcp_servers).await;
-    let cwd = req.cwd.clone();
-    let (handle, pending) = spawn_session(srv, params, req.cwd, None, Vec::new(), mcp.clone());
-    maki_otel::emit::session_started(
-        maki_otel::emit::START_FRESH,
-        Some(handle.session_id.as_str()),
-    );
+    let session_ref = start_session(srv, params, req.cwd, None, Vec::new(), mcp, None);
+    maki_otel::emit::session_started(maki_otel::emit::START_FRESH, Some(session_ref.as_str()));
     let spec = params.model.spec();
-    let resp = methods::new_session_response(handle.session_id.as_str())
+    let resp = methods::new_session_response(session_ref.as_str())
         .config_options(vec![methods::model_config_option(&spec, &srv.model_specs)]);
-    install_session(srv, handle, mcp, spec, pending, cwd, None);
     Ok(AgentResponse::NewSessionResponse(resp))
 }
 
@@ -292,22 +290,6 @@ async fn load_session(
     for update in translate::replay_history(&restored.history, replay_cwd, home.as_deref()) {
         session_update(&srv.out_tx, &sid, update);
     }
-    let cwd = req.cwd.clone();
-    let (handle, pending) = spawn_session(
-        srv,
-        params,
-        req.cwd,
-        Some(session_ref),
-        restored.history,
-        mcp.clone(),
-    );
-    maki_otel::emit::session_started(
-        maki_otel::emit::START_RESUME,
-        Some(handle.session_id.as_str()),
-    );
-    let spec = params.model.spec();
-    let resp = methods::load_session_response()
-        .config_options(vec![methods::model_config_option(&spec, &srv.model_specs)]);
     // Priced against the model the session recorded, not the one selected now
     // (which may cost 10x more or less). Later turns add their own exact cost.
     let recorded_model = Model::from_spec(&restored.model).unwrap_or_else(|_| params.model.clone());
@@ -317,18 +299,34 @@ async fn load_session(
         &recorded_model,
         RESTORED_FAST,
     );
-    install_session(srv, handle, mcp, spec, pending, cwd, restored_cost);
+    let started = start_session(
+        srv,
+        params,
+        req.cwd,
+        Some(session_ref),
+        restored.history,
+        mcp,
+        restored_cost,
+    );
+    maki_otel::emit::session_started(maki_otel::emit::START_RESUME, Some(started.as_str()));
+    let spec = params.model.spec();
+    let resp = methods::load_session_response()
+        .config_options(vec![methods::model_config_option(&spec, &srv.model_specs)]);
     Ok(AgentResponse::LoadSessionResponse(resp))
 }
 
-fn spawn_session(
-    srv: &Server,
+/// Spawns a session and installs it as the server's current one. Spawning
+/// alone is not a useful state: the event stream has exactly one reader, so it
+/// must be handed to the pump here rather than travel any further.
+fn start_session(
+    srv: &mut Server,
     params: &AcpParams,
     cwd: PathBuf,
     session_id: Option<SessionRef>,
     history: Vec<Message>,
-    mcp_handle: Option<McpHandle>,
-) -> (InteractiveHandle, PendingState) {
+    mcp: Option<McpHandle>,
+    initial_cost: Option<f64>,
+) -> SessionRef {
     let pending = PendingState::default();
     // Without form elicitation the question tool would spin forever waiting
     // for a TUI that does not exist, so it is dropped and the model asks in
@@ -340,15 +338,15 @@ fn spawn_session(
     } else {
         (vec![QUESTION_TOOL_NAME], LocalTools::default())
     };
-    let handle = headless::spawn_interactive(InteractiveParams {
+    let (handle, events) = headless::spawn_interactive(InteractiveParams {
         model: params.model.clone(),
         config: params.config.clone(),
         permissions_config: params.permissions_config.clone(),
         timeouts: params.timeouts,
         prompt_slots: Arc::clone(&params.prompt_slots),
         excluded_tools,
-        mcp_handle,
-        initial_wd: cwd,
+        mcp_handle: mcp.clone(),
+        initial_wd: cwd.clone(),
         session_id,
         initial_history: history,
         yolo: params.yolo,
@@ -359,7 +357,25 @@ fn spawn_session(
         plugin_rules: Arc::clone(&params.plugin_rules),
         local_tools,
     });
-    (handle, pending)
+    let session_ref = handle.session_id.clone();
+    start_event_pump(
+        events,
+        session_ref.clone(),
+        srv.out_tx.clone(),
+        Arc::clone(&pending),
+        cwd,
+        maki_storage::paths::home(),
+        initial_cost,
+    )
+    .detach();
+    srv.session = Some(SessionState {
+        handle,
+        mcp,
+        current_mode: AgentMode::Build,
+        current_model: params.model.spec(),
+        pending,
+    });
+    session_ref
 }
 
 /// Sends a request the client must answer and records it as the outstanding
@@ -508,33 +524,6 @@ async fn close_session(srv: &mut Server, reason: SessionEndReason) {
     if let Some(mcp) = state.mcp {
         mcp.shutdown().await;
     }
-}
-
-fn install_session(
-    srv: &mut Server,
-    handle: InteractiveHandle,
-    mcp: Option<McpHandle>,
-    current_model: String,
-    pending: PendingState,
-    cwd: PathBuf,
-    initial_cost: Option<f64>,
-) {
-    start_event_pump(
-        handle.event_rx.clone(),
-        handle.session_id.clone(),
-        srv.out_tx.clone(),
-        Arc::clone(&pending),
-        cwd,
-        maki_storage::paths::home(),
-        initial_cost,
-    );
-    srv.session = Some(SessionState {
-        handle,
-        mcp,
-        current_mode: AgentMode::Build,
-        current_model,
-        pending,
-    });
 }
 
 #[derive(Debug)]
@@ -753,21 +742,21 @@ fn image_media_type(mime: &str) -> ImageMediaType {
 }
 
 fn start_event_pump(
-    event_rx: Receiver<Envelope>,
+    mut events: SessionEvents,
     session_id: SessionRef,
     out_tx: Sender<Value>,
     pending: PendingState,
     cwd: PathBuf,
     home: Option<PathBuf>,
     initial_cost: Option<f64>,
-) {
+) -> Task<()> {
     smol::spawn(async move {
         let sid = SessionId::from(session_id.to_string());
         let mut cost_total = initial_cost;
 
-        while let Ok(Envelope {
+        while let Some(Envelope {
             event, subagent, ..
-        }) = event_rx.recv_async().await
+        }) = events.next().await
         {
             // Subagent stream events stay out of the transcript, but their
             // turns still spend session money.
@@ -822,7 +811,6 @@ fn start_event_pump(
             session_update(&out_tx, &sid, update);
         }
     })
-    .detach();
 }
 
 fn send(out_tx: &Sender<Value>, msg: impl Serialize) {
@@ -859,6 +847,7 @@ fn json_str(e: &impl std::fmt::Display) -> Value {
 #[cfg(test)]
 mod tests {
     use maki_agent::permissions::PermissionManager;
+    use maki_agent::{DoneReason, SubagentInfo, TurnCompleteEvent};
     use maki_providers::{ContentBlock as MsgBlock, Role, TokenUsage};
     use maki_storage::StateDir;
     use maki_storage::sessions::Session;
@@ -893,11 +882,10 @@ mod tests {
         assert_eq!(permission_answer(&raw), expected);
     }
 
-    fn server_with_ask(kind: AskKind) -> (Server, Receiver<String>, Receiver<Value>) {
+    fn server_with_ask(kind: AskKind) -> (Server, flume::Receiver<String>, flume::Receiver<Value>) {
         let (answer_tx, answer_rx) = flume::unbounded();
         let (out_tx, out_rx) = flume::unbounded();
         let handle = InteractiveHandle {
-            event_rx: flume::unbounded().1,
             tool_names: Vec::new(),
             input_tx: flume::unbounded().0,
             answer_tx,
@@ -929,6 +917,125 @@ mod tests {
             }),
         };
         (server, answer_rx, out_rx)
+    }
+
+    const PUMP_CWD: &str = "/project";
+    const QUEUED_TEXT: &str = "queued before close";
+    const PROMPT_ID: i64 = 7;
+    const SUBAGENT_COST: f64 = 0.25;
+    const TURN_COST: f64 = 0.5;
+    const CONTEXT_WINDOW: u32 = 200_000;
+    const PARENT_TOOL_USE_ID: &str = "toolu_1";
+    const SUBAGENT_NAME: &str = "task";
+
+    fn spawn_pump(srv: &Server, events: SessionEvents, initial_cost: Option<f64>) -> Task<()> {
+        let session = srv.session.as_ref().expect("a session is installed");
+        start_event_pump(
+            events,
+            session.handle.session_id.clone(),
+            srv.out_tx.clone(),
+            Arc::clone(&session.pending),
+            PathBuf::from(PUMP_CWD),
+            None,
+            initial_cost,
+        )
+    }
+
+    fn turn_complete(cost: f64) -> Box<TurnCompleteEvent> {
+        Box::new(TurnCompleteEvent {
+            message: Message::user(String::new()),
+            usage: TokenUsage::default(),
+            model: SELECTED_SPEC.to_owned(),
+            cost: Some(cost),
+            context_size: None,
+            context_window: CONTEXT_WINDOW,
+        })
+    }
+
+    /// The close marker rides the same FIFO as the events, so a turn that was
+    /// still streaming when the session got replaced is reported in full and
+    /// the client's outstanding `session/prompt` is answered instead of
+    /// hanging. `sender` outliving the guard is the ACP leak: a Lua tool
+    /// context parks a clone that an idle VM never collects, so a pump keyed
+    /// off sender disconnect would block here forever.
+    #[test]
+    fn event_pump_delivers_everything_queued_before_the_close() {
+        let (srv, .., out_rx) = server_with_ask(AskKind::Permission);
+        let pending = Arc::clone(&srv.session.as_ref().unwrap().pending);
+        pending.lock().unwrap().prompt = Some(RequestId::Number(PROMPT_ID));
+        let (guard, events) = maki_agent::event_stream();
+        let sender = guard.sender(0);
+        let pump = spawn_pump(&srv, events, None);
+
+        sender
+            .send(AgentEvent::TextDelta {
+                text: QUEUED_TEXT.to_owned(),
+            })
+            .unwrap();
+        sender
+            .send(AgentEvent::Done {
+                usage: TokenUsage::default(),
+                cost: None,
+                list_cost: None,
+                context_size: 0,
+                context_window: CONTEXT_WINDOW,
+                num_turns: 1,
+                reason: DoneReason::EndTurn,
+            })
+            .unwrap();
+        drop(guard);
+        smol::block_on(pump);
+
+        let chunk = out_rx.try_recv().expect("the queued text reaches the wire");
+        let update = &chunk["params"]["update"];
+        assert_eq!(update["sessionUpdate"], "agent_message_chunk");
+        assert_eq!(update["content"]["text"], QUEUED_TEXT);
+
+        let answer = out_rx.try_recv().expect("the pending prompt is answered");
+        assert_eq!(answer["id"], PROMPT_ID);
+        assert_eq!(answer["result"]["stopReason"], "end_turn");
+        assert!(pending.lock().unwrap().prompt.is_none());
+    }
+
+    /// A resumed session opens with a bill, and subagent turns spend against it
+    /// even though their events never enter the transcript.
+    #[test]
+    fn event_pump_folds_restored_and_subagent_cost_into_the_usage_update() {
+        let (srv, .., out_rx) = server_with_ask(AskKind::Permission);
+        let (guard, events) = maki_agent::event_stream();
+        let sender = guard.sender(0);
+        let pump = spawn_pump(&srv, events, Some(RECORDED_COST));
+
+        sender
+            .send_envelope(Envelope {
+                event: AgentEvent::TurnComplete(turn_complete(SUBAGENT_COST)),
+                subagent: Some(SubagentInfo {
+                    parent_tool_use_id: PARENT_TOOL_USE_ID.to_owned(),
+                    name: SUBAGENT_NAME.to_owned(),
+                    prompt: None,
+                    model: None,
+                    answer_tx: None,
+                }),
+                run_id: 0,
+            })
+            .unwrap();
+        sender
+            .send(AgentEvent::TurnComplete(turn_complete(TURN_COST)))
+            .unwrap();
+        drop(guard);
+        smol::block_on(pump);
+
+        let usage = out_rx.try_recv().expect("the session's own turn reports");
+        let update = &usage["params"]["update"];
+        assert_eq!(update["sessionUpdate"], "usage_update");
+        assert_eq!(
+            update["cost"]["amount"].as_f64(),
+            Some(RECORDED_COST + SUBAGENT_COST + TURN_COST)
+        );
+        assert!(
+            out_rx.is_empty(),
+            "the subagent turn pays but stays out of the transcript"
+        );
     }
 
     #[test]

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -1,8 +1,9 @@
+use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_lock::Mutex;
-use flume::Receiver;
 use maki_config::ModelPolicy;
 use maki_providers::Message;
 use maki_providers::Timeouts;
@@ -22,10 +23,12 @@ use crate::prompt::ResolvedSlots;
 use crate::template;
 use crate::tools::{FileAccess, LocalTools, RequestTools, ToolAudience, ToolRegistry};
 use crate::{
-    Agent, AgentConfig, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams, Envelope,
-    EventSender, ImageSource, McpHandle, McpSession, PermissionsConfig, RunLedger, SessionMailbox,
-    ToolOutput, ToolOutputLines,
+    Agent, AgentConfig, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams,
+    EventStreamGuard, ImageSource, McpHandle, McpSession, PermissionsConfig, RunLedger,
+    SessionEvents, SessionMailbox, ToolOutput, ToolOutputLines, event_stream,
 };
+
+const SESSION_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 type StoredSession = Session<Message, TokenUsage, ToolOutput>;
 
@@ -87,7 +90,6 @@ pub struct HeadlessParams {
 }
 
 pub struct HeadlessHandle {
-    pub event_rx: Receiver<Envelope>,
     pub tool_names: Vec<String>,
     pub session_id: SessionRef,
     pub cwd: String,
@@ -138,7 +140,7 @@ fn advertised_tool_names(tools: &Value, mcp: Option<&McpSession>) -> Vec<String>
     extract_tool_names(&probe)
 }
 
-pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
+pub fn spawn(params: HeadlessParams) -> (HeadlessHandle, SessionEvents) {
     let working_dir = params.initial_wd.to_string_lossy().into_owned();
     let mode = AgentMode::Build;
     let AgentSetup {
@@ -164,7 +166,8 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
     let mcp = params.mcp_handle.clone().map(|h| McpSession::new(h, &[]));
     let tool_names = advertised_tool_names(tools.definitions(), mcp.as_ref());
 
-    let (raw_tx, event_rx) = flume::unbounded::<Envelope>();
+    let (guard, events) = event_stream();
+    let event_tx = guard.sender(0);
 
     let session_id = MakiId::generate();
     let session_ref = SessionRef::from(session_id);
@@ -172,91 +175,85 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
     let mailbox = SessionMailbox::register(session_id);
     let fast = params.fast;
     let workflow = params.workflow;
-    let task = smol::spawn({
-        let mcp_shutdown = params.mcp_handle.clone();
-        let working_dir_path = params.initial_wd.clone();
-        async move {
-            let event_tx = EventSender::new(raw_tx, 0);
-            let mut model = params.model;
-            let provider: Arc<dyn Provider> =
-                match provider::from_model_async(&mut model, params.timeouts).await {
-                    Ok(p) => Arc::from(p),
-                    Err(e) => {
-                        error!(error = %e, "provider error");
-                        let _ = event_tx.send(AgentEvent::Error {
-                            message: e.user_message(),
-                        });
-                        return;
-                    }
-                };
-            let error_tx = event_tx.clone();
-            let mut history = History::new(Vec::new());
-            let mut agent = Agent::new(
-                AgentParams {
-                    provider,
-                    model,
-                    config: params.config,
-                    tool_output_lines: ToolOutputLines::default(),
-                    permissions: Arc::new(PermissionManager::new(
-                        params.permissions_config,
-                        working_dir_path,
-                        params.plugin_rules,
-                    )),
-                    session_id: Some(session_ref_clone.clone()),
-                    mailbox: Some(mailbox.clone()),
-                    timeouts: params.timeouts,
-                    file_access: FileAccess::fresh(),
-                    prompt_slots: Arc::new(params.prompt_slots),
-                    subagent_cancels: Arc::new(CancelMap::new()),
-                    ledger: Arc::new(RunLedger::default()),
-                    registry: Arc::clone(ToolRegistry::global_arc()),
-                    audience: ToolAudience::MAIN,
-                    model_policy: Arc::clone(&params.model_policy),
-                },
-                AgentRunParams {
-                    history: &mut history,
-                    system,
-                    event_tx,
-                    tools,
-                },
-            )
-            .with_loaded_instructions(instructions.loaded)
-            .with_mcp(mcp);
+    let working_dir_path = params.initial_wd.clone();
+    let task = smol::spawn(run_session(guard, params.mcp_handle.clone(), async move {
+        let mut model = params.model;
+        let provider: Arc<dyn Provider> =
+            match provider::from_model_async(&mut model, params.timeouts).await {
+                Ok(p) => Arc::from(p),
+                Err(e) => {
+                    error!(error = %e, "provider error");
+                    let _ = event_tx.send(AgentEvent::Error {
+                        message: e.user_message(),
+                    });
+                    return;
+                }
+            };
+        let error_tx = event_tx.clone();
+        let mut history = History::new(Vec::new());
+        let mut agent = Agent::new(
+            AgentParams {
+                provider,
+                model,
+                config: params.config,
+                tool_output_lines: ToolOutputLines::default(),
+                permissions: Arc::new(PermissionManager::new(
+                    params.permissions_config,
+                    working_dir_path,
+                    params.plugin_rules,
+                )),
+                session_id: Some(session_ref_clone.clone()),
+                mailbox: Some(mailbox.clone()),
+                timeouts: params.timeouts,
+                file_access: FileAccess::fresh(),
+                prompt_slots: Arc::new(params.prompt_slots),
+                subagent_cancels: Arc::new(CancelMap::new()),
+                ledger: Arc::new(RunLedger::default()),
+                registry: Arc::clone(ToolRegistry::global_arc()),
+                audience: ToolAudience::MAIN,
+                model_policy: Arc::clone(&params.model_policy),
+            },
+            AgentRunParams {
+                history: &mut history,
+                system,
+                event_tx,
+                tools,
+            },
+        )
+        .with_loaded_instructions(instructions.loaded)
+        .with_mcp(mcp);
 
-            let result = agent
-                .run(AgentInput {
-                    message: params.prompt,
-                    mode,
-                    images: params.images,
-                    preamble: Vec::new(),
-                    thinking: Default::default(),
-                    fast,
-                    workflow,
-                    prompt: None,
-                })
-                .await;
-            drop(agent);
+        let result = agent
+            .run(AgentInput {
+                message: params.prompt,
+                mode,
+                images: params.images,
+                preamble: Vec::new(),
+                thinking: Default::default(),
+                fast,
+                workflow,
+                prompt: None,
+            })
+            .await;
+        drop(agent);
 
-            if let Err(e) = result {
-                error!(error = %e, "agent error");
-                let _ = error_tx.send(AgentEvent::Error {
-                    message: e.user_message(),
-                });
-            }
-
-            if let Some(handle) = mcp_shutdown {
-                handle.shutdown().await;
-            }
+        if let Err(e) = result {
+            error!(error = %e, "agent error");
+            let _ = error_tx.send(AgentEvent::Error {
+                message: e.user_message(),
+            });
         }
-    });
+    }));
 
-    HeadlessHandle {
-        event_rx,
-        tool_names,
-        session_id: session_ref,
-        cwd: working_dir,
-        task,
-    }
+    (
+        HeadlessHandle {
+            tool_names,
+            session_id: session_ref,
+            cwd: working_dir,
+            task,
+        },
+        events,
+    )
 }
 
 pub struct InteractiveParams {
@@ -282,7 +279,6 @@ pub struct InteractiveParams {
 }
 
 pub struct InteractiveHandle {
-    pub event_rx: Receiver<Envelope>,
     pub tool_names: Vec<String>,
     pub input_tx: flume::Sender<AgentInput>,
     pub answer_tx: flume::Sender<String>,
@@ -293,7 +289,7 @@ pub struct InteractiveHandle {
     pub task: smol::Task<()>,
 }
 
-pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
+pub fn spawn_interactive(params: InteractiveParams) -> (InteractiveHandle, SessionEvents) {
     let AgentSetup {
         vars,
         instructions,
@@ -312,7 +308,8 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
         .map(|h| McpSession::new(h, &params.initial_history));
     let tool_names = advertised_tool_names(tools.definitions(), mcp.as_ref());
 
-    let (raw_tx, event_rx) = flume::unbounded::<Envelope>();
+    let (guard, events) = event_stream();
+    let base_tx = guard.sender(0);
     let (input_tx, input_rx) = flume::unbounded::<AgentInput>();
     let (answer_tx, answer_rx) = flume::unbounded::<String>();
     let (cancel_tx, cancel_rx) = flume::bounded::<()>(1);
@@ -340,158 +337,179 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
     let file_access = FileAccess::fresh();
 
     let session_ref_clone = session_ref.clone();
-    let task = smol::spawn({
-        let permissions = Arc::clone(&permissions);
-        async move {
-            let mut model = params.model;
-            let mut provider: Arc<dyn Provider> =
-                match provider::from_model_async(&mut model, params.timeouts).await {
-                    Ok(p) => Arc::from(p),
-                    Err(e) => {
-                        error!(error = %e, "provider error");
-                        let _ = EventSender::new(raw_tx, 0).send(AgentEvent::Error {
-                            message: e.user_message(),
-                        });
-                        return;
-                    }
-                };
-
-            let mut store = SessionStore::open(session_id, &working_dir, &model.spec());
-            let mut history = History::restored(params.initial_history);
-            let mut run_id: u64 = 0;
-
-            while let Ok(input) = input_rx.recv_async().await {
-                let (trigger, cancel) = CancelToken::new();
-                let cancel_task = smol::spawn({
-                    let cancel_rx = cancel_rx.clone();
-                    async move {
-                        if cancel_rx.recv_async().await.is_ok() {
-                            trigger.cancel();
-                        }
-                    }
-                });
-
-                // MCP connects in the background, so a prompt that beats it waits
-                // here instead of shipping a turn without the MCP tools. The wait
-                // is racing cancel: a slow server must not pin the whole session.
-                if let Some(mcp) = &mcp {
-                    let _ = cancel.race(mcp.ready()).await;
-                }
-
-                let event_tx = EventSender::new(raw_tx.clone(), run_id);
-                let error_tx = event_tx.clone();
-
-                if let Some(mut new_model) = model_rx
-                    .try_iter()
-                    .last()
-                    .filter(|candidate| params.model_policy.allows(&candidate.spec()))
-                    && new_model.spec() != model.spec()
-                {
-                    match provider::from_model_async(&mut new_model, params.timeouts).await {
-                        Ok(p) => {
-                            provider = Arc::from(p);
-                            tools = RequestTools::build(
-                                ToolRegistry::global(),
-                                &vars,
-                                &new_model,
-                                &params.config,
-                                &params.excluded_tools,
-                                params.workflow,
-                                mcp.is_some(),
-                            );
-                            model = new_model;
-                        }
-                        Err(e) => {
-                            error!(error = %e, "provider error");
-                            let _ = error_tx.send(AgentEvent::Error {
-                                message: e.user_message(),
-                            });
-                            run_id += 1;
-                            continue;
-                        }
-                    }
-                }
-
-                let mut system = params.system_prompt_override.clone().unwrap_or_else(|| {
-                    agent::build_system_prompt(
-                        &vars,
-                        &input.mode,
-                        &instructions.text,
-                        &params.prompt_slots,
-                        &model,
-                    )
-                });
-                if let Some(append) = &params.append_system_prompt {
-                    system.push('\n');
-                    system.push_str(append);
-                }
-
-                while answer_rx.lock().await.try_recv().is_ok() {}
-
-                let mut agent = Agent::new(
-                    AgentParams {
-                        provider: Arc::clone(&provider),
-                        model: model.clone(),
-                        config: params.config.clone(),
-                        tool_output_lines: ToolOutputLines::default(),
-                        permissions: Arc::clone(&permissions),
-                        session_id: Some(session_ref_clone.clone()),
-                        mailbox: Some(mailbox.clone()),
-                        timeouts: params.timeouts,
-                        file_access: Arc::clone(&file_access),
-                        prompt_slots: Arc::clone(&params.prompt_slots),
-                        subagent_cancels: Arc::new(CancelMap::new()),
-                        ledger: Arc::new(RunLedger::default()),
-                        registry: Arc::clone(ToolRegistry::global_arc()),
-                        audience: ToolAudience::MAIN,
-                        model_policy: Arc::clone(&params.model_policy),
-                    },
-                    AgentRunParams {
-                        history: &mut history,
-                        system,
-                        event_tx,
-                        tools: tools.clone(),
-                    },
-                )
-                .with_loaded_instructions(instructions.loaded.clone())
-                .with_user_response_rx(Arc::clone(&answer_rx))
-                .with_cancel(cancel)
-                .with_local_tools(Arc::clone(&params.local_tools))
-                .with_mcp(mcp.clone());
-
-                let result = agent.run(input).await;
-                drop(agent);
-                cancel_task.cancel().await;
-
-                if let Err(ref e) = result {
-                    error!(error = %e, "agent error");
-                    let _ = error_tx.send(AgentEvent::Error {
+    let task_permissions = Arc::clone(&permissions);
+    let task = smol::spawn(run_session(guard, params.mcp_handle.clone(), async move {
+        let mut model = params.model;
+        let mut provider: Arc<dyn Provider> =
+            match provider::from_model_async(&mut model, params.timeouts).await {
+                Ok(p) => Arc::from(p),
+                Err(e) => {
+                    error!(error = %e, "provider error");
+                    let _ = base_tx.send(AgentEvent::Error {
                         message: e.user_message(),
                     });
+                    return;
                 }
+            };
 
-                if let Some(store) = &mut store {
-                    store.record_turn(history.as_slice(), model.spec());
+        let mut store = SessionStore::open(session_id, &working_dir, &model.spec());
+        let mut history = History::restored(params.initial_history);
+        let mut run_id: u64 = 0;
+
+        while let Ok(input) = input_rx.recv_async().await {
+            let (trigger, cancel) = CancelToken::new();
+            let cancel_task = smol::spawn({
+                let cancel_rx = cancel_rx.clone();
+                async move {
+                    if cancel_rx.recv_async().await.is_ok() {
+                        trigger.cancel();
+                    }
                 }
-                run_id += 1;
+            });
+
+            // MCP connects in the background, so a prompt that beats it waits
+            // here instead of shipping a turn without the MCP tools. The wait
+            // is racing cancel: a slow server must not pin the whole session.
+            if let Some(mcp) = &mcp {
+                let _ = cancel.race(mcp.ready()).await;
             }
 
-            if let Some(handle) = params.mcp_handle {
-                handle.shutdown().await;
+            let event_tx = base_tx.with_run_id(run_id);
+            let error_tx = event_tx.clone();
+
+            if let Some(mut new_model) = model_rx
+                .try_iter()
+                .last()
+                .filter(|candidate| params.model_policy.allows(&candidate.spec()))
+                && new_model.spec() != model.spec()
+            {
+                match provider::from_model_async(&mut new_model, params.timeouts).await {
+                    Ok(p) => {
+                        provider = Arc::from(p);
+                        tools = RequestTools::build(
+                            ToolRegistry::global(),
+                            &vars,
+                            &new_model,
+                            &params.config,
+                            &params.excluded_tools,
+                            params.workflow,
+                            mcp.is_some(),
+                        );
+                        model = new_model;
+                    }
+                    Err(e) => {
+                        error!(error = %e, "provider error");
+                        let _ = error_tx.send(AgentEvent::Error {
+                            message: e.user_message(),
+                        });
+                        run_id += 1;
+                        continue;
+                    }
+                }
             }
+
+            let mut system = params.system_prompt_override.clone().unwrap_or_else(|| {
+                agent::build_system_prompt(
+                    &vars,
+                    &input.mode,
+                    &instructions.text,
+                    &params.prompt_slots,
+                    &model,
+                )
+            });
+            if let Some(append) = &params.append_system_prompt {
+                system.push('\n');
+                system.push_str(append);
+            }
+
+            while answer_rx.lock().await.try_recv().is_ok() {}
+
+            let mut agent = Agent::new(
+                AgentParams {
+                    provider: Arc::clone(&provider),
+                    model: model.clone(),
+                    config: params.config.clone(),
+                    tool_output_lines: ToolOutputLines::default(),
+                    permissions: Arc::clone(&task_permissions),
+                    session_id: Some(session_ref_clone.clone()),
+                    mailbox: Some(mailbox.clone()),
+                    timeouts: params.timeouts,
+                    file_access: Arc::clone(&file_access),
+                    prompt_slots: Arc::clone(&params.prompt_slots),
+                    subagent_cancels: Arc::new(CancelMap::new()),
+                    ledger: Arc::new(RunLedger::default()),
+                    registry: Arc::clone(ToolRegistry::global_arc()),
+                    audience: ToolAudience::MAIN,
+                    model_policy: Arc::clone(&params.model_policy),
+                },
+                AgentRunParams {
+                    history: &mut history,
+                    system,
+                    event_tx,
+                    tools: tools.clone(),
+                },
+            )
+            .with_loaded_instructions(instructions.loaded.clone())
+            .with_user_response_rx(Arc::clone(&answer_rx))
+            .with_cancel(cancel)
+            .with_local_tools(Arc::clone(&params.local_tools))
+            .with_mcp(mcp.clone());
+
+            let result = agent.run(input).await;
+            drop(agent);
+            cancel_task.cancel().await;
+
+            if let Err(ref e) = result {
+                error!(error = %e, "agent error");
+                let _ = error_tx.send(AgentEvent::Error {
+                    message: e.user_message(),
+                });
+            }
+
+            if let Some(store) = &mut store {
+                store.record_turn(history.as_slice(), model.spec());
+            }
+            run_id += 1;
         }
-    });
+    }));
 
-    InteractiveHandle {
-        event_rx,
-        tool_names,
-        input_tx,
-        answer_tx,
-        cancel_tx,
-        model_tx,
-        session_id: session_ref,
-        permissions,
-        task,
+    (
+        InteractiveHandle {
+            tool_names,
+            input_tx,
+            answer_tx,
+            cancel_tx,
+            model_tx,
+            session_id: session_ref,
+            permissions,
+            task,
+        },
+        events,
+    )
+}
+
+/// Waits for a session task that has nothing left to do but tear MCP down,
+/// dropping it if that wedges. Safe to bound: the event stream already ended
+/// (see [`run_session`]), and dropping the task cannot resurrect it.
+pub async fn await_shutdown(task: smol::Task<()>) {
+    futures_lite::future::or(task, async {
+        smol::Timer::after(SESSION_SHUTDOWN_TIMEOUT).await;
+    })
+    .await;
+}
+
+/// Runs a session body, ends its event stream, then tears MCP down. The stream
+/// ends with the run and not with teardown: a wedged shutdown must not keep a
+/// consumer waiting for events that can no longer come.
+async fn run_session(
+    guard: EventStreamGuard,
+    mcp_handle: Option<McpHandle>,
+    body: impl Future<Output = ()>,
+) {
+    body.await;
+    drop(guard);
+    if let Some(handle) = mcp_handle {
+        handle.shutdown().await;
     }
 }
 
@@ -508,14 +526,26 @@ fn extract_tool_names(tools: &Value) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::pin::pin;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use futures_lite::future::poll_once;
     use maki_storage::sessions::generate_title;
     use tempfile::TempDir;
 
     use super::*;
+    use crate::mcp::McpCommand;
 
     const SESSION_ID: &str = "01965087-4c71-7f00-8000-000000000000";
     const CWD: &str = "/project";
     const MODEL_SPEC: &str = "anthropic/claude-test";
+    const RUN_ID: u64 = 7;
+    const STREAM_ENDED: &str = "the stream must end with the run, not with teardown";
+    const SHUTDOWN_WEDGED: &str = "the MCP shutdown must still be waiting for its ack";
+    const PROVIDER_ERROR: &str = "provider error";
+    const BODY_EVENT: &str = "the body's event must be delivered before the close";
+    const STILL_WORKING: &str = "await_shutdown must not return while the task still works";
+    const TASK_DROPPED: &str = "await_shutdown dropped a task that had work left";
 
     fn session_id() -> MakiId {
         SESSION_ID.parse().unwrap()
@@ -618,5 +648,75 @@ mod tests {
             "probing must not bake MCP entries into the base tools"
         );
         assert_eq!(advertised_tool_names(&base, None), vec!["read"]);
+    }
+
+    /// The ordering the SDK exit rests on: the stream ends when the run ends,
+    /// not when MCP teardown does. The handle here takes the `Shutdown` and
+    /// never acks it, so the session future is still parked on its own timeout
+    /// while the consumer already has the body's error and the end of the
+    /// stream. The retained sender is the Lua tool context an idle VM never
+    /// collects.
+    #[test]
+    fn stream_ends_with_the_run_not_with_mcp_teardown() {
+        let (guard, mut events) = event_stream();
+        let retained = guard.sender(RUN_ID);
+        let event_tx = retained.clone();
+        let (cmd_tx, cmd_rx) = flume::unbounded();
+        smol::block_on(async {
+            let mut session = pin!(run_session(
+                guard,
+                Some(McpHandle::for_test(cmd_tx)),
+                async move {
+                    let _ = event_tx.send(AgentEvent::Error {
+                        message: PROVIDER_ERROR.into(),
+                    });
+                }
+            ));
+            assert!(
+                poll_once(session.as_mut()).await.is_none(),
+                "{SHUTDOWN_WEDGED}"
+            );
+            assert!(
+                matches!(cmd_rx.try_recv(), Ok(McpCommand::Shutdown { .. })),
+                "{SHUTDOWN_WEDGED}"
+            );
+            let envelope = events.next().await.expect(BODY_EVENT);
+            assert!(matches!(
+                envelope.event,
+                AgentEvent::Error { message } if message == PROVIDER_ERROR
+            ));
+            assert!(
+                matches!(poll_once(events.next()).await, Some(None)),
+                "{STREAM_ENDED}"
+            );
+        });
+        assert!(retained.send(AgentEvent::Nudge).is_ok());
+    }
+
+    /// `await_shutdown` bounds teardown, not the session: a task with work left
+    /// runs to completion. Dropping it here would cancel prompts stdin already
+    /// queued.
+    #[test]
+    fn await_shutdown_waits_for_a_task_that_still_works() {
+        let (release_tx, release_rx) = flume::bounded::<()>(1);
+        let finished = Arc::new(AtomicBool::new(false));
+        let task = smol::spawn({
+            let finished = Arc::clone(&finished);
+            async move {
+                let _ = release_rx.recv_async().await;
+                finished.store(true, Ordering::SeqCst);
+            }
+        });
+
+        smol::block_on(async {
+            let mut shutdown = pin!(await_shutdown(task));
+            assert!(
+                poll_once(shutdown.as_mut()).await.is_none(),
+                "{STILL_WORKING}"
+            );
+            release_tx.send(()).unwrap();
+            shutdown.await;
+        });
+        assert!(finished.load(Ordering::SeqCst), "{TASK_DROPPED}");
     }
 }

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -37,10 +37,11 @@ pub use maki_providers::AgentError;
 use maki_providers::Message;
 pub use maki_providers::{EMPTY_RESPONSE_MARKER, ImageMediaType, ImageSource, ThinkingConfig};
 pub use types::{
-    AgentEvent, BufferSnapshot, DoneReason, Envelope, EventSender, GrepFileEntry, GrepLine,
-    GrepMatchGroup, InstructionBlock, NO_FILES_FOUND, RunLedger, RunTotals, SessionEndReason,
-    SharedBuf, SnapshotLine, SnapshotSpan, SpanColor, SpanStyle, SubagentInfo, TextOutput,
-    ToolDoneEvent, ToolInput, ToolOutput, ToolStartEvent, TurnCompleteEvent,
+    AgentEvent, BufferSnapshot, DoneReason, Envelope, EventSender, EventStreamGuard, GrepFileEntry,
+    GrepLine, GrepMatchGroup, InstructionBlock, NO_FILES_FOUND, RunLedger, RunTotals,
+    SessionEndReason, SessionEvents, SharedBuf, SnapshotLine, SnapshotSpan, SpanColor, SpanStyle,
+    SubagentInfo, TextOutput, ToolDoneEvent, ToolInput, ToolOutput, ToolStartEvent,
+    TurnCompleteEvent, event_stream,
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]

--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -595,6 +595,19 @@ impl McpHandle {
             warn!("MCP shutdown timed out after {MCP_SHUTDOWN_TIMEOUT:?}");
         }
     }
+
+    /// Handle whose command loop is whatever the caller does with `cmd_rx`,
+    /// so a test can hold a `Shutdown` unacked and observe a wedged teardown.
+    #[cfg(test)]
+    pub(crate) fn for_test(cmd_tx: flume::Sender<McpCommand>) -> Self {
+        Self {
+            cmd_tx,
+            index: Arc::new(ArcSwap::from_pointee(ToolIndex::default())),
+            snapshot: Arc::new(ArcSwap::from_pointee(McpSnapshot::default())),
+            defer_tools: 0,
+            ready_rx: flume::bounded(0).1,
+        }
+    }
 }
 
 /// Returns as soon as the config is read, so nothing with a screen waits on a

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 
-use flume::Sender;
+use flume::{Receiver, Sender};
 use maki_config::ToolKey;
 use maki_providers::{AgentError, ContentBlock, Message, Role, StopReason, TokenUsage, add_cost};
 use serde::de::Deserializer;
@@ -684,6 +684,10 @@ pub enum AgentEvent {
         total: u32,
         cache: u32,
     },
+    /// End of a session's event stream. Emitted only by
+    /// [`EventStreamGuard::drop`] and swallowed by [`SessionEvents::next`], so
+    /// a consumer sees `None` and never this variant.
+    StreamClosed,
 }
 
 /// Append-only buffer for streaming tool output to the UI. Writers append
@@ -1037,8 +1041,13 @@ impl EventSender {
         self.run_id
     }
 
-    pub fn raw_tx(&self) -> &Sender<Envelope> {
-        &self.tx
+    /// Same stream, different run. Lets a session body stamp per-turn ids
+    /// without keeping the [`EventStreamGuard`] in scope.
+    pub fn with_run_id(&self, run_id: u64) -> Self {
+        Self {
+            tx: self.tx.clone(),
+            run_id,
+        }
     }
 }
 
@@ -1051,9 +1060,82 @@ pub struct Envelope {
     pub run_id: u64,
 }
 
+/// The only way to create a session event stream.
+///
+/// Never key a loop off sender disconnect instead: Lua tool contexts retain
+/// [`EventSender`] clones until the VM garbage-collects them, which never
+/// happens on an idle VM.
+pub fn event_stream() -> (EventStreamGuard, SessionEvents) {
+    let (tx, rx) = flume::unbounded();
+    (EventStreamGuard { tx }, SessionEvents { rx, closed: false })
+}
+
+/// Dropping this ends the stream, and it is the only thing that does. Handing
+/// out [`EventSender`]s is free, none of them extend it.
+///
+/// Nothing here bounds *when* the drop happens, that is the owner's job. An
+/// owner that parks the guard in a struct (the Lua subagent session does) is
+/// promising that the struct dies on a path it controls, not on a garbage
+/// collector's schedule.
+#[derive(Debug)]
+pub struct EventStreamGuard {
+    tx: Sender<Envelope>,
+}
+
+impl EventStreamGuard {
+    pub fn sender(&self, run_id: u64) -> EventSender {
+        EventSender::new(self.tx.clone(), run_id)
+    }
+}
+
+impl Drop for EventStreamGuard {
+    fn drop(&mut self) {
+        let _ = self.tx.try_send(Envelope {
+            event: AgentEvent::StreamClosed,
+            subagent: None,
+            run_id: 0,
+        });
+    }
+}
+
+/// The single reader of a session's stream. Not `Clone`: two readers would
+/// split the terminal item and one of them would wait forever.
+#[derive(Debug)]
+pub struct SessionEvents {
+    rx: Receiver<Envelope>,
+    /// Kept instead of dropping `rx`, so a retained [`EventSender`] still
+    /// reports success: the stream ends because the marker said so, never
+    /// because a sender happened to notice a dead channel.
+    closed: bool,
+}
+
+impl SessionEvents {
+    /// `None` once the stream closed, forever after. The marker rides the same
+    /// FIFO as the events, so everything sent before the guard dropped is
+    /// delivered first and everything sent after it is lost. That is why a
+    /// session drops its guard only once the run returned and history landed.
+    ///
+    /// Cancel-safe: the only suspension point is flume's `recv_async`, which
+    /// leaves a queued envelope in the queue when dropped.
+    pub async fn next(&mut self) -> Option<Envelope> {
+        if self.closed {
+            return None;
+        }
+        match self.rx.recv_async().await {
+            Ok(envelope) if !matches!(envelope.event, AgentEvent::StreamClosed) => Some(envelope),
+            _ => {
+                self.closed = true;
+                None
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_lite::future::poll_once;
+    use std::pin::pin;
     use test_case::test_case;
 
     #[test_case(ToolOutput::Plain("ok".into()),                      Some("1 lines")     ; "plain_short_annotates")]
@@ -1687,5 +1769,86 @@ mod tests {
             Some(FIRST_COST + SECOND_COST),
             "{ROLLUP_MSG}"
         );
+    }
+
+    const STREAM_RUN_IDS: [u64; 3] = [1, 2, 3];
+    const STILL_PENDING: &str = "an empty stream must not resolve `next()`";
+    const NO_LATE_EVENTS: &str = "events queued after the marker must stay invisible";
+
+    fn drain(events: &mut SessionEvents) -> Vec<u64> {
+        smol::block_on(async {
+            let mut seen = Vec::new();
+            while let Some(envelope) = events.next().await {
+                seen.push(envelope.run_id);
+            }
+            seen
+        })
+    }
+
+    /// The ordering the whole design rests on: the marker rides the same FIFO
+    /// as the events, so nothing queued before it is lost. The first `next()`
+    /// is polled on an empty queue and then dropped, the way a `select!` arm
+    /// in the SDK pump does, and it must not swallow what lands afterwards.
+    #[test]
+    fn queued_events_arrive_in_order_before_the_close() {
+        let (guard, mut events) = event_stream();
+        smol::block_on(async {
+            let mut pending = pin!(events.next());
+            assert!(
+                poll_once(pending.as_mut()).await.is_none(),
+                "{STILL_PENDING}"
+            );
+            for run_id in STREAM_RUN_IDS {
+                guard.sender(run_id).send(AgentEvent::Nudge).unwrap();
+            }
+        });
+        drop(guard);
+        assert_eq!(drain(&mut events), STREAM_RUN_IDS);
+    }
+
+    /// The marker is a point of no return, even for a reader that has not
+    /// polled yet. A Lua tool context parks a sender on an idle VM forever, so
+    /// its late send has to look fine to it and stay invisible to the reader.
+    #[test]
+    fn events_sent_after_the_close_are_never_observed() {
+        let (guard, mut events) = event_stream();
+        let retained = guard.sender(STREAM_RUN_IDS[0]);
+        retained.send(AgentEvent::Nudge).unwrap();
+        drop(guard);
+        retained.send(AgentEvent::Nudge).unwrap();
+        assert_eq!(drain(&mut events), [STREAM_RUN_IDS[0]], "{NO_LATE_EVENTS}");
+        assert!(smol::block_on(events.next()).is_none(), "{NO_LATE_EVENTS}");
+    }
+
+    /// A derived sender is just another clone: it stamps its own run id on the
+    /// same FIFO, and dropping it neither ends nor extends the stream.
+    #[test]
+    fn with_run_id_restamps_without_forking_the_stream() {
+        let (guard, mut events) = event_stream();
+        let original = guard.sender(STREAM_RUN_IDS[0]);
+        let derived = original.with_run_id(STREAM_RUN_IDS[1]);
+        derived.send(AgentEvent::Nudge).unwrap();
+        drop(derived);
+        original.send(AgentEvent::Nudge).unwrap();
+        drop(guard);
+        assert_eq!(
+            drain(&mut events),
+            [STREAM_RUN_IDS[1], STREAM_RUN_IDS[0]],
+            "{NO_LATE_EVENTS}"
+        );
+    }
+
+    /// A consumer that exits first (SDK stdout closed, ACP client gone) leaves
+    /// the guard sending the marker into a dead channel, often while unwinding.
+    #[test]
+    fn dropping_the_guard_after_the_reader_is_harmless() {
+        let (guard, events) = event_stream();
+        let retained = guard.sender(STREAM_RUN_IDS[0]);
+        drop(events);
+        drop(guard);
+        assert!(matches!(
+            retained.send(AgentEvent::Nudge),
+            Err(AgentError::Channel)
+        ));
     }
 }

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -19,8 +19,8 @@ use maki_agent::tools::{
 };
 use maki_agent::{
     Agent, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams, DoneReason,
-    EMPTY_RESPONSE_MARKER, Envelope, EventSender, History, McpSession, RunLedger, SubagentInfo,
-    ToolDoneEvent,
+    EMPTY_RESPONSE_MARKER, EventSender, EventStreamGuard, History, McpSession, RunLedger,
+    SessionEvents, SubagentInfo, ToolDoneEvent, event_stream,
 };
 use maki_lua_macro::{lua_class, lua_fn, lua_table};
 use maki_providers::model::ModelTier;
@@ -82,14 +82,14 @@ fn dispatch_ctx<'a>(ctx: &'a LuaCtx, method: &str) -> Result<&'a AgentContext, S
 /// turn's tokens plus the run's summed cost), and one total per run on
 /// `usage_tx`, which `prompt` waits for.
 async fn relay_session_events(
-    sub_rx: flume::Receiver<Envelope>,
+    mut sub_events: SessionEvents,
     parent_tx: EventSender,
     subagent_info: Arc<OnceLock<SubagentInfo>>,
     usage_tx: flume::Sender<TokenUsage>,
     live_sink: Option<flume::Sender<ToolLive>>,
 ) {
     let mut cost = None;
-    while let Ok(mut envelope) = sub_rx.recv_async().await {
+    while let Some(mut envelope) = sub_events.next().await {
         match &envelope.event {
             AgentEvent::TurnComplete(turn) => {
                 add_cost(&mut cost, turn.cost);
@@ -439,8 +439,11 @@ async fn call_tool(
 ///   name = "researcher",
 /// })
 /// if err then error(err) end
-/// local result = sess:prompt("Summarize this file.")
+///
+/// -- Close before handling the error, so no path leaves the session open.
+/// local result, prompt_err = sess:prompt("Summarize this file.")
 /// sess:close()
+/// if prompt_err then error(prompt_err) end
 #[lua_fn]
 async fn session(
     lua: Lua,
@@ -546,8 +549,8 @@ async fn session(
         None => agent_ctx.opts.thinking,
     };
 
-    let (sub_tx, sub_rx) = flume::unbounded::<Envelope>();
-    let sub_event_tx = EventSender::new(sub_tx, agent_ctx.event_tx.run_id());
+    let (stream_guard, sub_events) = event_stream();
+    let sub_event_tx = stream_guard.sender(agent_ctx.event_tx.run_id());
     let parent_tx = agent_ctx.event_tx.clone();
     let (answer_tx, answer_rx) = flume::unbounded::<String>();
 
@@ -555,7 +558,7 @@ async fn session(
     let (usage_tx, usage_rx) = flume::unbounded();
 
     smol::spawn(relay_session_events(
-        sub_rx,
+        sub_events,
         parent_tx.clone(),
         Arc::clone(&subagent_info),
         usage_tx,
@@ -619,6 +622,7 @@ async fn session(
             .map(McpSession::fresh),
         history: History::new(Vec::new()),
         sub_event_tx,
+        stream_guard: Some(stream_guard),
         child_cancel,
         answer_rx: Arc::new(AsyncMutex::new(answer_rx)),
         answer_tx: Some(answer_tx),
@@ -736,6 +740,10 @@ struct SessionState {
     mcp: Option<McpSession>,
     history: History,
     sub_event_tx: EventSender,
+    /// Dropped on close, which ends the relay task. Tool contexts keep
+    /// [`EventSender`] clones alive past the run, so the relay cannot key off
+    /// sender disconnect.
+    stream_guard: Option<EventStreamGuard>,
     child_cancel: maki_agent::cancel::CancelToken,
     answer_rx: Arc<AsyncMutex<flume::Receiver<String>>>,
     answer_tx: Option<flume::Sender<String>>,
@@ -762,6 +770,7 @@ impl SessionState {
             return;
         }
         self.closed = true;
+        self.stream_guard.take();
         self.parent_cancels.retire(&self.ui_id, self.cancel_slot);
         let messages = std::mem::replace(&mut self.history, History::new(Vec::new())).into_vec();
         let _ = self.parent_event_tx.send(AgentEvent::SubagentHistory {
@@ -928,9 +937,12 @@ async fn prompt(
     Ok((Some(tbl), None))
 }
 
-/// Close the session and flush its history back to the parent agent. You can
-/// call this multiple times safely. If you forget, it runs automatically when
-/// the session is garbage collected.
+/// Close the session and flush its history back to the parent agent. Calling
+/// it more than once is safe.
+///
+/// Close on every path, error paths included. Dropping the session instead
+/// leaves the work to the Lua garbage collector, which may never run while
+/// the VM sits idle, and the subagent's event relay stays alive until it does.
 ///
 /// @return
 #[lua_fn]
@@ -947,8 +959,11 @@ lua_class! {
     ///
     /// Create one with `maki.agent.session()`, then send messages with
     /// `:prompt()`. The session remembers previous turns, so you can have
-    /// a multi-step conversation. Call `:close()` when you are done, or let
-    /// garbage collection handle it.
+    /// a multi-step conversation.
+    ///
+    /// Always call `:close()` when you are done, on error paths too. The
+    /// garbage collector is a fallback that may never run while the VM sits
+    /// idle, so a session you only drop can stay open for the rest of the run.
     "maki.agent.Session" => LuaSession, SESSION_DOCS [prompt, close]
 }
 
@@ -1014,14 +1029,6 @@ mod tests {
         }
     }
 
-    fn envelope(event: AgentEvent) -> Envelope {
-        Envelope {
-            event,
-            subagent: None,
-            run_id: RUN_ID,
-        }
-    }
-
     fn turn(usage: TokenUsage, cost: f64) -> AgentEvent {
         AgentEvent::TurnComplete(Box::new(TurnCompleteEvent {
             message: Message::default(),
@@ -1033,20 +1040,28 @@ mod tests {
         }))
     }
 
+    fn subagent_info() -> Arc<OnceLock<SubagentInfo>> {
+        let info = Arc::new(OnceLock::new());
+        info.set(SubagentInfo {
+            parent_tool_use_id: PARENT_ID.into(),
+            name: "research".into(),
+            prompt: None,
+            model: None,
+            answer_tx: None,
+        })
+        .unwrap();
+        info
+    }
+
+    /// Dropping the guard is what ends the relay: a Lua tool context keeps a
+    /// sender alive past the run, so disconnect never comes. The forwarded
+    /// count also pins down that the close marker itself stays behind, since
+    /// passing it on would end the *parent's* stream at the first subagent.
     #[test]
     fn relay_session_events_reports_live_usage_and_done_total() {
-        let (sub_tx, sub_rx) = flume::unbounded();
+        let (guard, sub_events) = event_stream();
+        let sub_tx = guard.sender(RUN_ID);
         let (parent_raw_tx, parent_rx) = flume::unbounded();
-        let subagent_info = Arc::new(OnceLock::new());
-        subagent_info
-            .set(SubagentInfo {
-                parent_tool_use_id: PARENT_ID.into(),
-                name: "research".into(),
-                prompt: None,
-                model: None,
-                answer_tx: None,
-            })
-            .unwrap();
         let (usage_tx, usage_rx) = flume::unbounded();
         let (live_tx, live_rx) = flume::unbounded();
 
@@ -1066,14 +1081,14 @@ mod tests {
                 reason: DoneReason::EndTurn,
             },
         ] {
-            sub_tx.send(envelope(event)).unwrap();
+            sub_tx.send(event).unwrap();
         }
-        drop(sub_tx);
+        drop(guard);
 
         smol::block_on(relay_session_events(
-            sub_rx,
+            sub_events,
             EventSender::new(parent_raw_tx, RUN_ID),
-            subagent_info,
+            subagent_info(),
             usage_tx,
             Some(live_tx),
         ));

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -191,7 +191,7 @@ impl Chat {
                     ));
                 }
             }
-            AgentEvent::SubagentHistory { .. } => {}
+            AgentEvent::SubagentHistory { .. } | AgentEvent::StreamClosed => {}
             AgentEvent::LiveToolBuf { id, body } => {
                 self.messages_panel.register_live_buf(id, body);
             }

--- a/plugins/task/init.lua
+++ b/plugins/task/init.lua
@@ -176,10 +176,14 @@ local function handler(input, ctx)
   end
 
   local permit = semaphore:acquire()
+  -- Declared out here so the epilogue closes it on every path: left to the
+  -- garbage collector it keeps the subagent's event relay alive on an idle VM.
+  local sess
 
-  -- pcall so a raised error cannot leak the permit.
+  -- pcall so a raised error cannot leak the permit or the session.
   local ok, out = pcall(function()
-    local sess, sess_err = maki.agent.session(ctx, {
+    local sess_err
+    sess, sess_err = maki.agent.session(ctx, {
       model_spec = model.spec,
       system = system,
       tools = tool_defs,
@@ -210,8 +214,6 @@ local function handler(input, ctx)
       end
     end
 
-    sess:close()
-
     if err then
       -- A result alongside the error means the run was cut short after
       -- streaming some text, and half a transcript beats a bare error.
@@ -233,6 +235,9 @@ local function handler(input, ctx)
     return { llm_output = captured and maki.json.encode(captured) or result.text, format = "markdown" }
   end)
 
+  if sess then
+    sess:close()
+  end
   permit:release()
   if not ok then
     error(out, 0)

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -1279,8 +1279,11 @@ local sess, err = maki.agent.session(ctx, {
   name = "researcher",
 })
 if err then error(err) end
-local result = sess:prompt("Summarize this file.")
+
+-- Close before handling the error, so no path leaves the session open.
+local result, prompt_err = sess:prompt("Summarize this file.")
 sess:close()
+if prompt_err then error(prompt_err) end
 ```
 
 
@@ -1290,8 +1293,11 @@ A subagent session with its own conversation history.
 
 Create one with `maki.agent.session()`, then send messages with
 `:prompt()`. The session remembers previous turns, so you can have
-a multi-step conversation. Call `:close()` when you are done, or let
-garbage collection handle it.
+a multi-step conversation.
+
+Always call `:close()` when you are done, on error paths too. The
+garbage collector is a fallback that may never run while the VM sits
+idle, so a session you only drop can stay open for the rest of the run.
 
 ---
 
@@ -1335,9 +1341,12 @@ print(r.input_tokens .. " input, " .. r.output_tokens .. " output tokens")
 Session:close()
 ```
 
-Close the session and flush its history back to the parent agent. You can
-call this multiple times safely. If you forget, it runs automatically when
-the session is garbage collected.
+Close the session and flush its history back to the parent agent. Calling
+it more than once is safe.
+
+Close on every path, error paths included. Dropping the session instead
+leaves the work to the Lua garbage collector, which may never run while
+the VM sits idle, and the subagent's event relay stays alive until it does.
 
 
 ## maki.async {#maki-async}

--- a/src/print.rs
+++ b/src/print.rs
@@ -10,12 +10,12 @@
 use std::io::{self, Read};
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use clap::ValueEnum;
 use color_eyre::Result;
 use color_eyre::eyre::{Context, eyre};
-use maki_agent::headless::{HeadlessHandle, HeadlessParams};
+use maki_agent::headless::{self, HeadlessHandle, HeadlessParams};
 use maki_agent::permissions::PluginRuleStore;
 use maki_agent::tools::QUESTION_TOOL_NAME;
 use maki_agent::{AgentConfig, AgentEvent, DoneReason, Envelope, ImageSource, PermissionsConfig};
@@ -27,8 +27,6 @@ use maki_providers::{TokenUsage, add_cost};
 use maki_storage::id::SessionRef;
 use serde::Serialize;
 use serde_json::Value;
-
-const AGENT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 // Fails fast: silently dropping an image the caller explicitly attached
 // would be worse than erroring.
@@ -172,7 +170,7 @@ pub fn run(
         eprintln!("MCP config error: {mcp_config_errors}");
     }
 
-    let handle = maki_agent::headless::spawn(HeadlessParams {
+    let (handle, mut events) = maki_agent::headless::spawn(HeadlessParams {
         model: model.clone(),
         config,
         permissions_config,
@@ -190,7 +188,6 @@ pub fn run(
     });
 
     let HeadlessHandle {
-        event_rx,
         tool_names,
         session_id,
         cwd,
@@ -238,7 +235,7 @@ pub fn run(
         || MODE_BUILD,
     );
 
-    while let Ok(envelope) = smol::block_on(event_rx.recv_async()) {
+    while let Some(envelope) = smol::block_on(events.next()) {
         // Folded in first, so a plugin handling `TurnEnd` finds the finished
         // totals when it calls `maki.session.read()`.
         snapshot.observe(&envelope);
@@ -277,7 +274,8 @@ pub fn run(
             | AgentEvent::ToolHeaderSnapshot { .. }
             | AgentEvent::LiveToolBuf { .. }
             | AgentEvent::Nudge
-            | AgentEvent::PromptProgress { .. } => {}
+            | AgentEvent::PromptProgress { .. }
+            | AgentEvent::StreamClosed => {}
             AgentEvent::Retry {
                 attempt,
                 message,
@@ -347,12 +345,7 @@ pub fn run(
             }
         }
     }
-    smol::block_on(async {
-        futures_lite::future::or(task, async {
-            smol::Timer::after(AGENT_SHUTDOWN_TIMEOUT).await;
-        })
-        .await;
-    });
+    smol::block_on(headless::await_shutdown(task));
     lua_handle.end_sessions_blocking([session_id.id()], SessionEndReason::Completed);
 
     let duration_ms = start.elapsed().as_millis();

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -16,7 +16,7 @@ use std::time::Instant;
 
 use color_eyre::Result;
 use color_eyre::eyre::{Context, eyre};
-use flume::{Receiver, Sender};
+use flume::Sender;
 use maki_agent::headless::{self, InteractiveHandle, InteractiveParams};
 use maki_agent::mcp;
 use maki_agent::permissions::{PermissionAnswer, PluginRuleStore};
@@ -24,7 +24,7 @@ use maki_agent::prompt::ResolvedSlots;
 use maki_agent::tools::QUESTION_TOOL_NAME;
 use maki_agent::{
     AgentConfig, AgentEvent, AgentInput, AgentMode, DoneReason, Envelope, PermissionsConfig,
-    ToolOutput,
+    SessionEndReason, SessionEvents, ToolOutput,
 };
 use maki_config::ModelPolicy;
 use maki_lua::session_snapshot::{HeadlessMeta, HeadlessSnapshot, MODE_BUILD, MODE_PLAN};
@@ -457,11 +457,71 @@ pub struct SdkParams {
     pub lua_handle: maki_lua::EventHandle,
 }
 
+/// Routes permission answers between stdin and the agent.
+///
+/// Owning the outstanding ids *and* the answer channel is the point: an
+/// unanswered request parks the agent forever, so a request may only be
+/// recorded while a source that could answer it exists.
+struct Permissions {
+    answer_tx: Sender<String>,
+    outstanding: HashSet<String>,
+    answerable: bool,
+}
+
+impl Permissions {
+    fn new(answer_tx: Sender<String>) -> Self {
+        Self {
+            answer_tx,
+            outstanding: HashSet::new(),
+            answerable: true,
+        }
+    }
+
+    fn answer(&self, answer: PermissionAnswer) {
+        let _ = self.answer_tx.send(answer.encode());
+    }
+
+    fn deny_unanswerable(&self, request_id: &str) {
+        warn!(%request_id, "denying tool permission: stdin closed");
+        self.answer(PermissionAnswer::Deny);
+    }
+
+    /// Records an outstanding request. `false` means nobody is left to answer
+    /// it, so it was denied here and must not be put on the wire.
+    fn ask(&mut self, request_id: String) -> bool {
+        if !self.answerable {
+            self.deny_unanswerable(&request_id);
+            return false;
+        }
+        self.outstanding.insert(request_id);
+        true
+    }
+
+    fn resolve(&mut self, request_id: &str, answer: PermissionAnswer) {
+        if self.outstanding.remove(request_id) {
+            self.answer(answer);
+        }
+    }
+
+    /// The turn is over, so the agent is no longer parked on any of these.
+    fn forget_outstanding(&mut self) {
+        self.outstanding.clear();
+    }
+
+    /// No further answers can arrive. Idempotent.
+    fn close(&mut self) {
+        self.answerable = false;
+        for request_id in std::mem::take(&mut self.outstanding) {
+            self.deny_unanswerable(&request_id);
+        }
+    }
+}
+
 struct Shared {
     model: Model,
     permission_mode: PermissionMode,
     turn_start: Instant,
-    pending: HashSet<String>,
+    permissions: Permissions,
 }
 
 pub fn run(params: SdkParams) -> Result<()> {
@@ -502,7 +562,7 @@ pub fn run(params: SdkParams) -> Result<()> {
     }
 
     let startup_model = model.clone();
-    let handle = headless::spawn_interactive(InteractiveParams {
+    let (handle, events) = headless::spawn_interactive(InteractiveParams {
         model,
         config,
         permissions_config,
@@ -559,7 +619,7 @@ pub fn run(params: SdkParams) -> Result<()> {
         model: startup_model.clone(),
         permission_mode,
         turn_start: Instant::now(),
-        pending: HashSet::new(),
+        permissions: Permissions::new(handle.answer_tx.clone()),
     }));
 
     let snapshot = HeadlessSnapshot::default();
@@ -581,7 +641,6 @@ pub fn run(params: SdkParams) -> Result<()> {
     let pump = EventPump {
         writer: writer.clone(),
         shared: Arc::clone(&shared),
-        answer_tx: handle.answer_tx.clone(),
         include_partial_messages: cli.include_partial_messages,
         synth: StreamSynth::new(),
         tool_inputs: HashMap::new(),
@@ -592,7 +651,7 @@ pub fn run(params: SdkParams) -> Result<()> {
         session_id: handle.session_id.to_string(),
         snapshot,
     }
-    .spawn(handle.event_rx.clone());
+    .spawn(events);
 
     for line in io::stdin().lock().lines() {
         let line = line.context("read stdin")?;
@@ -657,12 +716,9 @@ pub fn run(params: SdkParams) -> Result<()> {
                     continue;
                 };
                 let data = cr.response;
-                if let Some(req_id) = data.get("request_id").and_then(Value::as_str)
-                    && shared.lock().unwrap().pending.remove(req_id)
-                {
-                    let _ = handle
-                        .answer_tx
-                        .send(decode_permission_response(&data).encode());
+                if let Some(req_id) = data.get("request_id").and_then(Value::as_str) {
+                    let answer = decode_permission_response(&data);
+                    shared.lock().unwrap().permissions.resolve(req_id, answer);
                 }
             }
             "control_cancel_request" => {
@@ -672,20 +728,38 @@ pub fn run(params: SdkParams) -> Result<()> {
                 ) else {
                     continue;
                 };
-                if shared.lock().unwrap().pending.remove(&ccr.request_id) {
-                    let _ = handle.answer_tx.send(PermissionAnswer::Deny.encode());
-                }
+                shared
+                    .lock()
+                    .unwrap()
+                    .permissions
+                    .resolve(&ccr.request_id, PermissionAnswer::Deny);
             }
             other => warn!("unknown inbound message type: {other}"),
         }
     }
 
-    let InteractiveHandle { input_tx, task, .. } = handle;
+    // stdin was the only source of permission answers, so a run still in
+    // flight has to stop asking now: an unanswerable request parks the agent,
+    // and a parked agent never ends the event stream the pump waits on.
+    shared.lock().unwrap().permissions.close();
+
+    let InteractiveHandle {
+        input_tx,
+        task,
+        session_id,
+        ..
+    } = handle;
     drop(input_tx);
     smol::block_on(async {
-        task.await;
+        // Unbounded: the pump ends at the stream marker, which the session
+        // emits once it has answered every prompt stdin queued.
         pump.await;
+        headless::await_shutdown(task).await;
     });
+    // Reaps session-owned plugin jobs before the writer thread joins: an
+    // orphan inheriting stdout would keep an orchestrator's read blocked
+    // after maki exits.
+    lua_handle.end_sessions_blocking([session_id.id()], SessionEndReason::Completed);
     drop(writer);
     let _ = writer_thread.join();
     Ok(())
@@ -883,7 +957,6 @@ fn decode_permission_response(data: &Value) -> PermissionAnswer {
 struct EventPump {
     writer: SdkWriter,
     shared: Arc<Mutex<Shared>>,
-    answer_tx: Sender<String>,
     include_partial_messages: bool,
     synth: StreamSynth,
     tool_inputs: HashMap<String, (String, Value)>,
@@ -898,9 +971,9 @@ struct EventPump {
 }
 
 impl EventPump {
-    fn spawn(mut self, event_rx: Receiver<Envelope>) -> smol::Task<()> {
+    fn spawn(mut self, mut events: SessionEvents) -> smol::Task<()> {
         smol::spawn(async move {
-            while let Ok(envelope) = event_rx.recv_async().await {
+            while let Some(envelope) = events.next().await {
                 // Folded in first, so a plugin handling `TurnEnd` finds the
                 // finished totals when it calls `maki.session.read()`.
                 self.snapshot.observe(&envelope);
@@ -934,7 +1007,7 @@ impl EventPump {
         self.tool_inputs.clear();
         self.result_text.clear();
         self.cost = None;
-        self.shared.lock().unwrap().pending.clear();
+        self.shared.lock().unwrap().permissions.forget_outstanding();
     }
 
     fn emit_turn_result(
@@ -1016,7 +1089,8 @@ impl EventPump {
             | AgentEvent::ToolHeaderSnapshot { .. }
             | AgentEvent::LiveToolBuf { .. }
             | AgentEvent::Nudge
-            | AgentEvent::PromptProgress { .. } => {}
+            | AgentEvent::PromptProgress { .. }
+            | AgentEvent::StreamClosed => {}
             AgentEvent::Retry {
                 attempt,
                 message,
@@ -1064,10 +1138,12 @@ impl EventPump {
                 }))?;
             }
             AgentEvent::PermissionRequest { id, tool, .. } => {
-                if self.shared.lock().unwrap().permission_mode == PermissionMode::BypassPermissions
                 {
-                    let _ = self.answer_tx.send(PermissionAnswer::AllowSession.encode());
-                    return Ok(());
+                    let shared = self.shared.lock().unwrap();
+                    if shared.permission_mode == PermissionMode::BypassPermissions {
+                        shared.permissions.answer(PermissionAnswer::AllowSession);
+                        return Ok(());
+                    }
                 }
 
                 let (tool_name, input) = self
@@ -1078,7 +1154,9 @@ impl EventPump {
 
                 self.request_counter += 1;
                 let req_id = format!("req_{}", self.request_counter);
-                self.shared.lock().unwrap().pending.insert(req_id.clone());
+                if !self.shared.lock().unwrap().permissions.ask(req_id.clone()) {
+                    return Ok(());
+                }
 
                 self.writer
                     .emit(WireInner::ControlRequest(ControlRequestPayload {
@@ -1134,8 +1212,11 @@ fn map_tool_names_in_content(content: &Value) -> Value {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use flume::Receiver;
+    use maki_config::ToolKey;
     use test_case::test_case;
+
+    use super::*;
 
     fn claude_to_maki_tool_name(name: &str) -> &str {
         TOOL_NAME_MAP
@@ -1516,5 +1597,196 @@ mod tests {
         assert_eq!(mapped[0]["type"], "text");
         assert_eq!(mapped[1]["name"], "Read");
         assert_eq!(mapped[2]["name"], "unknown_native");
+    }
+
+    const TEST_MODEL_SPEC: &str = "anthropic/claude-test";
+    const PUMP_ERROR: &str = "boom";
+    const PUMP_FORWARDED: &str = "the pump must forward what was queued before the close";
+    const TEST_TOOL: &str = "bash";
+    const TEST_TOOL_WIRE_NAME: &str = "Bash";
+    const TEST_TOOL_USE_ID: &str = "toolu_1";
+    const CONTROL_REQUEST_TYPE: &str = "control_request";
+    const NO_CONTROL_REQUEST: &str = "a request nobody can answer must not go on the wire";
+    const NO_ANSWER: &str = "answer sent with nobody parked on it";
+    const SOURCE_OPEN: &str = "a turn end must not close the answer source";
+    const OUTSTANDING_REQ: &str = "req_1";
+    const LATE_REQ: &str = "req_2";
+
+    fn test_pump(
+        permission_mode: PermissionMode,
+        answer_tx: Sender<String>,
+    ) -> (EventPump, Receiver<String>) {
+        let (out_tx, out_rx) = flume::unbounded();
+        let session_id = SessionRef::from(maki_storage::id::MakiId::generate());
+        let pump = EventPump {
+            writer: SdkWriter {
+                session_id: session_id.clone(),
+                out_tx,
+            },
+            shared: Arc::new(Mutex::new(Shared {
+                model: Model::from_spec(TEST_MODEL_SPEC).unwrap(),
+                permission_mode,
+                turn_start: Instant::now(),
+                permissions: Permissions::new(answer_tx),
+            })),
+            include_partial_messages: false,
+            synth: StreamSynth::new(),
+            tool_inputs: HashMap::new(),
+            result_text: String::new(),
+            cost: None,
+            request_counter: 0,
+            lua_handle: maki_lua::EventHandle::disconnected_for_test(),
+            session_id: session_id.to_string(),
+            snapshot: HeadlessSnapshot::default(),
+        };
+        (pump, out_rx)
+    }
+
+    fn permission_request() -> Envelope {
+        Envelope {
+            event: AgentEvent::PermissionRequest {
+                id: TEST_TOOL_USE_ID.to_owned(),
+                tool: ToolKey::parse(TEST_TOOL).unwrap(),
+                scopes: Vec::new(),
+            },
+            subagent: None,
+            run_id: 0,
+        }
+    }
+
+    /// The SDK hang: `retained` is the Lua tool context that keeps a sender
+    /// alive on an idle VM, so the pump has to end on the stream marker and
+    /// still report everything queued ahead of it.
+    #[test]
+    fn pump_ends_at_stream_close_with_a_retained_sender() {
+        let (guard, events) = maki_agent::event_stream();
+        let retained = guard.sender(0);
+        let (pump, out_rx) = test_pump(PermissionMode::Default, flume::unbounded().0);
+        let pump = pump.spawn(events);
+
+        retained
+            .send(AgentEvent::Error {
+                message: PUMP_ERROR.into(),
+            })
+            .unwrap();
+        drop(guard);
+        smol::block_on(pump);
+
+        let line = out_rx.try_recv().expect(PUMP_FORWARDED);
+        assert!(line.contains(PUMP_ERROR), "got: {line}");
+    }
+
+    /// Stdin is the only answerer, so once it is gone every request has to be
+    /// denied here. A single unanswered one parks the agent, and a parked
+    /// agent never ends the event stream the exit path waits on.
+    #[test]
+    fn closing_the_answer_source_denies_outstanding_and_later_requests() {
+        let (answer_tx, answer_rx) = flume::unbounded();
+        let mut permissions = Permissions::new(answer_tx);
+
+        assert!(permissions.ask(OUTSTANDING_REQ.to_owned()));
+        assert!(answer_rx.is_empty());
+
+        permissions.close();
+        assert_eq!(answer_rx.try_recv(), Ok(PermissionAnswer::Deny.encode()));
+
+        assert!(!permissions.ask(LATE_REQ.to_owned()));
+        assert_eq!(answer_rx.try_recv(), Ok(PermissionAnswer::Deny.encode()));
+
+        permissions.close();
+        assert!(answer_rx.is_empty());
+    }
+
+    /// Every answer has to match an id the agent is actually parked on. A
+    /// spare one would be picked up by the *next* turn's request and
+    /// auto-answer it, which is also why a turn end forgets its ids silently
+    /// instead of denying them the way `close` does.
+    #[test]
+    fn only_requests_the_agent_waits_on_get_answered() {
+        let (answer_tx, answer_rx) = flume::unbounded();
+        let mut permissions = Permissions::new(answer_tx);
+        assert!(permissions.ask(OUTSTANDING_REQ.to_owned()));
+
+        permissions.resolve(LATE_REQ, PermissionAnswer::AllowOnce);
+        assert!(answer_rx.is_empty(), "{NO_ANSWER}");
+
+        permissions.resolve(OUTSTANDING_REQ, PermissionAnswer::AllowOnce);
+        assert_eq!(
+            answer_rx.try_recv(),
+            Ok(PermissionAnswer::AllowOnce.encode())
+        );
+
+        permissions.resolve(OUTSTANDING_REQ, PermissionAnswer::AllowOnce);
+        assert!(answer_rx.is_empty(), "{NO_ANSWER}");
+
+        assert!(permissions.ask(LATE_REQ.to_owned()));
+        permissions.forget_outstanding();
+        permissions.resolve(LATE_REQ, PermissionAnswer::AllowOnce);
+        assert!(answer_rx.is_empty(), "{NO_ANSWER}");
+
+        assert!(permissions.ask(OUTSTANDING_REQ.to_owned()), "{SOURCE_OPEN}");
+        permissions.forget_outstanding();
+        permissions.close();
+        assert!(answer_rx.is_empty(), "{NO_ANSWER}");
+    }
+
+    /// Bypass answers on the spot, so recording the id or emitting a control
+    /// request would leave an answer nobody is parked on: stdin's reply (or
+    /// the deny on exit) would land on whatever the agent asks next.
+    #[test]
+    fn bypass_answers_immediately_without_recording_or_emitting() {
+        let (answer_tx, answer_rx) = flume::unbounded();
+        let (mut pump, out_rx) = test_pump(PermissionMode::BypassPermissions, answer_tx);
+
+        pump.handle(permission_request()).unwrap();
+
+        assert_eq!(
+            answer_rx.try_recv(),
+            Ok(PermissionAnswer::AllowSession.encode())
+        );
+        assert!(answer_rx.is_empty(), "{NO_ANSWER}");
+        assert!(out_rx.is_empty(), "{NO_CONTROL_REQUEST}");
+        assert!(
+            pump.shared
+                .lock()
+                .unwrap()
+                .permissions
+                .outstanding
+                .is_empty()
+        );
+    }
+
+    /// The wire and the outstanding set have to move together: an id on the
+    /// wire that was never recorded is unanswerable, and one recorded without
+    /// being asked parks the agent until exit.
+    #[test]
+    fn permission_request_reaches_the_wire_only_while_answerable() {
+        let (answer_tx, answer_rx) = flume::unbounded();
+        let (mut pump, out_rx) = test_pump(PermissionMode::Default, answer_tx);
+
+        pump.handle(permission_request()).unwrap();
+
+        let wire: Value = serde_json::from_str(&out_rx.try_recv().unwrap()).unwrap();
+        assert_eq!(wire["type"], CONTROL_REQUEST_TYPE);
+        assert_eq!(wire["request"]["tool_name"], TEST_TOOL_WIRE_NAME);
+        assert_eq!(wire["request"]["tool_use_id"], TEST_TOOL_USE_ID);
+        assert!(answer_rx.is_empty(), "{NO_ANSWER}");
+
+        let request_id = wire["request_id"].as_str().unwrap().to_owned();
+        pump.shared
+            .lock()
+            .unwrap()
+            .permissions
+            .resolve(&request_id, PermissionAnswer::AllowOnce);
+        assert_eq!(
+            answer_rx.try_recv(),
+            Ok(PermissionAnswer::AllowOnce.encode())
+        );
+
+        pump.shared.lock().unwrap().permissions.close();
+        pump.handle(permission_request()).unwrap();
+
+        assert_eq!(answer_rx.try_recv(), Ok(PermissionAnswer::Deny.encode()));
+        assert!(out_rx.is_empty(), "{NO_CONTROL_REQUEST}");
     }
 }


### PR DESCRIPTION
`maki --input-format stream-json` never exited after stdin EOF once a tool had run, because the SDK pump looped until every `Sender<Envelope>` was gone, and every Lua tool call parks a `LuaCtx` holding an `EventSender` clone that an idle VM never collects.

`event_stream()` now hands out an `EventStreamGuard` and a single non-`Clone` `SessionEvents`; the guard emits `AgentEvent::StreamClosed` on drop, in band behind every event the session sent, and `next()` turns it into `None`, so the buggy loop is no longer writable.

The same defect silently leaked one relay task per subagent call, since `sub_rx` was pinned by the same retained senders.

Note the ordering in `headless::spawn*`: MCP shutdown runs after `closing(..)`, so the stream ends with the run and the SDK exit only has to bound teardown. Bounding the whole session task instead cancels prompts stdin already queued, and the second one dies mid turn.