### PR TITLE
feat(providers): send reasoning_effort for custom openai providers

### DIFF
--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -15,7 +15,7 @@ use crate::manifest::ManifestRegistry;
 use crate::model::{FastPricing, Model, ModelInfo, ModelPricing, ModelTier, ThinkingSupport};
 use crate::provider::{BoxFuture, Provider, ProviderKind};
 use crate::providers::Timeouts;
-use crate::types::ThinkingConfig;
+use crate::types::{ThinkingConfig, dialect};
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
 
 static CUSTOM_OPENAI_CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
@@ -269,6 +269,21 @@ struct CustomOpenAiProvider {
     protocol: Protocol,
 }
 
+impl CustomOpenAiProvider {
+    fn build_request_body(
+        &self,
+        model: &Model,
+        messages: &[Message],
+        system: &str,
+        tools: &Value,
+        thinking: ThinkingConfig,
+    ) -> Value {
+        let mut body = self.compat.build_body(model, messages, system, tools);
+        thinking.apply_reasoning_effort(&mut body, &dialect::OPENAI_COMPAT, model);
+        body
+    }
+}
+
 impl Provider for CustomOpenAiProvider {
     fn stream_message<'a>(
         &'a self,
@@ -297,10 +312,7 @@ impl Provider for CustomOpenAiProvider {
                 .await;
             }
 
-            let mut body = self.compat.build_body(model, messages, system, tools);
-            if matches!(opts.thinking, ThinkingConfig::Off) {
-                body["thinking"] = serde_json::json!({"type": "disabled"});
-            }
+            let body = self.build_request_body(model, messages, system, tools, opts.thinking);
             self.compat
                 .do_stream(model, &[], &body, event_tx, &auth)
                 .await
@@ -384,5 +396,32 @@ mod tests {
         overlay_declared_tiers(&def, &mut models);
         assert_eq!(models[0].tier, Some(ModelTier::Strong));
         assert_eq!(models[1].tier, None);
+    }
+
+    #[test_case::test_case(ThinkingConfig::Off, None ; "body_omits_effort_when_off")]
+    #[test_case::test_case(ThinkingConfig::Adaptive, Some("medium") ; "body_uses_medium_for_adaptive")]
+    #[test_case::test_case(ThinkingConfig::Effort(maki_storage::sessions::Effort::Minimal), Some("low") ; "body_snaps_minimal_to_low")]
+    #[test_case::test_case(ThinkingConfig::Effort(maki_storage::sessions::Effort::Low), Some("low") ; "body_sends_low")]
+    #[test_case::test_case(ThinkingConfig::Effort(maki_storage::sessions::Effort::Medium), Some("medium") ; "body_sends_medium")]
+    #[test_case::test_case(ThinkingConfig::Effort(maki_storage::sessions::Effort::High), Some("high") ; "body_sends_high")]
+    #[test_case::test_case(ThinkingConfig::Effort(maki_storage::sessions::Effort::Max), Some("high") ; "body_snaps_max_to_high")]
+    fn custom_openai_request_body_reasoning_effort(
+        thinking: ThinkingConfig,
+        expected: Option<&str>,
+    ) {
+        let def = openai_def("test-model");
+        let model = model_from_def(&def, ProviderKind::OpenAi, "custom", "test-model");
+        let auth = Arc::new(Mutex::new(ResolvedAuth::bearer("custom", "token").unwrap()));
+        let provider = CustomOpenAiProvider {
+            compat: OpenAiCompatProvider::new(&CUSTOM_OPENAI_CONFIG, Timeouts::default()),
+            auth,
+            protocol: Protocol::Openai,
+        };
+        let body = provider.build_request_body(&model, &[], "", &Value::Null, thinking);
+        assert_eq!(
+            body.get("reasoning_effort").and_then(Value::as_str),
+            expected
+        );
+        assert!(body.get("thinking").is_none());
     }
 }

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -520,6 +520,12 @@ pub mod dialect {
         adaptive: Some(Medium),
         off: None,
     };
