### PR TITLE
feat(cli): add maki models --refresh to refetch the models.dev catalog 🤖🤖🤖

### DIFF
--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -19,7 +19,7 @@ pub use providers::Timeouts;
 pub use providers::catalog::ProviderData;
 pub use providers::catalog::{
     catalog_provider, catalog_provider_if_available, catalog_providers,
-    catalog_providers_if_available, model_meta_if_available, warm_catalog,
+    catalog_providers_if_available, model_meta_if_available, refresh_catalog, warm_catalog,
 };
 pub use providers::copilot::auth as copilot_auth;
 pub use providers::dynamic;

--- a/maki-providers/src/providers/catalog.rs
+++ b/maki-providers/src/providers/catalog.rs
@@ -477,6 +477,21 @@ pub fn warm_catalog() {
     init_shared_catalog_if_needed();
 }
 
+/// Force-refetches the models.dev catalog; failures keep the stale catalog and cache.
+/// Blocks, so only call it from startup paths, never from inside the executor.
+pub fn refresh_catalog() -> Result<(), AgentError> {
+    let state_dir = StateDir::resolve()
+        .map_err(|e| config_error(format!("failed to resolve state dir: {e}")))?;
+    let data = fetch_catalog_blocking(&state_dir)?;
+    match SHARED_CATALOG.get() {
+        Some(catalog) => *catalog.lock().unwrap() = data,
+        // Set instead of `get_or_init` so a cold catalog takes the fetch we just
+        // did rather than kicking off `init_catalog_blocking` and fetching twice.
+        None => drop(SHARED_CATALOG.set(Mutex::new(data))),
+    }
+    Ok(())
+}
+
 /// Returns the list of all providers in alphabetical order.
 pub fn catalog_providers() -> Vec<ProviderData> {
     let guard = init_shared_catalog_if_needed().lock().unwrap();
@@ -617,6 +632,22 @@ fn determine_catalog_format(npm: &str) -> EndpointType {
     }
 }
 
