### PR TITLE
agent: Load .maki/AGENTS.md preferred over AGENTS.md

### DIFF
--- a/maki-agent/src/agent/instructions.rs
+++ b/maki-agent/src/agent/instructions.rs
@@ -10,6 +10,7 @@ use crate::command::find_project_ancestor_dirs;
 use crate::template::Vars;
 
 const INSTRUCTION_FILES: &[&str] = &[
+    ".maki/AGENTS.md",
     "AGENTS.md",
     "CLAUDE.md",
     ".github/copilot-instructions.md",
@@ -294,6 +295,21 @@ mod tests {
     }
 
     #[test]
+    fn load_instructions_maki_agents_md_wins_over_agents_md() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join(".maki")).unwrap();
+        fs::write(dir.path().join(".maki").join("AGENTS.md"), "maki rules").unwrap();
+        fs::write(dir.path().join("AGENTS.md"), "team rules").unwrap();
+
+        let text = &load_instructions_with_home(dir.path().to_str().unwrap(), None, None).text;
+        assert!(text.contains("maki rules"));
+        assert!(
+            !text.contains("team rules"),
+            ".maki/AGENTS.md should replace AGENTS.md, got {text}"
+        );
+    }
+
+    #[test]
     fn load_instructions_local_without_project() {
         let dir = tempfile::tempdir().unwrap();
         fs::write(dir.path().join("AGENTS.local.md"), "solo preferences").unwrap();
@@ -399,6 +415,23 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert!(results[0].0.ends_with("AGENTS.md"));
         assert_eq!(results[0].1, "api rules");
+    }
+
+    #[test]
+    fn find_subdirectory_instructions_discovers_maki_agents_md() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("src").join("api");
+        let maki_dir = sub.join(".maki");
+        fs::create_dir_all(&maki_dir).unwrap();
+        fs::write(maki_dir.join("AGENTS.md"), "maki api rules").unwrap();
+        fs::write(sub.join("AGENTS.md"), "api rules").unwrap();
+
+        let loaded = LoadedInstructions::new();
+        let results = find_subdirectory_instructions(&sub, dir.path(), &loaded);
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].0.ends_with(".maki/AGENTS.md"));
+        assert_eq!(results[0].1, "maki api rules");
     }
 
     #[test]

--- a/site/docs/content/context/_index.md
+++ b/site/docs/content/context/_index.md
@@ -29,16 +29,19 @@ At session start Maki walks from the project git root down to the working direct
 
 | Order | File |
 |------|------|
-| 1 | `AGENTS.md` |
-| 2 | `CLAUDE.md` |
-| 3 | `.github/copilot-instructions.md` |
-| 4 | `COPILOT.md` |
-| 5 | `.cursorrules` |
-| 6 | `.windsurfrules` |
-| 7 | `.clinerules` |
-| 8 | `CONVENTIONS.md` |
-| 9 | `GEMINI.md` |
-| 10 | `CODING_AGENT.md` |
+| 1 | `.maki/AGENTS.md` |
+| 2 | `AGENTS.md` |
+| 3 | `CLAUDE.md` |
+| 4 | `.github/copilot-instructions.md` |
+| 5 | `COPILOT.md` |
+| 6 | `.cursorrules` |
+| 7 | `.windsurfrules` |
+| 8 | `.clinerules` |
+| 9 | `CONVENTIONS.md` |
+| 10 | `GEMINI.md` |
+| 11 | `CODING_AGENT.md` |
+
+When both `.maki/AGENTS.md` and `AGENTS.md` exist in the same directory, only the `.maki` one loads. Use it for rules that apply to maki only, so they override the shared file without doubling context.
 
 After the match it always loads `AGENTS.local.md` from the same directory if present: that one is yours, keep it gitignored. Closer directories win on conflicts. Finally one global `~/.config/maki/AGENTS.md` for preferences that follow you across projects.
 

--- a/site/docs/content/quick-start/_index.md
+++ b/site/docs/content/quick-start/_index.md
@@ -111,10 +111,11 @@ Without it, Maki remembers the last model you used.
 
 ## Teach it your project
 
-Maki loads `AGENTS.md` (or `CLAUDE.md`, `.cursorrules`, and friends) from your repo automatically. Per-project settings live under `.maki/`:
+Maki loads `.maki/AGENTS.md` or `AGENTS.md` (or `CLAUDE.md`, `.cursorrules`, and friends) from your repo automatically. Per-project settings live under `.maki/`:
 
 ```
 .maki/
+├── AGENTS.md          # maki-only instructions, wins over AGENTS.md
 ├── init.lua           # overrides global config
 ├── permissions.toml   # permission rules
 ├── mcp.toml           # MCP server config


### PR DESCRIPTION
This is useful for projects where you want to use your own AGENTS.md over whatever the project already provides.