+    /// Standard OpenAI chat completions: low, medium, high.
+    pub const OPENAI_COMPAT: EffortDialect = EffortDialect {
+        supported: &[Low, Medium, High],
+        adaptive: Some(Medium),
+        off: None,
+    };
     /// OpenAI Responses API models whose highest effort is `xhigh`.
     pub const CODEX: EffortDialect = EffortDialect {
         supported: &[Low, Medium, High, XHigh],
@@ -1047,7 +1053,7 @@ mod tests {
         assert!(!Arc::ptr_eq(&first.data, &read(INTERNED_DATA).data));
     }
 
-    use Effort::{High, Low, Max, Minimal, XHigh};
+    use Effort::{High, Low, Max, Medium, Minimal, XHigh};
 
     /// `max_output_tokens: 8192`, so `max_thinking_budget()` is 4096.
     fn thinking_model(id: &str) -> crate::model::Model {
@@ -1080,6 +1086,7 @@ mod tests {
     fn dialects_have_non_empty_ascending_supported() {
         let all = [
             &dialect::STANDARD,
+            &dialect::OPENAI_COMPAT,
             &dialect::CODEX,
             &dialect::CODEX_5_1,
             &dialect::CODING_PLAN,
@@ -1130,6 +1137,13 @@ mod tests {
     #[test_case(&dialect::STANDARD, ThinkingConfig::Effort(Minimal), Some("minimal") ; "standard_minimal_passthrough")]
     #[test_case(&dialect::STANDARD, ThinkingConfig::Effort(Max),     Some("high")    ; "standard_max_snaps_down")]
     #[test_case(&dialect::STANDARD, ThinkingConfig::Budget(1024),    Some("medium")  ; "standard_quarter_budget")]
+    #[test_case(&dialect::OPENAI_COMPAT, ThinkingConfig::Off,             None           ; "openai_compat_off")]
+    #[test_case(&dialect::OPENAI_COMPAT, ThinkingConfig::Adaptive,        Some("medium") ; "openai_compat_adaptive")]
+    #[test_case(&dialect::OPENAI_COMPAT, ThinkingConfig::Effort(Minimal), Some("low")    ; "openai_compat_minimal_snaps_up")]
+    #[test_case(&dialect::OPENAI_COMPAT, ThinkingConfig::Effort(Low),     Some("low")    ; "openai_compat_low")]
+    #[test_case(&dialect::OPENAI_COMPAT, ThinkingConfig::Effort(Medium),  Some("medium") ; "openai_compat_medium")]
+    #[test_case(&dialect::OPENAI_COMPAT, ThinkingConfig::Effort(High),    Some("high")   ; "openai_compat_high")]
+    #[test_case(&dialect::OPENAI_COMPAT, ThinkingConfig::Effort(Max),     Some("high")   ; "openai_compat_max_snaps_down")]
     #[test_case(&dialect::CODEX, ThinkingConfig::Adaptive,        Some("medium") ; "codex_adaptive")]
     #[test_case(&dialect::CODEX, ThinkingConfig::Effort(Minimal), Some("low")    ; "codex_minimal_snaps_up")]
     #[test_case(&dialect::CODEX, ThinkingConfig::Effort(Max),     Some("xhigh")  ; "codex_max_snaps_down")]


### PR DESCRIPTION
## Summary

When configuring custom OpenAI-compatible providers (`protocol = "openai"`) in `providers.toml`, Maki previously sent `{"thinking": {"type": "disabled"}}` when thinking was off and omitted reasoning parameters entirely when thinking was enabled.

This PR adds `reasoning_effort` support for custom OpenAI-compatible providers:
- Introduces the `OPENAI_COMPAT` effort dialect limited to `low`, `medium`, `high` (`adaptive` defaults to `medium`, `off` sends nothing).
- Applies `reasoning_effort` using this dialect when building chat completion request bodies in `CustomOpenAiProvider`.
- Removes the non-standard `thinking: {"type": "disabled"}` payload which triggers 400 errors on standard/strict OpenAI-compatible APIs.
- Adds unit tests in `types.rs` and `custom.rs` covering effort mapping, clamping, and body generation.