### PR TITLE
fix(providers): detect vision support for Ollama models

### DIFF
--- a/maki-providers/src/providers/local.rs
+++ b/maki-providers/src/providers/local.rs
@@ -390,6 +390,15 @@ struct OllamaShowResponse {
     parameters: Option<String>,
     #[serde(default)]
     model_info: Option<serde_json::Map<String, Value>>,
+    /// e.g. `["completion", "vision", "tools"]`; absent on older Ollama servers.
+    #[serde(default)]
+    capabilities: Option<Vec<String>>,
+}
+
+#[derive(Default)]
+struct OllamaModelDetails {
+    context_window: Option<u32>,
+    supports_vision: Option<bool>,
 }
 
 impl LocalEndpoint {
@@ -413,21 +422,21 @@ impl LocalEndpoint {
         let futures: Vec<_> = body
             .data
             .iter()
-            .map(|m| ollama_fetch_context_window(compat, auth, root, &m.id))
+            .map(|m| ollama_fetch_model_details(compat, auth, root, &m.id))
             .collect();
-        let context_windows = join_all(futures).await;
+        let details = join_all(futures).await;
 
         let mut models: Vec<crate::model::ModelInfo> = body
             .data
             .into_iter()
-            .zip(context_windows)
-            .map(|(m, context_window)| crate::model::ModelInfo {
+            .zip(details)
+            .map(|(m, d)| crate::model::ModelInfo {
                 id: m.id,
-                context_window,
+                context_window: d.context_window,
                 max_output_tokens: None,
                 pricing: Some(crate::model::ModelPricing::ZERO),
                 supports_thinking: None,
-                supports_vision: None,
+                supports_vision: d.supports_vision,
                 tier: None,
                 provider_info: None,
             })
@@ -437,15 +446,17 @@ impl LocalEndpoint {
     }
 }
 
-async fn ollama_fetch_context_window(
+async fn ollama_fetch_model_details(
     compat: &OpenAiCompatProvider,
     auth: &ResolvedAuth,
     root: &str,
     model_id: &str,
-) -> Option<u32> {
+) -> OllamaModelDetails {
     let show_url = format!("{root}/api/show");
     let body = json!({"model": model_id});
-    let json_body = serde_json::to_vec(&body).ok()?;
+    let Ok(json_body) = serde_json::to_vec(&body) else {
+        return OllamaModelDetails::default();
+    };
 
     let text = match compat
         .post_text(auth, &show_url, "application/json", &json_body)
@@ -454,30 +465,31 @@ async fn ollama_fetch_context_window(
         Ok(t) => t,
         Err(e) => {
             warn!(model = model_id, error = %e, "Ollama POST /api/show failed");
-            return None;
+            return OllamaModelDetails::default();
         }
     };
     let show: OllamaShowResponse = match serde_json::from_str(&text) {
         Ok(s) => s,
         Err(e) => {
             warn!(model = model_id, error = %e, "Failed to parse Ollama /api/show response");
-            return None;
+            return OllamaModelDetails::default();
         }
     };
 
-    if let Some(ref info) = show.model_info
-        && let Some(ctx) = ollama_extract_context_length(info)
-    {
-        return Some(ctx);
-    }
+    ollama_model_details(&show)
+}
 
-    if let Some(ref params) = show.parameters
-        && let Some(ctx) = ollama_extract_num_ctx(params)
-    {
-        return Some(ctx);
-    }
+fn ollama_model_details(show: &OllamaShowResponse) -> OllamaModelDetails {
+    let context_window = show
+        .model_info
+        .as_ref()
+        .and_then(ollama_extract_context_length)
+        .or_else(|| show.parameters.as_deref().and_then(ollama_extract_num_ctx));
 
-    None
+    OllamaModelDetails {
+        context_window,
+        supports_vision: ollama_extract_vision(show.capabilities.as_deref()),
+    }
 }
 
 fn ollama_extract_context_length(info: &serde_json::Map<String, Value>) -> Option<u32> {
@@ -491,6 +503,13 @@ fn ollama_extract_context_length(info: &serde_json::Map<String, Value>) -> Optio
                 .and_then(|(_, v)| v.as_u64())
                 .and_then(|v| u32::try_from(v).ok())
         })
+}
+
+/// `None` when the server didn't report capabilities at all (older Ollama),
+/// so discovery falls back to the family default instead of claiming "no
+/// vision" for a model it never actually checked.
+fn ollama_extract_vision(capabilities: Option<&[String]>) -> Option<bool> {
+    capabilities.map(|caps| caps.iter().any(|c| c == "vision"))
 }
 
 fn ollama_extract_num_ctx(params: &str) -> Option<u32> {
@@ -930,6 +949,52 @@ mod tests {
         fn ignores_props_in_router_mode() {
             let props = json!({"role": "router", "modalities": {"vision": true}});
             assert_eq!(llamacpp_props_vision(&props, &ServerMode::Router), None);
+        }
+    }
+
+    mod ollama_show_response {
+        use test_case::test_case;
+
+        use super::super::*;
+
+        const PARSE_FAILED: &str = "failed to parse /api/show body";
+        const CAPABILITIES_PLACEHOLDER: &str = "__CAPABILITIES__";
+        const CONTEXT_LENGTH: u32 = 128_000;
+
+        /// Shaped like a real Ollama `POST /api/show` body, so a rename or a
+        /// nesting change of any field discovery reads breaks these tests.
+        const SHOW_BODY: &str = r##"{
+  "license": "Apache License Version 2.0, January 2004",
+  "modelfile": "# Modelfile generated by \"ollama show\"\nFROM /root/.ollama/blobs/sha256-abc",
+  "parameters": "stop \"<|im_start|>\"\nnum_ctx 2048",
+  "template": "{{ .Prompt }}",
+  "details": {
+    "parent_model": "",
+    "format": "gguf",
+    "family": "qwen25vl",
+    "families": ["qwen25vl", "clip"],
+    "parameter_size": "8.3B",
+    "quantization_level": "Q4_K_M"
+  },
+  "model_info": {
+    "general.architecture": "qwen25vl",
+    "qwen25vl.context_length": 128000,
+    "qwen25vl.embedding_length": 3584
+  },
+  __CAPABILITIES__
+  "modified_at": "2026-01-01T12:00:00.000000000-05:00"
+}"##;
+
+        #[test_case(r#""capabilities": ["completion", "vision"],"#, Some(true)  ; "vision_capability")]
+        #[test_case(r#""capabilities": ["completion", "tools"],"#, Some(false) ; "no_vision_capability")]
+        #[test_case("", None ; "capabilities_omitted_by_old_server")]
+        fn parses_details(capabilities_field: &str, expected_vision: Option<bool>) {
+            let body = SHOW_BODY.replace(CAPABILITIES_PLACEHOLDER, capabilities_field);
+            let show: OllamaShowResponse = serde_json::from_str(&body).expect(PARSE_FAILED);
+
+            let details = ollama_model_details(&show);
+            assert_eq!(details.supports_vision, expected_vision);
+            assert_eq!(details.context_window, Some(CONTEXT_LENGTH));
         }
     }
 


### PR DESCRIPTION
## Problem

Attaching an image to a prompt while running any model through Ollama (`OLLAMA_HOST` set, local or remote) silently drops it — the message that reaches the model is `[image omitted: the current model does not support image input]`, even for genuinely multimodal models like `llava`, `qwen2.5vl`, `llama3.2-vision`, or `gemma3`.

## Root cause

`Model::supports_vision()` resolves in order: an explicit override → discovery-reported capability → the static per-model table → the model's family default.

For Ollama:
- `discover_ollama_models` (`maki-providers/src/providers/local.rs`) always set `supports_vision: None` on every discovered model, regardless of what the model actually supports.
- The builtin Ollama model table (`maki-providers/src/providers/ollama.rs::models()`) is empty, so there's no static fallback either.
- That leaves the family default, and Ollama models get `ModelFamily::Generic`, whose `supports_vision()` is hardcoded `false`.

So `supports_vision()` was unconditionally `false` for every Ollama model, and `adapt_images_for_model` (`maki-providers/src/types.rs`) stripped the image before the request went out.

The frustrating part: `/api/show` — which discovery already calls per-model just to read the context window — reports a `capabilities` array (e.g. `["completion", "vision"]`) on Ollama servers new enough to send it. That information was already being fetched and just never read.

## Fix

Extend the existing `/api/show` parsing to also read `capabilities`, and set `supports_vision` from whether it contains `"vision"` instead of hardcoding `None`. Renamed `ollama_fetch_context_window` to `ollama_fetch_model_details` since it now returns both pieces of info from the one call — no extra request added.

`None` (server capabilities-less) still defers to the family default rather than claiming "no vision," so older Ollama servers that don't send `capabilities` keep today's behavior.

## Testing

- New unit tests for the `capabilities` → vision extraction (`ollama_extract_vision`), following the same pattern as the existing `ollama_extract_context_length` tests.
- `cargo test -p maki-providers`, `cargo clippy -p maki-providers --tests -- -D warnings`, and `cargo fmt --all -- --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
