### PR TITLE
fix(config): make the `always_*` knobs one value every frontend takes

### DIFF
--- a/maki-acp/src/lib.rs
+++ b/maki-acp/src/lib.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use maki_agent::permissions::PluginRuleStore;
 use maki_agent::prompt::ResolvedSlots;
 use maki_agent::{AgentConfig, PermissionsConfig, SessionEndReason};
-use maki_config::ModelPolicy;
+use maki_config::{ModelPolicy, SessionDefaults};
 use maki_providers::Timeouts;
 use maki_providers::model::Model;
 use maki_storage::id::MakiId;
@@ -26,6 +26,9 @@ pub struct AcpParams {
     pub initial_wd: PathBuf,
     pub prompt_slots: Arc<ResolvedSlots>,
     pub yolo: bool,
+    /// ACP exposes no toggles of its own, so the `always_*` knobs are the whole
+    /// answer for every prompt this server runs.
+    pub defaults: SessionDefaults,
     pub model_policy: Arc<ModelPolicy>,
     pub plugin_rules: Arc<PluginRuleStore>,
     /// Called with the reason when an ACP session is replaced or the server

--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -26,7 +26,7 @@ use maki_agent::types::AgentEvent;
 use maki_agent::{
     AgentInput, AgentMode, Envelope, ImageMediaType, ImageSource, SessionEndReason, SessionEvents,
 };
-use maki_config::{MAX_SERVER_NAME_LEN, ModelPolicy};
+use maki_config::{MAX_SERVER_NAME_LEN, ModelPolicy, SessionDefaults};
 use maki_providers::model::Model;
 use maki_providers::provider::{available_model_specs, fetch_all_models};
 use maki_providers::{Message, TokenUsage, add_cost, settle_session};
@@ -41,8 +41,6 @@ use tracing::{debug, warn};
 use crate::{AcpParams, SessionEndHook, elicitation, methods, permissions, translate};
 
 const FIRST_OUTGOING_REQUEST_ID: i64 = 1000;
-/// ACP has no fast-mode toggle, so a restored total is priced at standard rates.
-const RESTORED_FAST: bool = false;
 
 /// Ids come from here and are never reused, so a late answer for a closed
 /// session cannot match a request of the session that replaced it.
@@ -77,6 +75,7 @@ struct Server {
     model_specs: Vec<String>,
     model_policy: Arc<ModelPolicy>,
     client_elicits_form: bool,
+    defaults: SessionDefaults,
     session: Option<SessionState>,
     on_session_end: Option<SessionEndHook>,
 }
@@ -111,6 +110,7 @@ pub async fn serve(params: AcpParams) -> color_eyre::Result<()> {
         model_specs: available_model_specs(&params.model_policy),
         model_policy: Arc::clone(&params.model_policy),
         client_elicits_form: false,
+        defaults: params.defaults,
         session: None,
         on_session_end: params.on_session_end.clone(),
     };
@@ -297,7 +297,7 @@ async fn load_session(
         &restored.usage,
         &mut restored.by_model,
         &recorded_model,
-        RESTORED_FAST,
+        params.defaults.fast,
     );
     let started = start_session(
         srv,
@@ -352,7 +352,7 @@ fn start_session(
         yolo: params.yolo,
         system_prompt_override: None,
         append_system_prompt: None,
-        workflow: false,
+        defaults: params.defaults,
         model_policy: Arc::clone(&params.model_policy),
         plugin_rules: Arc::clone(&params.plugin_rules),
         local_tools,
@@ -575,16 +575,8 @@ fn handle_prompt(srv: &mut Server, raw: &Value, id: &RequestId) -> Result<(), Ac
     let session = srv.session.as_ref().ok_or_else(no_session)?;
 
     let (message, images) = extract_prompt_content(&req.prompt);
-    let input = AgentInput {
-        message,
-        mode: session.current_mode.clone(),
-        images,
-        preamble: Vec::new(),
-        thinking: Default::default(),
-        fast: false,
-        workflow: false,
-        prompt: None,
-    };
+    let input =
+        AgentInput::from_defaults(message, session.current_mode.clone(), images, srv.defaults);
 
     session
         .handle
@@ -904,6 +896,7 @@ mod tests {
             model_specs: Vec::new(),
             model_policy: Arc::new(ModelPolicy::default()),
             client_elicits_form: false,
+            defaults: SessionDefaults::default(),
             on_session_end: None,
             session: Some(SessionState {
                 handle,
@@ -1206,7 +1199,7 @@ mod tests {
                 &restored.usage,
                 &mut restored.by_model,
                 &recorded_model,
-                RESTORED_FAST
+                false
             ),
             Some(RECORDED_COST)
         );

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -480,9 +480,8 @@ impl<'h> Agent<'h> {
     }
 
     fn emit_turn_complete(&self, response: &StreamResponse) -> Result<(), AgentError> {
-        let fast = self.opts.clamped(&self.model).fast;
-        let cost = self.model.billed_cost(&response.usage, fast);
-        let list_cost = self.model.list_cost(&response.usage, fast);
+        let cost = self.model.billed_cost(&response.usage, self.opts.fast);
+        let list_cost = self.model.list_cost(&response.usage, self.opts.fast);
         self.ledger.add(response.usage, cost, list_cost);
         self.event_tx
             .send(AgentEvent::TurnComplete(Box::new(TurnCompleteEvent {
@@ -645,10 +644,10 @@ impl<'h> Agent<'h> {
         )
         .await?;
         // The summariser can be a different model, so price this with
-        // `compact_model` and not `self.model`.
-        let fast = self.opts.clamped(&compact_model).fast;
-        let compact_cost = compact_model.billed_cost(&compaction_usage, fast);
-        let compact_list_cost = compact_model.list_cost(&compaction_usage, fast);
+        // `compact_model` and not `self.model`. `list_cost` gates `fast`
+        // against whichever one it gets.
+        let compact_cost = compact_model.billed_cost(&compaction_usage, self.opts.fast);
+        let compact_list_cost = compact_model.list_cost(&compaction_usage, self.opts.fast);
         self.ledger
             .add(compaction_usage, compact_cost, compact_list_cost);
         // The summary the model just wrote is all the next call will see, plus

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_lock::Mutex;
-use maki_config::ModelPolicy;
+use maki_config::{ModelPolicy, SessionDefaults};
 use maki_providers::Message;
 use maki_providers::Timeouts;
 use maki_providers::TokenUsage;
@@ -83,8 +83,9 @@ pub struct HeadlessParams {
     pub excluded_tools: Vec<&'static str>,
     pub mcp_handle: Option<McpHandle>,
     pub initial_wd: PathBuf,
-    pub fast: bool,
-    pub workflow: bool,
+    /// The `always_*` knobs. A headless run has no toggle UI, so config is the
+    /// whole answer. The model gate stays in `RequestOptions::clamped`.
+    pub defaults: SessionDefaults,
     pub model_policy: Arc<ModelPolicy>,
     pub plugin_rules: Arc<PluginRuleStore>,
 }
@@ -151,7 +152,7 @@ pub fn spawn(params: HeadlessParams) -> (HeadlessHandle, SessionEvents) {
         &params.model,
         &params.config,
         &params.excluded_tools,
-        params.workflow,
+        params.defaults.workflow,
         params.mcp_handle.as_ref(),
     );
 
@@ -173,8 +174,7 @@ pub fn spawn(params: HeadlessParams) -> (HeadlessHandle, SessionEvents) {
     let session_ref = SessionRef::from(session_id);
     let session_ref_clone = session_ref.clone();
     let mailbox = SessionMailbox::register(session_id);
-    let fast = params.fast;
-    let workflow = params.workflow;
+    let defaults = params.defaults;
     let working_dir_path = params.initial_wd.clone();
     let task = smol::spawn(run_session(guard, params.mcp_handle.clone(), async move {
         let mut model = params.model;
@@ -224,16 +224,12 @@ pub fn spawn(params: HeadlessParams) -> (HeadlessHandle, SessionEvents) {
         .with_mcp(mcp);
 
         let result = agent
-            .run(AgentInput {
-                message: params.prompt,
+            .run(AgentInput::from_defaults(
+                params.prompt,
                 mode,
-                images: params.images,
-                preamble: Vec::new(),
-                thinking: Default::default(),
-                fast,
-                workflow,
-                prompt: None,
-            })
+                params.images,
+                defaults,
+            ))
             .await;
         drop(agent);
 
@@ -270,7 +266,9 @@ pub struct InteractiveParams {
     pub yolo: bool,
     pub system_prompt_override: Option<String>,
     pub append_system_prompt: Option<String>,
-    pub workflow: bool,
+    /// The `always_*` knobs. `workflow` picks the tool catalog here; the rest
+    /// are what a host without toggles puts on every [`AgentInput`] it sends.
+    pub defaults: SessionDefaults,
     pub model_policy: Arc<ModelPolicy>,
     pub plugin_rules: Arc<PluginRuleStore>,
     /// Host-side overrides that shadow a registered tool's execution while
@@ -298,7 +296,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> (InteractiveHandle, Sessi
         &params.model,
         &params.config,
         &params.excluded_tools,
-        params.workflow,
+        params.defaults.workflow,
         params.mcp_handle.as_ref(),
     );
 
@@ -392,7 +390,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> (InteractiveHandle, Sessi
                             &new_model,
                             &params.config,
                             &params.excluded_tools,
-                            params.workflow,
+                            params.defaults.workflow,
                             mcp.is_some(),
                         );
                         model = new_model;

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -20,7 +20,7 @@ pub use agent::{
 };
 pub use cancel::{CancelMap, CancelToken, CancelTrigger};
 pub use mailbox::{MailboxError, SessionMailbox};
-pub use maki_config::{AgentConfig, PermissionsConfig, ToolOutputLines};
+pub use maki_config::{AgentConfig, PermissionsConfig, SessionDefaults, ToolOutputLines};
 pub mod command;
 pub mod diff;
 pub mod permissions;
@@ -91,4 +91,27 @@ pub struct AgentInput {
     /// No `Default` on this struct so adding a field forces every call site to update.
     pub workflow: bool,
     pub prompt: Option<Box<McpPromptRef>>,
+}
+
+impl AgentInput {
+    /// What a host with no toggle UI sends. `-p`, the SDK and ACP know nothing
+    /// about the toggles beyond what config says, so they all build their input
+    /// here and a knob added to [`SessionDefaults`] reaches every one of them.
+    pub fn from_defaults(
+        message: String,
+        mode: AgentMode,
+        images: Vec<ImageSource>,
+        defaults: SessionDefaults,
+    ) -> Self {
+        Self {
+            message,
+            mode,
+            images,
+            preamble: Vec::new(),
+            thinking: defaults.thinking.into(),
+            fast: defaults.fast,
+            workflow: defaults.workflow,
+            prompt: None,
+        }
+    }
 }

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use maki_config_macro::ConfigSection;
 use maki_storage::paths;
-use maki_storage::sessions::{StoredThinking, ThinkingParseError};
+use maki_storage::sessions::{SessionMeta, StoredThinking, ThinkingParseError};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Value as JsonValue};
 use strum::VariantArray;
@@ -326,6 +326,36 @@ impl AlwaysThinking {
     }
 }
 
+/// The `always_*` knobs that seed a session's own toggles.
+///
+/// One value, so every entry point that starts a session (TUI, `-p`, the SDK,
+/// ACP) takes the whole set at once. A knob that lives here cannot be honoured
+/// by one frontend and dropped by another, which is how `always_thinking` once
+/// reached the TUI and nobody else.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SessionDefaults {
+    pub fast: bool,
+    pub workflow: bool,
+    pub thinking: Option<StoredThinking>,
+}
+
+impl SessionDefaults {
+    /// Seeds a session that has not spoken yet. An unset knob means "no
+    /// opinion" and leaves the session's own toggle alone, so a `/fast` from an
+    /// earlier run survives a config that never mentions it.
+    ///
+    /// The model is nobody's business here. `RequestOptions::clamped` is the
+    /// single gate for what the model can actually do, and the model can still
+    /// change after this runs.
+    pub fn seed(self, meta: &mut SessionMeta) {
+        meta.fast |= self.fast;
+        meta.workflow |= self.workflow;
+        if self.thinking.is_some() {
+            meta.thinking = self.thinking;
+        }
+    }
+}
+
 #[derive(Deserialize, Default, Debug)]
 #[serde(default, deny_unknown_fields)]
 pub struct RawConfig {
@@ -380,12 +410,14 @@ impl RawConfig {
         self.validate_plugin_tables(packages)?;
         Ok(Config {
             always_yolo: self.always_yolo.unwrap_or(false),
-            always_fast: self.always_fast.unwrap_or(false),
-            always_workflow: self.always_workflow.unwrap_or(false),
-            always_thinking: self
-                .always_thinking
-                .map(AlwaysThinking::resolve)
-                .transpose()?,
+            session_defaults: SessionDefaults {
+                fast: self.always_fast.unwrap_or(false),
+                workflow: self.always_workflow.unwrap_or(false),
+                thinking: self
+                    .always_thinking
+                    .map(AlwaysThinking::resolve)
+                    .transpose()?,
+            },
             ui: UiConfig::from_file(self.ui),
             agent: AgentConfig::from_file(self.agent),
             provider: ProviderConfig::from_file(self.provider)?,
@@ -949,9 +981,7 @@ pub struct PermissionsConfig {
 #[derive(Clone)]
 pub struct Config {
     pub always_yolo: bool,
-    pub always_fast: bool,
-    pub always_workflow: bool,
-    pub always_thinking: Option<StoredThinking>,
+    pub session_defaults: SessionDefaults,
     pub ui: UiConfig,
     pub agent: AgentConfig,
     pub provider: ProviderConfig,
@@ -2608,13 +2638,46 @@ mod tests {
     #[test]
     fn always_workflow_resolves_default_and_set() {
         let defaults = RawConfig::default().into_config(&[]).unwrap();
-        assert!(!defaults.always_workflow, "absent resolves to false");
+        assert!(
+            !defaults.session_defaults.workflow,
+            "absent resolves to false"
+        );
 
         let raw = RawConfig {
             always_workflow: Some(true),
             ..Default::default()
         };
-        assert!(raw.into_config(&[]).unwrap().always_workflow);
+        assert!(raw.into_config(&[]).unwrap().session_defaults.workflow);
+    }
+
+    /// `(fast, workflow, thinking)`, for both the config knobs and the session.
+    type Toggles = (bool, bool, Option<StoredThinking>);
+
+    const HIGH: Option<StoredThinking> = Some(StoredThinking::Effort {
+        level: Effort::High,
+    });
+
+    #[test_case((true, true, Some(StoredThinking::Adaptive)), (false, false, None)
+        => (true, true, Some(StoredThinking::Adaptive)) ; "blank_session_takes_every_knob")]
+    #[test_case((false, false, None), (true, true, HIGH)
+        => (true, true, HIGH) ; "silence_leaves_the_session_alone")]
+    #[test_case((false, false, Some(StoredThinking::Off)), (false, false, Some(StoredThinking::Adaptive))
+        => (false, false, Some(StoredThinking::Off)) ; "explicit_off_still_wins")]
+    fn seed_applies_only_the_knobs_config_sets(defaults: Toggles, session: Toggles) -> Toggles {
+        let mut meta = SessionMeta {
+            fast: session.0,
+            workflow: session.1,
+            thinking: session.2,
+            ..Default::default()
+        };
+        SessionDefaults {
+            fast: defaults.0,
+            workflow: defaults.1,
+            thinking: defaults.2,
+        }
+        .seed(&mut meta);
+
+        (meta.fast, meta.workflow, meta.thinking)
     }
 
     #[test_case(AlwaysThinking::Toggle(true), StoredThinking::Adaptive ; "toggle_true")]
@@ -2629,7 +2692,7 @@ mod tests {
     #[test]
     fn into_config_resolves_always_thinking() {
         let defaults = RawConfig::default().into_config(&[]).unwrap();
-        assert!(defaults.always_thinking.is_none());
+        assert!(defaults.session_defaults.thinking.is_none());
 
         let raw = RawConfig {
             always_thinking: Some(AlwaysThinking::Mode("8192".into())),
@@ -2637,7 +2700,7 @@ mod tests {
         };
         let config = raw.into_config(&[]).unwrap();
         assert_eq!(
-            config.always_thinking,
+            config.session_defaults.thinking,
             Some(StoredThinking::Budget { tokens: 8192 })
         );
 
@@ -2693,9 +2756,7 @@ mod tests {
     fn validate_rejects_invalid_sections(section: &str, field: &str, value: u64) {
         let mut config = Config {
             always_yolo: false,
-            always_fast: false,
-            always_workflow: false,
-            always_thinking: None,
+            session_defaults: SessionDefaults::default(),
             ui: UiConfig::default(),
             agent: AgentConfig::default(),
             provider: ProviderConfig::default(),

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -429,8 +429,14 @@ impl Model {
     /// what makes it right for re-pricing a session whose turns never recorded
     /// what they paid: the rate back then is unknown, and the table price is
     /// the honest guess.
+    ///
+    /// `fast` arrives as the user's raw preference and is gated here, against
+    /// *this* model. Callers often price a model they are not running (a
+    /// session's per-model breakdown, a compaction model), so a gate on their
+    /// side would answer for the wrong one.
     pub fn list_cost(&self, usage: &TokenUsage, fast: bool) -> Option<f64> {
-        (!self.pricing.is_zero()).then(|| usage.estimate(&self.pricing, fast))
+        (!self.pricing.is_zero())
+            .then(|| usage.estimate(&self.pricing, fast && self.supports_fast()))
     }
 
     pub fn provider_display_name(&self) -> &'static str {
@@ -1111,8 +1117,11 @@ mod tests {
         assert_eq!(model.supports_fast(), expected);
     }
 
+    /// Fast mode is Anthropic-only, so a fast rate that lands on anyone else is
+    /// dead weight: nobody can turn it on, and an `always_fast` carried in from
+    /// config must not quietly reprice the session with it.
     #[test]
-    fn supports_fast_false_for_non_anthropic_even_with_fast_pricing() {
+    fn fast_pricing_on_a_non_anthropic_model_stays_inert() {
         let mut model = Model::from_base(
             ManifestRegistry::get("google").unwrap(),
             "google",
@@ -1123,6 +1132,11 @@ mod tests {
             output: 150.0,
         });
         assert!(!model.supports_fast());
+
+        let standard = model
+            .list_cost(&INPUT_ONLY, false)
+            .expect("the table prices this model");
+        assert_eq!(model.list_cost(&INPUT_ONLY, true), Some(standard));
     }
 
     #[test]

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -778,6 +778,15 @@ impl From<StoredThinking> for ThinkingConfig {
     }
 }
 
+/// One place decides what silence means, so a session that never set a level, a
+/// config without `always_thinking` and a frontend with no toggle all read it
+/// the same way: off.
+impl From<Option<StoredThinking>> for ThinkingConfig {
+    fn from(s: Option<StoredThinking>) -> Self {
+        s.map_or(Self::Off, Self::from)
+    }
+}
+
 impl From<ThinkingConfig> for StoredThinking {
     fn from(c: ThinkingConfig) -> Self {
         match c {
@@ -1286,6 +1295,15 @@ mod tests {
             fast: false,
         };
         assert_eq!(opts.clamped(&model).thinking, expected);
+    }
+
+    #[test_case(None,                           ThinkingConfig::Off      ; "absent_means_off")]
+    #[test_case(Some(StoredThinking::Adaptive), ThinkingConfig::Adaptive ; "a_stored_level_carries_over")]
+    fn optional_stored_thinking_into_config(
+        stored: Option<StoredThinking>,
+        expected: ThinkingConfig,
+    ) {
+        assert_eq!(ThinkingConfig::from(stored), expected);
     }
 
     #[test]

--- a/maki-ui/src/app/session_state.rs
+++ b/maki-ui/src/app/session_state.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use maki_config::{Effect, ModelPolicy};
 use maki_providers::provider::adjust_model;
-use maki_providers::{Model, ThinkingConfig, Timeouts, TokenUsage, settle_session};
+use maki_providers::{Model, RequestOptions, ThinkingConfig, Timeouts, TokenUsage, settle_session};
 use maki_storage::StateDir;
 use maki_storage::sessions::{StoredEffect, StoredMode, StoredRule};
 
@@ -30,6 +30,13 @@ pub(crate) struct SessionState {
 }
 
 const PLAN_FILE_MISSING_WARNING: &str = "Plan file was deleted \u{2014} started a new plan";
+
+/// The badge, the cost line and the request all read the same gate, so none of
+/// them can advertise a mode this model lacks, or miss one it demands.
+fn clamp(thinking: ThinkingConfig, fast: bool, model: &Model) -> (ThinkingConfig, bool) {
+    let opts = RequestOptions { thinking, fast }.clamped(model);
+    (opts.thinking, opts.fast)
+}
 
 impl SessionState {
     pub fn from_session(
@@ -81,20 +88,15 @@ impl SessionState {
             plan.allocate_path(storage);
         }
 
-        let fast = session.meta.fast && model.supports_fast();
+        // Saved model may differ from the live one (updated, removed, etc), so
+        // reconcile before anyone reads the toggles or prices history with them.
+        let (thinking, fast) = clamp(session.meta.thinking.into(), session.meta.fast, &model);
         let token_usage = session.token_usage;
         let cost = settle_session(&token_usage, session.usage_by_model_mut(), &model, fast);
         let context_size = session.meta.context_size;
 
         Self {
-            // Saved model may differ from the live one (updated, removed, etc).
-            // Reconcile so the UI badge and agent always see the truth.
-            thinking: session
-                .meta
-                .thinking
-                .map(Into::into)
-                .filter(|_| model.supports_thinking())
-                .unwrap_or_default(),
+            thinking,
             fast,
             workflow: session.meta.workflow,
             session: Arc::new(session),
@@ -113,12 +115,7 @@ impl SessionState {
     }
 
     pub fn update_model(&mut self, model: &Model) {
-        if !model.supports_thinking() {
-            self.thinking = ThinkingConfig::Off;
-        }
-        if !model.supports_fast() {
-            self.fast = false;
-        }
+        (self.thinking, self.fast) = clamp(self.thinking, self.fast, model);
         self.session_mut().set_model(model.spec());
         self.model = model.clone();
     }
@@ -208,7 +205,7 @@ pub(crate) fn stored_to_rules(stored: &[StoredRule]) -> Vec<maki_config::Permiss
 mod tests {
     use super::*;
     use crate::components::{test_model, test_pricing};
-    use maki_providers::{FastPricing, ModelPricing};
+    use maki_providers::{FastPricing, ModelPricing, ThinkingSupport};
     use maki_storage::sessions::StoredThinking;
     use test_case::test_case;
 
@@ -227,6 +224,8 @@ mod tests {
     const FAST_INPUT_RATE: f64 = 6.0;
     const UNRESOLVABLE_MODEL: &str = "a-model-no-table-has-ever-heard-of";
     const FAST_FLAG_LOST: &str = "the model has fast pricing, so the flag must survive as stored";
+    const THINKING_NOT_LIFTED: &str =
+        "a model that requires thinking must not show, or send, thinking off";
 
     fn resumed(session: AppSession, model: &Model) -> SessionState {
         let tmp = tempfile::tempdir().unwrap();
@@ -357,6 +356,21 @@ mod tests {
             SessionState::from_session(session, &test_model(), &storage, &ModelPolicy::default());
         assert_eq!(state.mode, Mode::Build);
         assert!(state.plan.path().is_none());
+    }
+
+    /// The level `clamped` picks is its own business. All this layer promises
+    /// is that it asks, instead of keeping its own rule that only knew how to
+    /// turn thinking off.
+    #[test]
+    fn update_model_lifts_thinking_for_a_model_that_requires_it() {
+        let mut state = resumed(AppSession::new("test-model", "/tmp"), &test_model());
+        state.thinking = ThinkingConfig::Off;
+
+        let mut required = test_model();
+        required.thinking_override = Some(ThinkingSupport::Required);
+        state.update_model(&required);
+
+        assert_ne!(state.thinking, ThinkingConfig::Off, "{THINKING_NOT_LIFTED}");
     }
 
     #[test]

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -68,6 +68,7 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
         initial_wd: cwd,
         prompt_slots: Arc::new(prompt_slots),
         yolo,
+        defaults: config.session_defaults,
         model_policy: Arc::new(config.provider.model_policy.clone()),
         plugin_rules: plugin_host.plugin_rules(),
         on_session_end: Some(Arc::new(move |id, reason| {

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -270,7 +270,6 @@ pub fn run(mut cli: Cli) -> Result<()> {
     }
 
     if cli.is_sdk_mode() {
-        let fast = stack.config.always_fast && stack.model.supports_fast();
         let prompt_slots = stack.plugin_host.event_handle().collect_prompt_slots();
         let timeouts = stack.timeouts();
         crate::sdk_mode::run(crate::sdk_mode::SdkParams {
@@ -280,8 +279,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
             permissions_config: stack.config.permissions,
             timeouts,
             prompt_slots,
-            fast,
-            workflow: stack.config.always_workflow,
+            defaults: stack.config.session_defaults,
             model_policy: Arc::new(stack.config.provider.model_policy.clone()),
             plugin_rules: stack.plugin_host.plugin_rules(),
             lua_handle: stack.plugin_host.event_handle(),
@@ -290,23 +288,21 @@ pub fn run(mut cli: Cli) -> Result<()> {
         return Ok(());
     }
     if cli.print {
-        let fast = stack.config.always_fast && stack.model.supports_fast();
         let timeouts = stack.timeouts();
-        crate::print::run(
-            &stack.model,
-            cli.initial_prompt,
-            cli.images,
-            cli.output_format,
-            cli.verbose,
-            stack.config.agent,
-            stack.config.permissions,
+        crate::print::run(crate::print::PrintParams {
+            model: stack.model,
+            prompt: cli.initial_prompt,
+            image_paths: cli.images,
+            format: cli.output_format,
+            verbose: cli.verbose,
+            config: stack.config.agent,
+            permissions_config: stack.config.permissions,
             timeouts,
-            stack.plugin_host.event_handle(),
-            fast,
-            stack.config.always_workflow,
-            Arc::new(stack.config.provider.model_policy.clone()),
-            stack.plugin_host.plugin_rules(),
-        )
+            lua_handle: stack.plugin_host.event_handle(),
+            defaults: stack.config.session_defaults,
+            model_policy: Arc::new(stack.config.provider.model_policy.clone()),
+            plugin_rules: stack.plugin_host.plugin_rules(),
+        })
         .context("run print mode")?;
         return Ok(());
     }
@@ -328,11 +324,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
     loop {
         for session in &mut tabs {
             if session.messages().is_empty() {
-                session.meta.fast |= stack.config.always_fast;
-                session.meta.workflow |= stack.config.always_workflow;
-                if let Some(thinking) = stack.config.always_thinking {
-                    session.meta.thinking = Some(thinking);
-                }
+                stack.config.session_defaults.seed(&mut session.meta);
             }
         }
         let focused_tab = &tabs[focused];
@@ -521,13 +513,13 @@ mod tests {
     #[test]
     fn broken_config_with_fallback_uses_last_good_and_warns() {
         let mut last_good = test_config();
-        last_good.always_fast = true;
+        last_good.session_defaults.fast = true;
         let mut warnings = Vec::new();
 
         let config = config_or_fallback(Err(eyre!("boom")), Some(last_good), &mut warnings)
             .expect("fallback config");
 
-        assert!(config.always_fast);
+        assert!(config.session_defaults.fast);
         assert_eq!(warnings.len(), 1);
         assert!(
             warnings[0].starts_with(CONFIG_FALLBACK_WARNING),

--- a/src/print.rs
+++ b/src/print.rs
@@ -19,7 +19,7 @@ use maki_agent::headless::{self, HeadlessHandle, HeadlessParams};
 use maki_agent::permissions::PluginRuleStore;
 use maki_agent::tools::QUESTION_TOOL_NAME;
 use maki_agent::{AgentConfig, AgentEvent, DoneReason, Envelope, ImageSource, PermissionsConfig};
-use maki_config::ModelPolicy;
+use maki_config::{ModelPolicy, SessionDefaults};
 use maki_lua::session_snapshot::{HeadlessMeta, HeadlessSnapshot, MODE_BUILD};
 use maki_lua::{EventHandle, SessionEndReason};
 use maki_providers::model::Model;
@@ -135,23 +135,38 @@ impl VerboseOutput {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn run(
-    model: &Model,
-    prompt_arg: Option<String>,
-    image_paths: Vec<PathBuf>,
-    format: OutputFormat,
-    verbose: bool,
-    config: AgentConfig,
-    permissions_config: PermissionsConfig,
-    timeouts: maki_providers::Timeouts,
-    lua_handle: EventHandle,
-    fast: bool,
-    workflow: bool,
-    model_policy: Arc<ModelPolicy>,
-    plugin_rules: Arc<PluginRuleStore>,
-) -> Result<()> {
-    let prompt = match prompt_arg {
+pub struct PrintParams {
+    pub model: Model,
+    pub prompt: Option<String>,
+    pub image_paths: Vec<PathBuf>,
+    pub format: OutputFormat,
+    pub verbose: bool,
+    pub config: AgentConfig,
+    pub permissions_config: PermissionsConfig,
+    pub timeouts: maki_providers::Timeouts,
+    pub lua_handle: EventHandle,
+    pub defaults: SessionDefaults,
+    pub model_policy: Arc<ModelPolicy>,
+    pub plugin_rules: Arc<PluginRuleStore>,
+}
+
+pub fn run(params: PrintParams) -> Result<()> {
+    let PrintParams {
+        model,
+        prompt,
+        image_paths,
+        format,
+        verbose,
+        config,
+        permissions_config,
+        timeouts,
+        lua_handle,
+        defaults,
+        model_policy,
+        plugin_rules,
+    } = params;
+
+    let prompt = match prompt {
         Some(p) => p,
         None => {
             let mut buf = String::new();
@@ -181,8 +196,7 @@ pub fn run(
         excluded_tools: vec![QUESTION_TOOL_NAME],
         mcp_handle,
         initial_wd: cwd,
-        fast,
-        workflow,
+        defaults,
         model_policy,
         plugin_rules,
     });

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -26,7 +26,7 @@ use maki_agent::{
     AgentConfig, AgentEvent, AgentInput, AgentMode, DoneReason, Envelope, PermissionsConfig,
     SessionEndReason, SessionEvents, ToolOutput,
 };
-use maki_config::ModelPolicy;
+use maki_config::{ModelPolicy, SessionDefaults};
 use maki_lua::session_snapshot::{HeadlessMeta, HeadlessSnapshot, MODE_BUILD, MODE_PLAN};
 use maki_providers::model::Model;
 use maki_providers::{ImageSource, Message, StopReason, Timeouts, TokenUsage, add_cost};
@@ -448,8 +448,7 @@ pub struct SdkParams {
     pub permissions_config: PermissionsConfig,
     pub timeouts: Timeouts,
     pub prompt_slots: ResolvedSlots,
-    pub fast: bool,
-    pub workflow: bool,
+    pub defaults: SessionDefaults,
     pub model_policy: Arc<ModelPolicy>,
     pub plugin_rules: Arc<PluginRuleStore>,
     /// Plugins loaded here still want turn events, and this is what fires
@@ -532,8 +531,7 @@ pub fn run(params: SdkParams) -> Result<()> {
         permissions_config,
         timeouts,
         prompt_slots,
-        fast,
-        workflow,
+        defaults,
         model_policy,
         plugin_rules,
         lua_handle,
@@ -576,7 +574,7 @@ pub fn run(params: SdkParams) -> Result<()> {
         yolo: permission_mode == PermissionMode::BypassPermissions,
         system_prompt_override: cli.system_prompt.clone().filter(|s| !s.is_empty()),
         append_system_prompt: cli.append_system_prompt.clone().filter(|s| !s.is_empty()),
-        workflow,
+        defaults,
         model_policy: Arc::clone(&model_policy),
         plugin_rules,
         local_tools: Default::default(),
@@ -680,16 +678,8 @@ pub fn run(params: SdkParams) -> Result<()> {
                     shared.turn_start = Instant::now();
                     shared.permission_mode
                 };
-                let input = AgentInput {
-                    message: prompt,
-                    mode: mode.agent_mode(&cwd),
-                    images,
-                    preamble: Vec::new(),
-                    thinking: Default::default(),
-                    fast,
-                    workflow,
-                    prompt: None,
-                };
+                let input =
+                    AgentInput::from_defaults(prompt, mode.agent_mode(&cwd), images, defaults);
                 if handle.input_tx.send(input).is_err() {
                     break;
                 }


### PR DESCRIPTION
`always_thinking` was read in the TUI branch only, so `-p`, the SDK and ACP built their `AgentInput` with `thinking: Default::default()` and quietly thought nothing, while the same config in the same terminal gave the TUI effort high.

The three knobs now live together in `maki_config::SessionDefaults`, threaded as one value through `HeadlessParams`, `InteractiveParams`, `PrintParams`, `SdkParams` and `AcpParams`, so a knob added there lands in every frontend at once instead of in whichever was remembered.

`AgentInput::from_defaults` is the single constructor for a host with no toggle UI, and `SessionDefaults::seed` the single one for a fresh TUI session; neither consults the model, because `RequestOptions::clamped` is the one gate that reconciles toggles with what the model can do and it also handles `requires_thinking`, which the TUI-side copy got wrong.

ACP now honours all three instead of hardcoding them off, which put an unclamped `fast` in front of pricing, so `Model::list_cost` gates it against the model it is actually pricing rather than trusting three callers that price models they are not running.