### PR TITLE
feat(ui): bind PageUp/PageDown to page scrolling in the chat

### DIFF
--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -856,6 +856,17 @@ impl App {
             return actions;
         }
 
+        if key::SCROLL_PAGE_UP.matches(key) {
+            let page = self.chats[self.active_chat].page();
+            self.active_chat().scroll(page);
+            return vec![];
+        }
+        if key::SCROLL_PAGE_DOWN.matches(key) {
+            let page = self.chats[self.active_chat].page();
+            self.active_chat().scroll(-page);
+            return vec![];
+        }
+
         if !self.is_main_chat() {
             return match key.code {
                 KeyCode::Tab if !self.is_bash_input() => self.toggle_mode(),

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -1509,6 +1509,8 @@ fn cancelling_from_inside_a_subagent_reports_error() {
 const OVERLAY_BLOCKED_KEYS: &[KeyEvent] = &[
     kb::SCROLL_HALF_UP.to_key_event(),
     kb::SCROLL_HALF_DOWN.to_key_event(),
+    kb::SCROLL_PAGE_UP.to_key_event(),
+    kb::SCROLL_PAGE_DOWN.to_key_event(),
     kb::HELP.to_key_event(),
 ];
 
@@ -1548,6 +1550,42 @@ fn overlay_blocks_ctrl_shortcuts(setup: fn(&mut App)) {
         app.chats[app.active_chat].scroll_pos(),
         scroll_before,
         "scroll changed through overlay"
+    );
+}
+
+#[test]
+fn page_keys_scroll_the_transcript_by_one_page() {
+    let area = Rect::new(0, 0, 80, 20);
+    let mut app = app_with_transcript(area);
+    let start = app.active_chat().win_view();
+    assert!(
+        start.scroll_top > 0,
+        "the transcript must overflow the viewport for this to prove anything"
+    );
+
+    app.update(Msg::Key(kb::SCROLL_PAGE_UP.to_key_event()));
+    let up = app.active_chat().win_view();
+    assert_eq!(
+        start.scroll_top - up.scroll_top,
+        u32::from(start.height),
+        "page up moves the viewport up by one page"
+    );
+    assert!(!up.auto_scroll, "page up unpins the transcript");
+
+    app.update(Msg::Key(kb::SCROLL_PAGE_DOWN.to_key_event()));
+    let backend = ratatui::backend::TestBackend::new(area.width, area.bottom());
+    let mut terminal = ratatui::Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| app.active_chat().view(frame, area, false))
+        .unwrap();
+    let down = app.active_chat().win_view();
+    assert_eq!(
+        down.scroll_top, start.scroll_top,
+        "page down lands back on the bottom"
+    );
+    assert!(
+        down.auto_scroll,
+        "landing on the bottom re-pins the transcript"
     );
 }
 

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -223,6 +223,10 @@ impl Chat {
         self.messages_panel.half_page()
     }
 
+    pub fn page(&self) -> i32 {
+        self.messages_panel.page()
+    }
+
     pub fn win_view(&self) -> WinView {
         self.messages_panel.win_view()
     }

--- a/maki-ui/src/components/keybindings.rs
+++ b/maki-ui/src/components/keybindings.rs
@@ -132,6 +132,16 @@ pub mod key {
     pub const SESSIONS: Bind = ctrl_bind!('p');
     pub const SCROLL_HALF_UP: Bind = ctrl_bind!('u');
     pub const SCROLL_HALF_DOWN: Bind = ctrl_bind!('d');
+    pub const SCROLL_PAGE_UP: Bind = Bind {
+        code: KeyCode::PageUp,
+        modifiers: KeyModifiers::NONE,
+        label: "PageUp",
+    };
+    pub const SCROLL_PAGE_DOWN: Bind = Bind {
+        code: KeyCode::PageDown,
+        modifiers: KeyModifiers::NONE,
+        label: "PageDown",
+    };
     pub const SCROLL_LINE_UP: Bind = ctrl_bind!('y');
     pub const SCROLL_LINE_DOWN: Bind = ctrl_bind!('e');
     pub const SCROLL_TOP: Bind = ctrl_bind!('g');
@@ -417,6 +427,12 @@ pub const KEYBINDS: &[Keybind] = &[
         platform: Platform::All,
     },
     Keybind {
+        label: KeyLabel::Alt(key::SCROLL_PAGE_UP.label, key::SCROLL_PAGE_DOWN.label),
+        description: "Scroll page up / down",
+        context: KeybindContext::Editing,
+        platform: Platform::All,
+    },
+    Keybind {
         label: KeyLabel::Single(key::LINE_END.label),
         description: "Jump to end of line",
         context: KeybindContext::Editing,
@@ -514,7 +530,7 @@ pub const KEYBINDS: &[Keybind] = &[
     },
     Keybind {
         label: KeyLabel::Alt(key::SCROLL_HALF_UP.label, key::SCROLL_HALF_DOWN.label),
-        description: "Scroll page up / down",
+        description: "Scroll half page up / down",
         context: KeybindContext::Picker,
         platform: Platform::All,
     },

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -623,6 +623,10 @@ impl MessagesPanel {
         self.viewport_height as i32 / 2
     }
 
+    pub fn page(&self) -> i32 {
+        self.viewport_height.max(1) as i32
+    }
+
     pub fn set_accent(&mut self, color: ratatui::style::Color) {
         self.accent.set(color);
     }

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -147,6 +147,8 @@ impl ModalScroll {
             KeyCode::Down => self.scroll(-1),
             _ if key::SCROLL_HALF_UP.matches(key_event) => self.scroll(self.half_page()),
             _ if key::SCROLL_HALF_DOWN.matches(key_event) => self.scroll(-self.half_page()),
+            _ if key::SCROLL_PAGE_UP.matches(key_event) => self.scroll(self.page()),
+            _ if key::SCROLL_PAGE_DOWN.matches(key_event) => self.scroll(-self.page()),
             _ if key::SCROLL_LINE_UP.matches(key_event) => self.scroll(1),
             _ if key::SCROLL_LINE_DOWN.matches(key_event) => self.scroll(-1),
             _ if key::SCROLL_TOP.matches(key_event) => {
@@ -164,6 +166,10 @@ impl ModalScroll {
 
     fn half_page(&self) -> i32 {
         (self.viewport_h / 2).max(1) as i32
+    }
+
+    fn page(&self) -> i32 {
+        self.viewport_h.max(1) as i32
     }
 
     fn clamp(&mut self) {

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -34,6 +34,7 @@ On macOS, some bindings use Option or Fn keys instead (run `/help` for exact key
 | `Ctrl+A` | Jump to start of line |
 | `Home` / `End` | Jump to start/end of line |
 | `Ctrl+U` / `Ctrl+D` | Scroll half page up / down |
+| `PageUp` / `PageDown` | Scroll page up / down |
 | `Ctrl+E` | Jump to end of line |
 | `Ctrl+G` | Scroll to top |
 | `Ctrl+B` | Scroll to bottom |
@@ -72,7 +73,7 @@ On macOS, some bindings use Option or Fn keys instead (run `/help` for exact key
 | `Esc` | Close |
 | `Type` | Filter |
 | `PageUp` / `PageDown` | Scroll page up / down |
-| `Ctrl+U` / `Ctrl+D` | Scroll page up / down |
+| `Ctrl+U` / `Ctrl+D` | Scroll half page up / down |
 
 ## Context-Specific
 


### PR DESCRIPTION
PageUp and PageDown move the chat viewport by one page, matching the pickers. The bindings sit with the other chat scroll keys in App::handle_key, so they work while streaming and in subagent views; open pickers, modals and Lua keymap overrides keep precedence. Scrolling away from the bottom unpins auto-scroll; landing back on the bottom re-pins it.

Documented under the Editing context; /help and the keybindings page render the row from KEYBINDS.