### PR TITLE
feat(cli): add session list and delete subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2648,6 +2648,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
+ "unicode-width",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ libc = { workspace = true }
 uuid = { workspace = true }
 flume = { workspace = true }
 open = { workspace = true }
+unicode-width = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -242,6 +242,7 @@ pub struct Session<M, U, T> {
 pub struct SessionSummary {
     pub id: MakiId,
     pub title: String,
+    pub cwd: String,
     pub updated_at: u64,
 }
 
@@ -1178,7 +1179,7 @@ fn file_signature(path: &Path) -> Option<(u64, u64)> {
     Some((meta.len(), mtime_ms))
 }
 
-fn scan_headers(cwd: &str, dir: &Path) -> Result<Vec<SessionSummary>, StorageError> {
+fn scan_headers(cwd: Option<&str>, dir: &Path) -> Result<Vec<SessionSummary>, StorageError> {
     let mut cache = load_scan_cache(dir);
     let mut fresh = ScanCache::new();
     let mut dirty = false;
@@ -1207,11 +1208,12 @@ fn scan_headers(cwd: &str, dir: &Path) -> Result<Vec<SessionSummary>, StorageErr
             }
         };
         if let Some(h) = &entry.header
-            && h.cwd == cwd
+            && cwd.is_none_or(|c| h.cwd == c)
         {
             out.push(SessionSummary {
                 id: h.id,
                 title: normalize_title(&h.title),
+                cwd: h.cwd.clone(),
                 updated_at: h.updated_at,
             });
         }
@@ -1655,7 +1657,18 @@ where
     }
 
     pub fn list_in(cwd: &str, dir: &Path) -> Result<Vec<SessionSummary>, SessionError> {
-        let mut summaries = scan_headers(cwd, dir)?;
+        let mut summaries = scan_headers(Some(cwd), dir)?;
+        summaries.sort_unstable_by_key(|s| Reverse(s.updated_at));
+        Ok(summaries)
+    }
+
+    pub fn list_all(dir: &StateDir) -> Result<Vec<SessionSummary>, SessionError> {
+        let sessions_dir = dir.ensure_subdir(SESSIONS_DIR)?;
+        Self::list_all_in(&sessions_dir)
+    }
+
+    pub fn list_all_in(dir: &Path) -> Result<Vec<SessionSummary>, SessionError> {
+        let mut summaries = scan_headers(None, dir)?;
         summaries.sort_unstable_by_key(|s| Reverse(s.updated_at));
         Ok(summaries)
     }
@@ -1682,7 +1695,7 @@ where
             }
         }
 
-        scan_headers(cwd, dir)?
+        scan_headers(Some(cwd), dir)?
             .into_iter()
             .max_by_key(|s| s.updated_at)
             .map(|s| Self::load_from(s.id, dir).map(Some))
@@ -2498,7 +2511,28 @@ mod tests {
 
         let list = TestSession::list_in("/project-a", dir).unwrap();
         assert_eq!(list.len(), 2);
-        assert!(list.iter().all(|s| s.id != s2.id));
+        assert!(list.iter().all(|s| s.id != s2.id && s.cwd == "/project-a"));
+    }
+
+    #[test]
+    fn list_all_spans_cwds_newest_first() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        // `SessionLog::rewrite` persists `updated_at` verbatim; `save_to`
+        // would stamp both sessions with the same wall-clock second.
+        let mut older: TestSession = Session::new("m", "/project-a");
+        older.updated_at = 100;
+        SessionLog::rewrite(dir, &older).unwrap();
+        let mut newer: TestSession = Session::new("m", "/project-b");
+        newer.updated_at = 200;
+        SessionLog::rewrite(dir, &newer).unwrap();
+
+        let list = TestSession::list_all_in(dir).unwrap();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].id, newer.id);
+        assert_eq!(list[0].cwd, "/project-b");
+        assert_eq!(list[1].id, older.id);
+        assert_eq!(list[1].cwd, "/project-a");
     }
 
     /// Rewrites the scan-cache title of `id` without touching the session