+fn catalog_client() -> HttpClient {
+    isahc::HttpClient::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .low_speed_timeout(1, Duration::from_secs(30))
+        // curl carries http2 for OTLP.
+        .version_negotiation(VersionNegotiation::http11())
+        .build()
+        .expect("failed to build catalog HTTP client")
+}
+
+fn fetch_catalog_blocking(state_dir: &StateDir) -> Result<CatalogData, AgentError> {
+    let index = smol::block_on(fetch_remote_catalog_async(&catalog_client()))?;
+    smol::block_on(save_cached_catalog_async(&index));
+    Ok(CatalogData::from_index(index, state_dir))
+}
+
 // Try cache first, then fetch from remote.
 fn init_catalog_blocking() -> CatalogData {
     let state_dir = match StateDir::resolve() {
@@ -631,19 +662,8 @@ fn init_catalog_blocking() -> CatalogData {
         return CatalogData::from_index(index, &state_dir);
     }
 
-    let client = isahc::HttpClient::builder()
-        .connect_timeout(Duration::from_secs(10))
-        .low_speed_timeout(1, Duration::from_secs(30))
-        // curl carries http2 for OTLP.
-        .version_negotiation(VersionNegotiation::http11())
-        .build()
-        .expect("failed to build catalog HTTP client");
-
-    match smol::block_on(fetch_remote_catalog_async(&client)) {
-        Ok(index) => {
-            smol::block_on(save_cached_catalog_async(&index));
-            CatalogData::from_index(index, &state_dir)
-        }
+    match fetch_catalog_blocking(&state_dir) {
+        Ok(data) => data,
         Err(e) => {
             warn!(error = %e, "catalog fetch failed, using empty catalog");
             CatalogData::empty(state_dir)

--- a/site/docs/content/cli/_index.md
+++ b/site/docs/content/cli/_index.md
@@ -93,7 +93,12 @@ maki auth status
 
 ### `maki models`
 
-Lists every model Maki currently knows about (built-ins, discovered, catalog). One model spec per line. Warnings from discovery go to stderr.
+```bash
+maki models
+maki models --refresh    # refetch the models.dev catalog
+```
+
+One spec per line, warnings on stderr. Built-in and script providers are listed live, catalog-backed providers from the models.dev cache, which expires after 24 hours and supplies model pricing and context windows. `--refresh` refetches it. When the refetch fails, the cached catalog stays in place, the list still prints, and the command exits non-zero.
 
 ### `maki session`
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -201,7 +201,11 @@ pub enum Command {
         action: AuthAction,
     },
     /// List all available models
-    Models,
+    Models {
+        /// Refetch the models.dev catalog, ignoring its 24h cache
+        #[arg(long)]
+        refresh: bool,
+    },
     /// Manage sessions
     Session {
         #[command(subcommand)]

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -129,7 +129,7 @@ pub fn dispatch(cli: Cli) -> Result<()> {
         Some(Command::Index { path }) => {
             subcmd::index(&path, cli.no_plugins, cli.no_jit)?;
         }
-        Some(Command::Models) => subcmd::models(cli.no_plugins, cli.no_jit)?,
+        Some(Command::Models { refresh }) => subcmd::models(cli.no_plugins, cli.no_jit, refresh)?,
         Some(Command::Session { action }) => {
             let storage = StateDir::resolve().context("resolve data directory")?;
             match action {

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -537,7 +537,7 @@ pub fn auth_status(storage: &StateDir) -> Result<()> {
     Ok(())
 }
 
-pub fn models(no_plugins: bool, no_jit: bool) -> Result<()> {
+pub fn models(no_plugins: bool, no_jit: bool, refresh: bool) -> Result<()> {
     let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
     load_env_files(&cwd);
 
@@ -552,6 +552,14 @@ pub fn models(no_plugins: bool, no_jit: bool) -> Result<()> {
     )?;
     super::report_warnings(warnings);
 
+    let mut refresh_failure = None;
+    if refresh {
+        match maki_providers::refresh_catalog() {
+            Ok(()) => eprintln!("models.dev catalog has been refreshed"),
+            Err(e) => refresh_failure = Some(e),
+        }
+    }
+
     smol::block_on(fetch_all_models(
         &config.provider.model_policy,
         |batch| {
@@ -564,6 +572,10 @@ pub fn models(no_plugins: bool, no_jit: bool) -> Result<()> {
         },
         None,
     ));
+
+    if let Some(e) = refresh_failure {
+        bail!("catalog refresh failed, keeping existing cache: {e}");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## What

`maki models --refresh` refetches the models.dev catalog before listing models.

The catalog is cached on disk with a 24h TTL, and catalog-backed providers are listed from that cache. A model released mid-window stays invisible for up to 24h because the TTL check only compares the cache age against 24h, never against upstream. The flag is the only built-in way to pick up catalog changes sooner: it fetches, rewrites the cache, and swaps the in-memory catalog. On failure the stale cache is kept and a warning is printed, so a refresh never leaves you worse off.

Built-in and script provider listings are unaffected: they were already fetched live on every run.

## Details

- `maki-providers`: new `refresh_catalog()` (fetch, rewrite cache, swap the shared catalog under the mutex); HTTP client construction extracted into `catalog_client()`
- `maki`: `Models` subcommand gains `--refresh`, wired before `fetch_all_models`
- docs: `maki models` section in `site/docs` updated

## Out of scope

- TUI (`Ctrl+M` / `/model`) still refreshes only the live listings, not the catalog cache
- A running session never reloads the catalog; the flag only benefits processes started afterwards

## AI use

Designed with the human author (flag semantics, scope, failure behavior) and implemented by an AI coding agent (maki): `refresh_catalog()`, CLI wiring, doc updates, and the rustfmt fix. The human reviewed every iteration (CLI output, docs phrasing, list-source correction). Prompts were interactive review comments on this session; full transcript available on request.