### PR TITLE
Bash permissions improvements

### DIFF
--- a/maki-agent/src/permissions.rs
+++ b/maki-agent/src/permissions.rs
@@ -770,7 +770,14 @@ pub fn scope_matches(pattern: &str, value: &str) -> bool {
         return true;
     }
     if let Some(prefix) = pattern.strip_suffix(" *") {
-        return value == prefix || value.starts_with(&format!("{prefix} "));
+        // The separator between command and arguments can be any whitespace,
+        // not just a space: `rm *` must cover `rm\t-rf /` too.
+        if value == prefix {
+            return true;
+        }
+        return value
+            .strip_prefix(prefix)
+            .is_some_and(|rest| rest.starts_with(char::is_whitespace));
     }
     if let Some(prefix) = pattern.strip_suffix('*') {
         return value.starts_with(prefix);
@@ -941,6 +948,9 @@ mod tests {
     #[test_case("pwd *", "pwd" => true ; "space_star_matches_bare_command")]
     #[test_case("pwd *", "pwd -L" => true ; "space_star_matches_with_args")]
     #[test_case("pwd *", "pwdx" => false ; "space_star_no_partial_token")]
+    #[test_case("rm *", "rm\t-rf /" => true ; "space_star_tab_separator")]
+    #[test_case("rm *", "rm\n-rf /" => true ; "space_star_newline_separator")]
+    #[test_case("rm *", "rm\r-rf /" => true ; "space_star_crlf_separator")]
     #[test_case("src/**", "src/main.rs" => true ; "glob")]
     #[test_case("src/**", "src/deep/nested/file.rs" => true ; "glob_deep_nested")]
     #[test_case("src/**", "src" => true ; "glob_exact_prefix")]

--- a/maki-agent/src/permissions.rs
+++ b/maki-agent/src/permissions.rs
@@ -1335,6 +1335,93 @@ mod tests {
         assert!(matches!(check, PermissionCheck::Denied), "got {check:?}");
     }
 
+    /// The bash plugin emits a block's inner commands as additional scopes, so
+    /// a deny rule reaches a command the loop body runs.
+    #[test]
+    fn deny_rule_reaches_commands_inside_a_block() {
+        let mgr = mgr_with(
+            make_config(vec![deny_rule("sudo *")]),
+            PathBuf::from("/tmp"),
+        );
+        assert!(matches!(
+            mgr.check_multi(
+                &ToolKey::native("bash"),
+                &["while true; do sudo x; done", "true", "sudo x"],
+                false,
+                None,
+            ),
+            PermissionCheck::Denied
+        ));
+    }
+
+    /// The loop's condition is a scope too, so a deny rule on the header
+    /// command denies the whole block, no prompt.
+    #[test]
+    fn deny_rule_reaches_loop_header_command() {
+        let mgr = mgr_with(
+            make_config(vec![deny_rule("true *")]),
+            PathBuf::from("/tmp"),
+        );
+        assert!(matches!(
+            mgr.check_multi(
+                &ToolKey::native("bash"),
+                &["while true; do echo hi; done", "true", "echo hi"],
+                false,
+                None,
+            ),
+            PermissionCheck::Denied
+        ));
+    }
+
+    /// One denied inner scope denies the whole block, even when every other
+    /// scope is allowed.
+    #[test]
+    fn one_denied_inner_scope_denies_whole_block() {
+        let mgr = mgr_with(
+            make_config(vec![
+                allow_rule("true *"),
+                allow_rule("echo *"),
+                deny_rule("sudo *"),
+            ]),
+            PathBuf::from("/tmp"),
+        );
+        assert!(matches!(
+            mgr.check_multi(
+                &ToolKey::native("bash"),
+                &[
+                    "while true; do echo hi && sudo x; done",
+                    "true",
+                    "echo hi",
+                    "sudo x"
+                ],
+                false,
+                None,
+            ),
+            PermissionCheck::Denied
+        ));
+    }
+
+    /// An allow rule on a block's inner command claims just that scope: the
+    /// block scope stays unclaimed, so the loop itself is never approved by it.
+    #[test]
+    fn allow_rule_on_inner_command_does_not_claim_block() {
+        let mgr = mgr_with(
+            make_config(vec![allow_rule("true *"), allow_rule("sudo *")]),
+            PathBuf::from("/tmp"),
+        );
+        match mgr.check_multi(
+            &ToolKey::native("bash"),
+            &["while true; do sudo x; done", "true", "sudo x"],
+            false,
+            None,
+        ) {
+            PermissionCheck::NeedsPrompt { scopes, .. } => {
+                assert_eq!(scopes, vec!["while true; do sudo x; done"]);
+            }
+            other => panic!("expected NeedsPrompt, got {other:?}"),
+        }
+    }
+
     #[test]
     fn apply_decision_multi_scope_generalizes_all() {
         let mgr = default_mgr();

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -5250,8 +5250,8 @@ fn bash_permission_scopes_never_falls_back_to_json(command: &str) {
 )]
 #[test_case::test_case(
     "if [ -f x ]; then rm x; fi",
-    &["if [ -f x ]; then rm x; fi"]
-    ; "block_stays_one_scope"
+    &["if [ -f x ]; then rm x; fi", "[ -f x ]", "rm x"]
+    ; "block_scope_kept_and_inner_commands_added"
 )]
 #[test_case::test_case(
     "cd /tmp && > log",