--- a/maki-ui/src/lib.rs
+++ b/maki-ui/src/lib.rs
@@ -44,6 +44,12 @@ use maki_storage::id::MakiId;
 
 pub type AppSession = maki_storage::sessions::Session<Message, TokenUsage, ToolOutput>;
 
+/// Width of the controlling terminal, if any. Answers even when stdout is
+/// redirected, so callers that care gate on [`std::io::IsTerminal`].
+pub fn terminal_width() -> Option<u16> {
+    crossterm::terminal::size().ok().map(|(w, _)| w)
+}
+
 pub(crate) use agent::AgentCommand;
 pub use event_loop::EventLoopParams;
 

--- a/site/docs/content/cli/_index.md
+++ b/site/docs/content/cli/_index.md
@@ -95,6 +95,16 @@ maki auth status
 
 Lists every model Maki currently knows about (built-ins, discovered, catalog). One model spec per line. Warnings from discovery go to stderr.
 
+### `maki session`
+
+```bash
+maki session list            # sessions for the current directory
+maki session list --global   # sessions from all projects
+maki session delete <id>     # no confirmation
+```
+
+Prints stored sessions as a table (id, title, project directory with `$HOME` collapsed to `~`, last update as a relative age), newest first. A listed id works with `maki --session <id>` to resume it. `delete` removes the session log along with its archives and index entries. Inside the TUI the same data lives behind `/sessions` (`Ctrl+P`), where `Ctrl+D` deletes.
+
 ### `maki mcp`
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -202,6 +202,11 @@ pub enum Command {
     },
     /// List all available models
     Models,
+    /// Manage sessions
+    Session {
+        #[command(subcommand)]
+        action: SessionAction,
+    },
     /// Run the index tool on a file to see how it looks like
     Index { path: String },
     /// Manage MCP server authentication