@@ -5259,6 +5259,60 @@ fn bash_permission_scopes_never_falls_back_to_json(command: &str) {
     ; "bodiless_redirect_is_its_own_scope"
 )]
 fn bash_permission_scopes_split_per_command(command: &str, expected: &[&str]) {
+    let (reg, _host) = builtins_host();
+
+    let input = serde_json::json!({ "command": command });
+    let entry = reg.get("bash").expect("bash registered");
+    let inv = entry.tool.parse(&input).expect("parse failed");
+    let scopes = smol::block_on(inv.permission_scopes()).expect("permission_scopes returned None");
+
+    assert!(!scopes.force_prompt, "command: {command}");
+    assert_eq!(scopes.scopes, expected, "command: {command}");
+}
+
+/// A block stays one scope, but the commands it runs come along as additional
+/// scopes: deny reaches inside, and an allow on one can't claim the block.
+#[test_case::test_case(
+    "for f in *.rs; do wc -l $f; done",
+    &["for f in *.rs; do wc -l $f; done", "wc -l $f"]
+    ; "for_loop_body"
+)]
+#[test_case::test_case(
+    "while true; do sudo x; done",
+    &["while true; do sudo x; done", "true", "sudo x"]
+    ; "while_loop_head_and_body"
+)]
+#[test_case::test_case(
+    "until cargo test; do sleep 1; done",
+    &["until cargo test; do sleep 1; done", "cargo test", "sleep 1"]
+    ; "until_loop_head_and_body"
+)]
+#[test_case::test_case(
+    "case $x in a) rm -rf / ;; esac",
+    &["case $x in a) rm -rf / ;; esac", "rm -rf /"]
+    ; "case_body"
+)]
+#[test_case::test_case(
+    "{ rm -rf ~; }",
+    &["{ rm -rf ~; }", "rm -rf ~"]
+    ; "brace_group_body"
+)]
+#[test_case::test_case(
+    "for ((i=0;i<5;i++)); do rm $i; done",
+    &["for ((i=0;i<5;i++)); do rm $i; done", "rm $i"]
+    ; "c_style_for_body"
+)]
+#[test_case::test_case(
+    "if a; then if b; then c; fi; fi",
+    &["if a; then if b; then c; fi; fi", "a", "b", "c"]
+    ; "nested_blocks"
+)]
+#[test_case::test_case(
+    "while true; do echo hi && sudo x; done",
+    &["while true; do echo hi && sudo x; done", "true", "echo hi", "sudo x"]
+    ; "while_list_body"
+)]
+fn bash_block_scopes_include_inner_commands(command: &str, expected: &[&str]) {
     let (reg, _host) = builtins_host();
 
     let input = serde_json::json!({ "command": command });

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -5349,6 +5349,94 @@ fn bash_scopes_unwrap_prefix_commands(command: &str, expected: &[&str]) {
     assert_eq!(scopes.scopes, expected, "command: {command}");
 }
 
+/// A leading `!` before a compound statement mis-parses in tree-sitter, so it
+/// is stripped before parsing: the negation changes nothing about what runs.
+#[test_case::test_case("! { rm x; }", &["{ rm x; }", "rm x"] ; "negated_brace_group")]
+#[test_case::test_case(
+    "! if a; then rm x; fi",
+    &["if a; then rm x; fi", "a", "rm x"]
+    ; "negated_if"
+)]
+#[test_case::test_case(
+    "! while true; do sudo x; done",
+    &["while true; do sudo x; done", "true", "sudo x"]
+    ; "negated_loop"
+)]
+#[test_case::test_case("! ls | grep x", &["ls", "grep x"] ; "negated_pipeline")]
+fn bash_scopes_strip_leading_negation(command: &str, expected: &[&str]) {
+    let (reg, _host) = builtins_host();
+
+    let input = serde_json::json!({ "command": command });
+    let entry = reg.get("bash").expect("bash registered");
+    let inv = entry.tool.parse(&input).expect("parse failed");
+    let scopes = smol::block_on(inv.permission_scopes()).expect("permission_scopes returned None");
+
+    assert!(!scopes.force_prompt, "command: {command}");
+    assert_eq!(scopes.scopes, expected, "command: {command}");
+}
+
+/// A `!` that is not the command's leading token only wraps a simple command
+/// (a `negated_command`), which `command_scope` already unwraps, so nested
+/// negation of a simple command scopes the wrapped command as usual.
+#[test_case::test_case(
+    "if a; then ! rm x; fi",
+    &["if a; then ! rm x; fi", "a", "rm x"]
+    ; "negated_simple_in_if"
+)]
+fn bash_scopes_nested_negation(command: &str, expected: &[&str]) {
+    let (reg, _host) = builtins_host();
+
+    let input = serde_json::json!({ "command": command });
+    let entry = reg.get("bash").expect("bash registered");
+    let inv = entry.tool.parse(&input).expect("parse failed");
+    let scopes = smol::block_on(inv.permission_scopes()).expect("permission_scopes returned None");
+
+    assert!(!scopes.force_prompt, "command: {command}");
+    assert_eq!(scopes.scopes, expected, "command: {command}");
+}
+
+/// A `!` before a compound statement mis-parses anywhere it begins a pipeline,
+/// so it is stripped before parsing (as it is when leading): the negation
+/// changes nothing about what runs. The scopes reflect the stripped command.
+#[test_case::test_case(
+    "if a; then ! { rm x; }; fi",
+    &["if a; then { rm x; }; fi", "a", "rm x"]
+    ; "negated_compound_in_if"
+)]
+#[test_case::test_case(
+    "a && ! { rm x; }",
+    &["a", "{ rm x; }", "rm x"]
+    ; "negated_compound_in_list"
+)]
+fn bash_scopes_strip_nested_compound_negation(command: &str, expected: &[&str]) {
+    let (reg, _host) = builtins_host();
+
+    let input = serde_json::json!({ "command": command });
+    let entry = reg.get("bash").expect("bash registered");
+    let inv = entry.tool.parse(&input).expect("parse failed");
+    let scopes = smol::block_on(inv.permission_scopes()).expect("permission_scopes returned None");
+
+    assert!(!scopes.force_prompt, "command: {command}");
+    assert_eq!(scopes.scopes, expected, "command: {command}");
+}
+
+/// A `!` that does not negate a compound statement — inside quotes, or an
+/// argument rather than a pipeline head — is left in place: stripping it would
+/// rewrite the command's scope.
+#[test_case::test_case("echo \"a; ! if b\"", &["echo \"a; ! if b\""] ; "in_quotes")]
+#[test_case::test_case("echo ! if", &["echo ! if"] ; "as_argument")]
+fn bash_scopes_leaves_non_negating_bang(command: &str, expected: &[&str]) {
+    let (reg, _host) = builtins_host();
+
+    let input = serde_json::json!({ "command": command });
+    let entry = reg.get("bash").expect("bash registered");
+    let inv = entry.tool.parse(&input).expect("parse failed");
+    let scopes = smol::block_on(inv.permission_scopes()).expect("permission_scopes returned None");
+
+    assert!(!scopes.force_prompt, "command: {command}");
+    assert_eq!(scopes.scopes, expected, "command: {command}");
+}
+
 fn exec_tool_with_perms(
     perms: maki_lua::PluginPermissions,
     src: &str,

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -5324,6 +5324,31 @@ fn bash_block_scopes_include_inner_commands(command: &str, expected: &[&str]) {
     assert_eq!(scopes.scopes, expected, "command: {command}");
 }
 
+/// `time`/`nohup`/`env`/`exec`/`stdbuf` wrap a command without changing what
+/// runs, and `!` only inverts the exit status: scope the wrapped command.
+#[test_case::test_case("time cargo test", &["cargo test"] ; "time")]
+#[test_case::test_case("nohup cargo test", &["cargo test"] ; "nohup")]
+#[test_case::test_case("env FOO=1 cargo test", &["FOO=1 cargo test"] ; "env_with_assignment")]
+#[test_case::test_case("exec sudo x", &["sudo x"] ; "exec")]
+#[test_case::test_case("stdbuf -o0 cargo test", &["cargo test"] ; "stdbuf_flags")]
+#[test_case::test_case("stdbuf cargo test", &["cargo test"] ; "stdbuf_bare")]
+#[test_case::test_case("! rm -rf /", &["rm -rf /"] ; "negated")]
+#[test_case::test_case("! time rm -rf /", &["rm -rf /"] ; "negated_then_prefix")]
+#[test_case::test_case("time nohup cargo test", &["cargo test"] ; "chained_prefixes")]
+#[test_case::test_case("rm time", &["rm time"] ; "prefix_word_as_argument")]
+#[test_case::test_case("time", &["time"] ; "bare_prefix_word")]
+fn bash_scopes_unwrap_prefix_commands(command: &str, expected: &[&str]) {
+    let (reg, _host) = builtins_host();
+
+    let input = serde_json::json!({ "command": command });
+    let entry = reg.get("bash").expect("bash registered");
+    let inv = entry.tool.parse(&input).expect("parse failed");
+    let scopes = smol::block_on(inv.permission_scopes()).expect("permission_scopes returned None");
+
+    assert!(!scopes.force_prompt, "command: {command}");
+    assert_eq!(scopes.scopes, expected, "command: {command}");
+}
+
 fn exec_tool_with_perms(
     perms: maki_lua::PluginPermissions,
     src: &str,

--- a/plugins/bash/init.lua
+++ b/plugins/bash/init.lua
@@ -210,16 +210,46 @@ local WALK_THROUGH_TYPES = {
   redirected_statement = true,
 }
 
+-- Block forms: kept as one scope, plus their inner commands as scopes, so a
+-- deny rule reaches inside and an allow on one can't claim the block.
+local BLOCK_TYPES = {
+  if_statement = true,
+  for_statement = true,
+  while_statement = true,
+  c_style_for_statement = true,
+  case_statement = true,
+  compound_statement = true,
+}
+
+-- The smallest command nodes a rule can be about.
+local ATOMIC_COMMAND_TYPES = {
+  command = true,
+  negated_command = true,
+  test_command = true,
+  declaration_command = true,
+  unset_command = true,
+}
+
 local function node_text(node, source)
   return maki.treesitter.get_node_text(node, source):match("^%s*(.-)%s*$")
 end
 
--- Anything we don't walk through becomes one scope, its own text. That covers
--- plain commands and the block forms (`if`, `while`, subshells) we deliberately
--- keep whole, plus any node type we never thought of, which is what we want:
--- an unknown node has to end up in front of the user, not get dropped.
-local function collect_commands(node, source)
-  if not WALK_THROUGH_TYPES[node:type()] then
+local function attach_redirects(out, redirects)
+  if #redirects == 0 then
+    return
+  end
+  local text = table.concat(redirects, " ")
+  if #out > 0 then
+    out[#out] = out[#out] .. " " .. text
+  else
+    out[1] = text
+  end
+end
+
+-- The commands a block runs, through nested pipelines, lists, redirects and
+-- blocks. Non-command words (loop variables, `case` patterns) yield nothing.
+local function inner_commands(node, source)
+  if ATOMIC_COMMAND_TYPES[node:type()] then
     local text = node_text(node, source)
     return text ~= "" and { text } or {}
   end
@@ -231,22 +261,54 @@ local function collect_commands(node, source)
       if REDIRECT_TYPES[kind] then
         redirects[#redirects + 1] = node_text(child, source)
       else
-        for _, cmd in ipairs(collect_commands(child, source)) do
+        for _, cmd in ipairs(inner_commands(child, source)) do
           out[#out + 1] = cmd
         end
       end
     end
   end
+  attach_redirects(out, redirects)
+  return out
+end
 
-  -- The redirect belongs to the last command of the chain, the one bash would
-  -- actually apply it to. A bodiless `> log` has no such command and still
-  -- truncates the file, so it becomes a scope of its own instead of vanishing.
-  if #redirects > 0 then
-    local text = table.concat(redirects, " ")
-    if #out > 0 then
-      out[#out] = out[#out] .. " " .. text
-    else
-      out[1] = text
+-- Anything we don't walk through becomes a scope of its own text, so an
+-- unknown node reaches the user instead of getting dropped. Blocks add their
+-- inner commands as scopes too.
+local function collect_commands(node, source)
+  if WALK_THROUGH_TYPES[node:type()] then
+    local out, redirects = {}, {}
+    for child in node:iter_children() do
+      local kind = child:type()
+      if child:named() and kind ~= "comment" then
+        if REDIRECT_TYPES[kind] then
+          redirects[#redirects + 1] = node_text(child, source)
+        else
+          for _, cmd in ipairs(collect_commands(child, source)) do
+            out[#out + 1] = cmd
+          end
+        end
+      end
+    end
+
+    -- The redirect belongs to the last command of the chain, the one bash
+    -- would actually apply it to. A bodiless `> log` has no such command and
+    -- still truncates the file, so it becomes a scope of its own.
+    attach_redirects(out, redirects)
+    return out
+  end
+
+  local text = node_text(node, source)
+  if text == "" then
+    return {}
+  end
+  local out = { text }
+  if BLOCK_TYPES[node:type()] then
+    local seen = {}
+    for _, inner in ipairs(inner_commands(node, source)) do
+      if not seen[inner] then
+        seen[inner] = true
+        out[#out + 1] = inner
+      end
     end
   end
   return out

--- a/plugins/bash/init.lua
+++ b/plugins/bash/init.lua
@@ -234,6 +234,65 @@ local function node_text(node, source)
   return maki.treesitter.get_node_text(node, source):match("^%s*(.-)%s*$")
 end
 
+-- `time`/`nohup`/`env`/`exec`/`stdbuf` wrap a command, so scope what runs.
+-- Tried one at a time: the LuaU runtime we ship never matches `|` alternation.
+local PREFIX_WORDS = { "time", "nohup", "env", "exec" }
+
+-- stdbuf's own flags (`-o0`, ...) are not part of the command it runs.
+local function strip_flags(text)
+  while true do
+    local rest = text:match("^%-%S+%s+(.+)$")
+    if rest then
+      text = rest
+    else
+      return text
+    end
+  end
+end
+
+local function unwrap_prefixes(text)
+  while true do
+    local rest
+    for _, p in ipairs(PREFIX_WORDS) do
+      rest = text:match("^" .. p .. "%s+(.+)$")
+      if rest then
+        break
+      end
+    end
+    if rest then
+      text = rest
+    else
+      local body = text:match("^stdbuf%s+(.+)$")
+      if body then
+        text = strip_flags(body)
+      else
+        return text
+      end
+    end
+  end
+end
+
+-- The scope for a command leaf. `!` only inverts the exit status, so scope
+-- the wrapped command, not the negation.
+local function command_scope(node, source)
+  local kind = node:type()
+  if kind == "negated_command" then
+    for child in node:iter_children() do
+      if child:named() and child:type() == "command" then
+        local inner = node_text(child, source)
+        if inner ~= "" then
+          return unwrap_prefixes(inner)
+        end
+      end
+    end
+  end
+  local text = node_text(node, source)
+  if text == "" then
+    return nil
+  end
+  return kind == "command" and unwrap_prefixes(text) or text
+end
+
 local function attach_redirects(out, redirects)
   if #redirects == 0 then
     return
@@ -250,8 +309,8 @@ end
 -- blocks. Non-command words (loop variables, `case` patterns) yield nothing.
 local function inner_commands(node, source)
   if ATOMIC_COMMAND_TYPES[node:type()] then
-    local text = node_text(node, source)
-    return text ~= "" and { text } or {}
+    local scope = command_scope(node, source)
+    return scope and { scope } or {}
   end
 
   local out, redirects = {}, {}
@@ -297,11 +356,11 @@ local function collect_commands(node, source)
     return out
   end
 
-  local text = node_text(node, source)
-  if text == "" then
+  local scope = command_scope(node, source)
+  if scope == nil then
     return {}
   end
-  local out = { text }
+  local out = { scope }
   if BLOCK_TYPES[node:type()] then
     local seen = {}
     for _, inner in ipairs(inner_commands(node, source)) do

--- a/plugins/bash/init.lua
+++ b/plugins/bash/init.lua
@@ -293,6 +293,101 @@ local function command_scope(node, source)
   return kind == "command" and unwrap_prefixes(text) or text
 end
 
+-- tree-sitter's `!` only negates a simple command; before a compound statement
+-- it mis-parses into garbage scopes. `!` only inverts the exit status, so drop
+-- any `!` that negates a compound statement, wherever it begins a pipeline
+-- (not just the leading one). A `!` before a simple command is left alone (it
+-- parses as a `negated_command`), and so is a `!` inside quotes or one that
+-- does not start a pipeline (e.g. an argument like `echo ! if`).
+local COMPOUND_KEYWORDS = { "{", "if", "while", "until", "for", "case" }
+local PIPELINE_START_KEYWORDS = { "then", "do", "else", "elif" }
+
+local function at_pipeline_start(command, i)
+  local j = i - 1
+  while j >= 1 and command:sub(j, j):match("%s") do
+    j = j - 1
+  end
+  if j < 1 then
+    return true
+  end
+  local c = command:sub(j, j)
+  if c == ";" or c == "|" or c == "&" or c == "(" or c == "{" then
+    return true
+  end
+  for _, kw in ipairs(PIPELINE_START_KEYWORDS) do
+    local start = j - #kw + 1
+    if start >= 1 and command:sub(start, j) == kw then
+      local before = start > 1 and command:sub(start - 1, start - 1) or ""
+      if before == "" or before:match("%s") then
+        return true
+      end
+    end
+  end
+  return false
+end
+
+local function strip_compound_negations(command)
+  local out = {}
+  local n = #command
+  local i = 1
+  while i <= n do
+    local c = command:sub(i, i)
+    if c == "'" then
+      out[#out + 1] = c
+      i = i + 1
+      while i <= n and command:sub(i, i) ~= "'" do
+        out[#out + 1] = command:sub(i, i)
+        i = i + 1
+      end
+      if i <= n then
+        out[#out + 1] = command:sub(i, i)
+        i = i + 1
+      end
+    elseif c == '"' then
+      out[#out + 1] = c
+      i = i + 1
+      while i <= n do
+        local q = command:sub(i, i)
+        out[#out + 1] = q
+        if q == "\\" and i < n then
+          out[#out + 1] = command:sub(i + 1, i + 1)
+          i = i + 2
+        else
+          i = i + 1
+          if q == '"' then
+            break
+          end
+        end
+      end
+    elseif c == "!" then
+      local rest = command:sub(i + 1)
+      local ws, after_ws = rest:match("^(%s+)(.*)$")
+      local negates = false
+      if ws and at_pipeline_start(command, i) then
+        for _, kw in ipairs(COMPOUND_KEYWORDS) do
+          if after_ws:sub(1, #kw) == kw then
+            local after = after_ws:sub(#kw + 1, #kw + 1)
+            if after == "" or after:match("^%s$") or after == ";" or after == "(" then
+              negates = true
+              break
+            end
+          end
+        end
+      end
+      if negates then
+        i = i + 1 + #ws
+      else
+        out[#out + 1] = c
+        i = i + 1
+      end
+    else
+      out[#out + 1] = c
+      i = i + 1
+    end
+  end
+  return table.concat(out)
+end
+
 -- Redirects attach to the last command of the chain, the one bash would
 -- actually apply it to. A bodiless `> log` has no such command and becomes a
 -- scope of its own instead of vanishing: it still truncates the file.
@@ -407,7 +502,11 @@ maki.api.register_tool({
       return nil
     end
 
-    local parser = maki.treesitter.get_parser(command, "bash")
+    -- A `!` mis-parses the compound statement it negates, so drop such
+    -- negations before parsing: they change nothing about what runs.
+    local parse = strip_compound_negations(command)
+
+    local parser = maki.treesitter.get_parser(parse, "bash")
     if not parser then
       return { scopes = { command }, force_prompt = true }
     end
@@ -417,7 +516,7 @@ maki.api.register_tool({
       return { scopes = { command }, force_prompt = true }
     end
 
-    local segments = collect_commands(root, command)
+    local segments = collect_commands(root, parse)
     if #segments == 0 then
       segments = { command }
     end

--- a/plugins/bash/init.lua
+++ b/plugins/bash/init.lua
@@ -293,6 +293,9 @@ local function command_scope(node, source)
   return kind == "command" and unwrap_prefixes(text) or text
 end
 
+-- Redirects attach to the last command of the chain, the one bash would
+-- actually apply it to. A bodiless `> log` has no such command and becomes a
+-- scope of its own instead of vanishing: it still truncates the file.
 local function attach_redirects(out, redirects)
   if #redirects == 0 then
     return
@@ -305,14 +308,9 @@ local function attach_redirects(out, redirects)
   end
 end
 
--- The commands a block runs, through nested pipelines, lists, redirects and
--- blocks. Non-command words (loop variables, `case` patterns) yield nothing.
-local function inner_commands(node, source)
-  if ATOMIC_COMMAND_TYPES[node:type()] then
-    local scope = command_scope(node, source)
-    return scope and { scope } or {}
-  end
-
+-- The shared child walk: named, non-comment children yield their scopes
+-- through {recurse}, redirects are handled by attach_redirects.
+local function walk_children(node, source, recurse)
   local out, redirects = {}, {}
   for child in node:iter_children() do
     local kind = child:type()
@@ -320,7 +318,7 @@ local function inner_commands(node, source)
       if REDIRECT_TYPES[kind] then
         redirects[#redirects + 1] = node_text(child, source)
       else
-        for _, cmd in ipairs(inner_commands(child, source)) do
+        for _, cmd in ipairs(recurse(child, source)) do
           out[#out + 1] = cmd
         end
       end
@@ -330,30 +328,22 @@ local function inner_commands(node, source)
   return out
 end
 
+-- The commands a block runs, through nested pipelines, lists, redirects and
+-- blocks. Non-command words (loop variables, `case` patterns) yield nothing.
+local function inner_commands(node, source)
+  if ATOMIC_COMMAND_TYPES[node:type()] then
+    local scope = command_scope(node, source)
+    return scope and { scope } or {}
+  end
+  return walk_children(node, source, inner_commands)
+end
+
 -- Anything we don't walk through becomes a scope of its own text, so an
 -- unknown node reaches the user instead of getting dropped. Blocks add their
 -- inner commands as scopes too.
 local function collect_commands(node, source)
   if WALK_THROUGH_TYPES[node:type()] then
-    local out, redirects = {}, {}
-    for child in node:iter_children() do
-      local kind = child:type()
-      if child:named() and kind ~= "comment" then
-        if REDIRECT_TYPES[kind] then
-          redirects[#redirects + 1] = node_text(child, source)
-        else
-          for _, cmd in ipairs(collect_commands(child, source)) do
-            out[#out + 1] = cmd
-          end
-        end
-      end
-    end
-
-    -- The redirect belongs to the last command of the chain, the one bash
-    -- would actually apply it to. A bodiless `> log` has no such command and
-    -- still truncates the file, so it becomes a scope of its own.
-    attach_redirects(out, redirects)
-    return out
+    return walk_children(node, source, collect_commands)
   end
 
   local scope = command_scope(node, source)


### PR DESCRIPTION
As last time, I did not review this at all yet but just made sure the idea makes sense to me.

@tontinton Can you check each individual commit (just the commit message is fine)? If it is I'll review/clean up the code accordingly.

Personally:

  - The "let deny rules reach the commands a bash block runs" seems uncontroversial. It doesn't allow anything new but if there's a denied command in a loop it just denies immediately. Also adds more scopes to the prompt so the user can't so easily miss a bad command in a loop
  - "scope bash prefix wrappers to the command they run" doesn't seem very important to me, more nice to have
  - "fix(permissions): match bash cmd * rules across any whitespace separator" seems uncontroversial and and important gap in the permission checks
  - "share the child walk between the scope collectors" is just a refactoring
  - "fix(permissions): strip a leading ! before parsing bash scopes" handles negations in a more sensible way. Previously just caused asking the user (I think), now actually parses it