@@ -248,6 +253,22 @@ pub enum Command {
     Migrate {
         #[command(subcommand)]
         action: MigrateAction,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum SessionAction {
+    /// List sessions
+    List {
+        /// Show sessions from all projects
+        #[arg(short, long)]
+        global: bool,
+    },
+    /// Delete a session
+    Delete {
+        /// Session ID (see `maki session list`)
+        #[arg(value_name = "SESSION_ID")]
+        session_id: String,
     },
 }
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,5 +1,6 @@
 mod acp;
 mod migrate;
+mod session;
 mod subcmd;
 mod tui;
 
@@ -10,7 +11,7 @@ use maki_config::Config;
 use maki_lua::{DiscoveredPackage, Interaction, PluginHost};
 use maki_storage::StateDir;
 
-use crate::cli::{AuthAction, Cli, Command, McpAction, MigrateAction};
+use crate::cli::{AuthAction, Cli, Command, McpAction, MigrateAction, SessionAction};
 use crate::update;
 
 fn sanitize_warnings(warnings: &[String]) -> Vec<String> {
@@ -129,6 +130,13 @@ pub fn dispatch(cli: Cli) -> Result<()> {
             subcmd::index(&path, cli.no_plugins, cli.no_jit)?;
         }
         Some(Command::Models) => subcmd::models(cli.no_plugins, cli.no_jit)?,
+        Some(Command::Session { action }) => {
+            let storage = StateDir::resolve().context("resolve data directory")?;
+            match action {
+                SessionAction::List { global } => session::list(global, &storage)?,
+                SessionAction::Delete { session_id } => session::delete(&session_id, &storage)?,
+            }
+        }
         Some(Command::Mcp { action }) => {
             let storage = StateDir::resolve().context("resolve data directory")?;
             match action {

--- a/src/cmd/session.rs
+++ b/src/cmd/session.rs
@@ -1,0 +1,292 @@
+use std::borrow::Cow;
+use std::env;
+use std::fmt::Write as _;
+use std::io::IsTerminal;
+
+use color_eyre::Result;
+use color_eyre::eyre::{Context, bail, eyre};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use maki_storage::id::MakiId;
+use maki_storage::paths;
+use maki_storage::sessions::{SessionError, SessionSummary};
+use maki_storage::{StateDir, StorageError, now_epoch};
+use maki_ui::AppSession;
+
+/// Mirrors `AGE_UNITS` in the `sessions` picker plugin.
+const AGE_UNITS: [(u64, &str); 6] = [
+    (31_536_000, "y"),
+    (2_592_000, "mo"),
+    (604_800, "w"),
+    (86_400, "d"),
+    (3_600, "h"),
+    (60, "m"),
+];
+const JUST_NOW: &str = "just now";
+const HEADERS: [&str; 4] = ["Session ID", "Title", "Project", "Updated"];
+const COLUMN_GAP: &str = "  ";
+const RULE: char = '─';
+const ELLIPSIS: &str = "…";
+const MIN_TITLE_WIDTH: usize = 20;
+const MIN_PROJECT_WIDTH: usize = 12;
+const PROJECT_COLUMN: usize = 2;
+const NO_SESSIONS: &str = "No sessions found";
+const NO_SESSIONS_HERE: &str = "No sessions found in this directory (try --global)";
+
+pub fn list(global: bool, storage: &StateDir) -> Result<()> {
+    let summaries = if global {
+        AppSession::list_all(storage)
+    } else {
+        let cwd = env::current_dir().context("read current directory")?;
+        AppSession::list(&cwd.to_string_lossy(), storage)
+    }
+    .context("list sessions")?;
+
+    if summaries.is_empty() {
+        if global {
+            println!("{NO_SESSIONS}");
+        } else {
+            println!("{NO_SESSIONS_HERE}");
+        }
+        return Ok(());
+    }
+    let table = render_table(&summaries, now_epoch(), terminal_budget());
+    print!("{table}");
+    Ok(())
+}
+
+pub fn delete(session_id: &str, storage: &StateDir) -> Result<()> {
+    let id: MakiId = session_id
+        .parse()
+        .map_err(|e| eyre!("invalid session id {session_id:?}: {e}"))?;
+    match AppSession::delete(id, storage) {
+        Ok(()) => println!("Deleted session {id}"),
+        Err(SessionError::Storage(StorageError::NotFound(_))) => {
+            bail!("session {session_id} not found")
+        }
+        Err(e) => return Err(e).context("delete session"),
+    }
+    Ok(())
+}
+
+/// Table budget when writing to a terminal. `terminal_width` answers from the
+/// controlling tty even when stdout is redirected, so piped output keeps full
+/// titles.
+fn terminal_budget() -> Option<usize> {
+    std::io::stdout()
+        .is_terminal()
+        .then(maki_ui::terminal_width)
+        .flatten()
+        .map(usize::from)
+}
+
+fn age(updated_at: u64, now: u64) -> String {
+    let secs = now.saturating_sub(updated_at);
+    for (unit_secs, suffix) in AGE_UNITS {
+        if secs >= unit_secs {
+            return format!("{}{} ago", secs / unit_secs, suffix);
+        }
+    }
+    JUST_NOW.to_owned()
+}
+
+fn collapse_home(path: &str) -> String {
+    match paths::home() {
+        Some(home) => collapse_home_with(path, &home.to_string_lossy()),
+        None => path.to_owned(),
+    }
+}
+
+fn collapse_home_with(path: &str, home: &str) -> String {
+    path.strip_prefix(home)
+        .map(|rest| format!("~{rest}"))
+        .unwrap_or_else(|| path.to_owned())
+}
+
+fn truncate_end(s: &str, max: usize) -> Cow<'_, str> {
+    if s.width() <= max {
+        return Cow::Borrowed(s);
+    }
+    let budget = max.saturating_sub(ELLIPSIS.width());
+    let mut used = 0;
+    let end = s
+        .char_indices()
+        .find_map(|(i, c)| {
+            used += c.width().unwrap_or(0);
+            (used > budget).then_some(i)
+        })
+        .unwrap_or(s.len());
+    Cow::Owned(format!("{}{ELLIPSIS}", &s[..end]))
+}
+
+/// Keeps the tail, which is the part of a path that identifies the checkout.
+fn truncate_start(s: &str, max: usize) -> Cow<'_, str> {
+    if s.width() <= max {
+        return Cow::Borrowed(s);
+    }
+    let budget = max.saturating_sub(ELLIPSIS.width());
+    let mut used = 0;
+    let start = s
+        .char_indices()
+        .rev()
+        .find_map(|(i, c)| {
+            used += c.width().unwrap_or(0);
+            (used > budget).then_some(i + c.len_utf8())
+        })
+        .unwrap_or(0);
+    Cow::Owned(format!("{ELLIPSIS}{}", &s[start..]))
+}
+
+/// Largest width that fits `allowed` without dropping below `floor`, unless
+/// the natural width is already smaller than the floor.
+fn fit(natural: usize, allowed: usize, floor: usize) -> usize {
+    natural.min(allowed).max(natural.min(floor))
+}
+
+fn render_table(summaries: &[SessionSummary], now: u64, budget: Option<usize>) -> String {
+    let rows: Vec<[String; 4]> = summaries.iter().map(|s| row_cells(s, now)).collect();
+    let mut widths = HEADERS.map(UnicodeWidthStr::width);
+    for row in &rows {
+        for (w, cell) in widths.iter_mut().zip(row) {
+            *w = (*w).max(cell.width());
+        }
+    }
+    let gaps = COLUMN_GAP.len() * (HEADERS.len() - 1);
+    if let Some(budget) = budget {
+        let rest = budget.saturating_sub(widths[0] + widths[3] + gaps);
+        let project = rest.saturating_sub(MIN_TITLE_WIDTH);
+        widths[2] = fit(widths[2], project, MIN_PROJECT_WIDTH);
+        let title = rest.saturating_sub(widths[2]);
+        widths[1] = fit(widths[1], title, MIN_TITLE_WIDTH);
+    }
+
+    let total: usize = widths.iter().sum::<usize>() + gaps;
+    let mut out = String::new();
+    let _ = writeln!(out, "{}", format_row(HEADERS, &widths));
+    let _ = writeln!(out, "{}", RULE.to_string().repeat(total));
+    for row in &rows {
+        let cells = std::array::from_fn(|i| row[i].as_str());
+        let _ = writeln!(out, "{}", format_row(cells, &widths));
+    }
+    out
+}
+
+fn row_cells(s: &SessionSummary, now: u64) -> [String; 4] {
+    [
+        s.id.to_string(),
+        s.title.clone(),
+        collapse_home(&s.cwd),
+        age(s.updated_at, now),
+    ]
+}
+
+fn format_row(cells: [&str; 4], widths: &[usize; 4]) -> String {
+    let mut line = String::new();
+    let last = cells.len() - 1;
+    for (i, (cell, w)) in cells.iter().zip(widths).enumerate() {
+        if i > 0 {
+            line.push_str(COLUMN_GAP);
+        }
+        let cell = if i == PROJECT_COLUMN {
+            truncate_start(cell, *w)
+        } else {
+            truncate_end(cell, *w)
+        };
+        line.push_str(&cell);
+        if i < last {
+            for _ in cell.width()..*w {
+                line.push(' ');
+            }
+        }
+    }
+    line
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    fn summary(title: &str, cwd: &str, updated_at: u64) -> SessionSummary {
+        SessionSummary {
+            id: MakiId::generate(),
+            title: title.to_owned(),
+            cwd: cwd.to_owned(),
+            updated_at,
+        }
+    }
+
+    #[test_case(0, JUST_NOW)]
+    #[test_case(59, JUST_NOW)]
+    #[test_case(60, "1m ago")]
+    #[test_case(3_599, "59m ago")]
+    #[test_case(3_600, "1h ago")]
+    #[test_case(86_399, "23h ago")]
+    #[test_case(86_400, "1d ago")]
+    #[test_case(604_800, "1w ago")]
+    #[test_case(2_592_000, "1mo ago")]
+    #[test_case(31_536_000, "1y ago")]
+    fn age_formats_elapsed(secs: u64, expected: &str) {
+        assert_eq!(age(0, secs), expected);
+    }
+
+    #[test_case("/home/tony/c/maki", "/home/tony", "~/c/maki" ; "under_home")]
+    #[test_case("/workspace/maki", "/home/tony", "/workspace/maki" ; "outside_home")]
+    #[test_case("/home/tony", "/home/tony", "~" ; "home_itself")]
+    fn collapse_home_rewrites_prefix(cwd: &str, home: &str, expected: &str) {
+        assert_eq!(collapse_home_with(cwd, home), expected);
+    }
+
+    #[test_case("short", 10, "short" ; "fits_untouched")]
+    #[test_case("exact", 5, "exact" ; "exact_fit")]
+    #[test_case("longer", 5, "long…" ; "ascii")]
+    #[test_case("文档文档", 5, "文档…" ; "cjk_stops_before_overflow")]
+    #[test_case("🚀🚀🚀", 4, "🚀…" ; "emoji")]
+    fn truncate_end_caps_at_width(input: &str, max: usize, expected: &str) {
+        assert_eq!(truncate_end(input, max), expected);
+        assert!(truncate_end(input, max).width() <= max);
+    }
+
+    #[test_case("~/c/maki", 10, "~/c/maki" ; "fits_untouched")]
+    #[test_case("~/c/maki", 5, "…maki" ; "ascii_tail")]
+    #[test_case("~/文档/proj", 6, "…/proj" ; "cjk_path")]
+    fn truncate_start_keeps_tail(input: &str, max: usize, expected: &str) {
+        assert_eq!(truncate_start(input, max), expected);
+        assert!(truncate_start(input, max).width() <= max);
+    }
+
+    #[test]
+    fn render_table_without_budget_keeps_full_title() {
+        let long_title = "t".repeat(60);
+        let table = render_table(&[summary(&long_title, "/workspace/maki", 0)], 100, None);
+        assert!(table.contains(&long_title));
+        assert!(table.contains("/workspace/maki"));
+        assert!(table.contains("1m ago"));
+    }
+
+    #[test]
+    fn render_table_fits_budget_and_ellipsizes() {
+        let long_title = "t".repeat(60);
+        let table = render_table(&[summary(&long_title, "/workspace/maki", 0)], 100, Some(80));
+        let lines: Vec<&str> = table.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].starts_with("Session ID"));
+        assert_eq!(lines[0].width(), 80);
+        assert_eq!(lines[1], RULE.to_string().repeat(80));
+        assert!(lines[2].contains(ELLIPSIS));
+        assert!(lines[2].ends_with("1m ago"));
+        assert!(lines[2].width() <= 80);
+    }
+
+    #[test]
+    fn render_table_fits_budget_with_wide_chars() {
+        let table = render_table(
+            &[summary(&"文".repeat(40), "/workspace/文档", 0)],
+            100,
+            Some(80),
+        );
+        for line in table.lines() {
+            assert!(line.width() <= 80);
+        }
+    }
+}


### PR DESCRIPTION
Add opencode-like cli session management.

`maki session list` prints stored sessions for the current directory as a table (id, title, project directory, last update as a relative age), newest first; `--global` spans all projects. `maki session delete <id>` removes the session log, its archives, and its index entries without confirmation. The table fits the terminal width when stdout is a terminal, shrinking the title column first, and keeps full titles when piped.

The storage scan now exposes each session's cwd: SessionSummary carries it and Session::list_all lists across projects. maki_ui::terminal_width wraps the crossterm size query so the binary crate gains no crossterm dependency.

Example output:
```
$ maki session list -g
Session ID             Title                                                        Project        Updated
───────────────────────────────────────────────────────────────────────────────────────────────────────────
CeqfGM98eMH254jXQSvYK  please add proper argument parsing using clap and a…         Overload       just now
CekjuLKFx7wKSeftuoRNK  testing: can you access the mcp memory server?               maki           2d ago
CeksjKy5fHnA5NCWNRHVF  please investigate this LLM project; do you see any way to…  warp           1d ago
````