### PR TITLE
feat(openai): support codex subscription fast mode

### DIFF
--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -210,7 +210,7 @@ pub const TOP_LEVEL_FIELDS: &[ConfigField] = &[
         default: ConfigValue::Bool(false),
         min: None,
         env: None,
-        description: "Start every session with Anthropic fast mode (Opus only; ignored otherwise)",
+        description: "Start every session with fast mode (Anthropic Opus or eligible Codex subscription models, ignored elsewhere)",
     },
     ConfigField {
         name: "always_workflow",

--- a/maki-docgen/src/gen_commands.rs
+++ b/maki-docgen/src/gen_commands.rs
@@ -88,7 +88,7 @@ pub fn generate() -> String {
     .unwrap();
     writeln!(
         out,
-        "- **`/fast`**: Anthropic fast mode (Opus only; ignored on other models). Config: `always_fast = true`."
+        "- **`/fast`**: faster responses on Anthropic Opus, and on eligible Codex models when you sign in with a ChatGPT subscription. OpenAI API keys and every other model ignore it. Config: `always_fast = true`."
     )
     .unwrap();
     writeln!(

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -326,6 +326,13 @@ pub struct ThinkingOption {
     pub tokens: Option<u32>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FastSupport {
+    Pending,
+    Supported,
+    Unsupported,
+}
+
 #[derive(Debug, Clone)]
 pub struct Model {
     pub id: String,
@@ -338,6 +345,7 @@ pub struct Model {
     /// back to discovery, then the provider manifest.
     pub thinking_override: Option<ThinkingSupport>,
     pub supports_vision_override: Option<bool>,
+    pub supports_fast_override: Option<FastSupport>,
     pub pricing: ModelPricing,
     /// Discovery reported an explicit all-zero price. Distinct from a zero
     /// `pricing`, which also covers "no price is known".
@@ -396,6 +404,7 @@ impl Model {
             supports_tool_examples_override: None,
             thinking_override: None,
             supports_vision_override: None,
+            supports_fast_override: None,
             pricing,
             discovered_free: discovered_pricing.is_some_and(ModelPricing::is_zero),
             max_output_tokens,
@@ -420,6 +429,7 @@ impl Model {
             supports_tool_examples_override: None,
             thinking_override: ThinkingSupport::from_flags(meta.supports_thinking, false),
             supports_vision_override: meta.supports_vision,
+            supports_fast_override: None,
             pricing: meta.pricing.unwrap_or_default(),
             discovered_free: false,
             max_output_tokens: Some(max_output_tokens),
@@ -544,14 +554,22 @@ impl Model {
         self.output_tokens().map(|n| n / 2)
     }
 
-    /// A model supports fast mode exactly when it carries fast-tier pricing, so
-    /// capability and billing can never disagree. The provider gate keeps fast
-    /// mode to Anthropic-based providers, resolved through the base manifest so
-    /// oauth scripts keep it; Bedrock separately ignores `opts.fast` at request
-    /// time.
+    /// A provider that knows better speaks through `supports_fast_override`.
+    /// Otherwise a model supports fast mode exactly when it carries fast-tier
+    /// pricing, so capability and billing can never disagree. The provider gate
+    /// keeps fast mode to Anthropic-based providers, resolved through the base
+    /// manifest so oauth scripts keep it; Bedrock separately ignores
+    /// `opts.fast` at request time.
     pub fn supports_fast(&self) -> bool {
-        self.pricing.fast.is_some()
-            && ManifestRegistry::for_slug(&self.provider).is_some_and(|m| m.slug == FAST_PROVIDER)
+        match self.supports_fast_override {
+            Some(FastSupport::Supported) => true,
+            Some(FastSupport::Pending | FastSupport::Unsupported) => false,
+            None => {
+                self.pricing.fast.is_some()
+                    && ManifestRegistry::for_slug(&self.provider)
+                        .is_some_and(|m| m.slug == FAST_PROVIDER)
+            }
+        }
     }
 
     pub fn spec(&self) -> String {
@@ -1339,9 +1357,35 @@ mod tests {
         assert_eq!(model.supports_fast(), expected);
     }
 
-    /// Fast mode is Anthropic-only, so a fast rate that lands on anyone else is
-    /// dead weight: nobody can turn it on, and an `always_fast` carried in from
-    /// config must not quietly reprice the session with it.
+    #[test_case("google/gemini-2.5-pro", Some(FastSupport::Supported), true ; "override_enables_without_fast_pricing")]
+    #[test_case("anthropic/claude-opus-5", Some(FastSupport::Unsupported), false ; "override_disables_native_support")]
+    #[test_case("anthropic/claude-opus-5", None, true ; "default_preserves_native_support")]
+    #[test_case("google/gemini-2.5-pro", None, false ; "default_preserves_unsupported")]
+    #[test_case("anthropic/claude-opus-5", Some(FastSupport::Pending), false ; "pending_disables_native_support")]
+    fn supports_fast_respects_override(
+        spec: &str,
+        fast_override: Option<FastSupport>,
+        expected: bool,
+    ) {
+        let mut model = Model::from_spec(spec).unwrap();
+        model.supports_fast_override = fast_override;
+        assert_eq!(model.supports_fast(), expected);
+    }
+
+    #[test_case("google/gemini-2.5-pro" ; "non_anthropic")]
+    #[test_case("anthropic/claude-sonnet-5" ; "anthropic")]
+    fn fast_override_without_fast_pricing_uses_standard_rates(spec: &str) {
+        let mut model = Model::from_spec(spec).unwrap();
+        model.supports_fast_override = Some(FastSupport::Supported);
+        assert!(model.supports_fast());
+        assert!(model.pricing.fast.is_none());
+        assert!(!model.pricing.is_zero());
+        assert_eq!(
+            model.list_cost(&COUNTERS, true),
+            Some(COUNTERS.estimate(&model.pricing, false))
+        );
+    }
+
     #[test]
     fn fast_pricing_on_a_non_anthropic_model_stays_inert() {
         let mut model = Model::from_base(

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -554,22 +554,27 @@ impl Model {
         self.output_tokens().map(|n| n / 2)
     }
 
-    /// A provider that knows better speaks through `supports_fast_override`.
-    /// Otherwise a model supports fast mode exactly when it carries fast-tier
-    /// pricing, so capability and billing can never disagree. The provider gate
-    /// keeps fast mode to Anthropic-based providers, resolved through the base
-    /// manifest so oauth scripts keep it; Bedrock separately ignores
-    /// `opts.fast` at request time.
+    /// A provider that knows its own plan speaks through the override: a Codex
+    /// subscription bills a flat rate, so there is no fast per-token price to
+    /// read. Everyone else falls back to fast-tier pricing, so capability and
+    /// billing can never disagree. The provider gate keeps that path to
+    /// Anthropic-based providers, resolved through the base manifest so oauth
+    /// scripts keep it; Bedrock separately ignores `opts.fast` at request time.
     pub fn supports_fast(&self) -> bool {
         match self.supports_fast_override {
-            Some(FastSupport::Supported) => true,
-            Some(FastSupport::Pending | FastSupport::Unsupported) => false,
+            Some(support) => support == FastSupport::Supported,
             None => {
                 self.pricing.fast.is_some()
                     && ManifestRegistry::for_slug(&self.provider)
                         .is_some_and(|m| m.slug == FAST_PROVIDER)
             }
         }
+    }
+
+    /// Discovery has not answered yet, so the `false` from [`Self::supports_fast`]
+    /// is provisional. Frontends park the user's wish instead of rejecting it.
+    pub fn fast_pending(&self) -> bool {
+        self.supports_fast_override == Some(FastSupport::Pending)
     }
 
     pub fn spec(&self) -> String {
@@ -1359,8 +1364,7 @@ mod tests {
 
     #[test_case("google/gemini-2.5-pro", Some(FastSupport::Supported), true ; "override_enables_without_fast_pricing")]
     #[test_case("anthropic/claude-opus-5", Some(FastSupport::Unsupported), false ; "override_disables_native_support")]
-    #[test_case("anthropic/claude-opus-5", None, true ; "default_preserves_native_support")]
-    #[test_case("google/gemini-2.5-pro", None, false ; "default_preserves_unsupported")]
+    #[test_case("anthropic/claude-opus-5", None, true ; "no_override_falls_back_to_pricing")]
     #[test_case("anthropic/claude-opus-5", Some(FastSupport::Pending), false ; "pending_disables_native_support")]
     fn supports_fast_respects_override(
         spec: &str,
@@ -1386,6 +1390,10 @@ mod tests {
         );
     }
 
+    /// Without an override, fast mode is Anthropic-only, so a fast rate that
+    /// lands on anyone else is dead weight: nobody can turn it on, and an
+    /// `always_fast` carried in from config must not quietly reprice the
+    /// session with it.
     #[test]
     fn fast_pricing_on_a_non_anthropic_model_stays_inert() {
         let mut model = Model::from_base(
@@ -1566,6 +1574,7 @@ mod tests {
             supports_tool_examples_override: None,
             thinking_override: Some(support),
             supports_vision_override: None,
+            supports_fast_override: None,
             pricing: ModelPricing::default(),
             discovered_free: false,
             max_output_tokens,

--- a/maki-providers/src/model_registry.rs
+++ b/maki-providers/src/model_registry.rs
@@ -51,6 +51,10 @@ pub fn discovered(provider: &str, model_id: &str) -> Option<ModelInfo> {
     read().discovered(provider, model_id).cloned()
 }
 
+pub fn discovery_complete(provider: &str) -> bool {
+    read().known_models.contains_key(provider)
+}
+
 /// Typed `provider_info` for a discovered model. Key by the builtin slug, not
 /// `model.provider`: a dynamic wrap's model carries its own slug.
 pub fn provider_info<T: Send + Sync + 'static>(provider: &str, model_id: &str) -> Option<Arc<T>> {

--- a/maki-providers/src/pricing.rs
+++ b/maki-providers/src/pricing.rs
@@ -233,6 +233,7 @@ mod tests {
             supports_tool_examples_override: None,
             thinking_override: None,
             supports_vision_override: None,
+            supports_fast_override: None,
             pricing: ModelPricing {
                 input: input_rate,
                 ..ModelPricing::ZERO

--- a/maki-providers/src/providers/catalog.rs
+++ b/maki-providers/src/providers/catalog.rs
@@ -1135,6 +1135,7 @@ mod tests {
             supports_tool_examples_override: None,
             thinking_override: None,
             supports_vision_override: None,
+            supports_fast_override: None,
             pricing: ModelPricing::default(),
             discovered_free: false,
             max_output_tokens: None,

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -151,6 +151,7 @@ fn model_from_def(def: &ProviderDef, kind: ProviderKind, slug: &str, model_id: &
         supports_tool_examples_override,
         thinking_override,
         supports_vision_override,
+        supports_fast_override: None,
         pricing,
         discovered_free: false,
         max_output_tokens,

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -101,6 +101,7 @@ impl ScriptModel {
                 self.requires_thinking,
             ),
             supports_vision_override: self.supports_vision,
+            supports_fast_override: None,
             pricing: self.pricing.clone().unwrap_or_default(),
             discovered_free: false,
             max_output_tokens: Some(self.max_output_tokens),

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -713,6 +713,7 @@ mod tests {
             tier: ModelTier::Medium,
             family: ModelFamily::Gemini,
             supports_vision_override: Some(true),
+            supports_fast_override: None,
             supports_tool_examples_override: None,
             thinking_override: None,
             pricing: ModelPricing::default(),

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use tracing::{debug, warn};
 
-use crate::model::{Model, ModelInfo};
+use crate::model::{FastSupport, Model, ModelInfo};
 use crate::model_registry;
 use crate::provider::{BoxFuture, Provider};
 use crate::types::EffortDialect;
@@ -52,6 +52,9 @@ const USAGE_URL: &str = "https://chatgpt.com/backend-api/wham/usage";
 const CODEX_CLIENT_VERSION: &str = "0.153.4";
 const PLAN_MODELS_PATH: &str = "/models?client_version=";
 const LISTED_VISIBILITY: &str = "list";
+const ACCOUNT_ID_HEADER: &str = "chatgpt-account-id";
+const FAST_SERVICE_TIER: &str = "priority";
+const LEGACY_FAST_SPEED_TIER: &str = "fast";
 const IMAGE_MODALITY: &str = "image";
 const EMPTY_USAGE_ERROR: &str =
     "OpenAI usage response contained no plan or rate limits; the endpoint schema likely changed";
@@ -98,6 +101,13 @@ struct PlanModel {
     default_reasoning_level: Option<String>,
     supported_reasoning_levels: Vec<PlanReasoningLevel>,
     input_modalities: Vec<String>,
+    service_tiers: Vec<PlanServiceTier>,
+    additional_speed_tiers: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct PlanServiceTier {
+    id: String,
 }
 
 #[derive(Deserialize, Default)]
@@ -112,6 +122,8 @@ pub(crate) struct PlanModelInfo {
     efforts: Vec<Effort>,
     adaptive: Option<Effort>,
     off: bool,
+    supports_fast: bool,
+    account_id: Option<String>,
 }
 
 impl PlanModelInfo {
@@ -124,8 +136,9 @@ impl PlanModelInfo {
     }
 }
 
-impl From<PlanModel> for ModelInfo {
-    fn from(model: PlanModel) -> Self {
+impl PlanModel {
+    fn into_info(self, account_id: Option<&str>) -> ModelInfo {
+        let model = self;
         let levels = &model.supported_reasoning_levels;
         let mut efforts: Vec<Effort> = levels
             .iter()
@@ -134,13 +147,22 @@ impl From<PlanModel> for ModelInfo {
         efforts.sort_unstable();
         efforts.dedup();
         let info = PlanModelInfo {
+            account_id: account_id.map(str::to_owned),
+            supports_fast: model
+                .service_tiers
+                .iter()
+                .any(|tier| tier.id == FAST_SERVICE_TIER)
+                || model
+                    .additional_speed_tiers
+                    .iter()
+                    .any(|tier| tier == LEGACY_FAST_SPEED_TIER),
             off: levels.iter().any(|level| level.effort == dialect::OFF),
             adaptive: model
                 .default_reasoning_level
                 .and_then(|level| level.parse().ok()),
             efforts,
         };
-        Self {
+        ModelInfo {
             id: model.slug,
             context_window: model.context_window,
             max_output_tokens: None,
@@ -154,13 +176,16 @@ impl From<PlanModel> for ModelInfo {
     }
 }
 
-fn parse_plan_models(response: &str) -> Result<Vec<ModelInfo>, AgentError> {
+fn parse_plan_models(
+    response: &str,
+    account_id: Option<&str>,
+) -> Result<Vec<ModelInfo>, AgentError> {
     let parsed: PlanModelsResponse = serde_json::from_str(response)?;
     let models: Vec<ModelInfo> = parsed
         .models
         .into_iter()
         .filter(|model| model.visibility == LISTED_VISIBILITY)
-        .map(ModelInfo::from)
+        .map(|model| model.into_info(account_id))
         .collect();
     if models.is_empty() {
         return Err(AgentError::Config {
@@ -168,6 +193,43 @@ fn parse_plan_models(response: &str) -> Result<Vec<ModelInfo>, AgentError> {
         });
     }
     Ok(models)
+}
+
+fn plan_account_id(auth: &ResolvedAuth) -> Option<&str> {
+    auth.headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case(ACCOUNT_ID_HEADER))
+        .map(|(_, value)| value.as_str())
+        .filter(|value| !value.is_empty())
+}
+
+fn supports_plan_fast(auth: Option<&ResolvedAuth>, info: Option<&PlanModelInfo>) -> FastSupport {
+    let Some(auth) =
+        auth.filter(|auth| auth.base_url.as_deref() == Some(auth::CODING_PLAN_BASE_URL))
+    else {
+        return FastSupport::Unsupported;
+    };
+    match (plan_account_id(auth), info) {
+        (Some(account_id), Some(info)) if info.account_id.as_deref() == Some(account_id) => {
+            if info.supports_fast {
+                FastSupport::Supported
+            } else {
+                FastSupport::Unsupported
+            }
+        }
+        _ => FastSupport::Pending,
+    }
+}
+
+fn apply_plan_fast(
+    body: &mut Value,
+    opts: RequestOptions,
+    auth: &ResolvedAuth,
+    info: Option<&PlanModelInfo>,
+) {
+    if opts.fast && supports_plan_fast(Some(auth), info) == FastSupport::Supported {
+        body["service_tier"] = FAST_SERVICE_TIER.into();
+    }
 }
 
 fn static_plan_models() -> Vec<ModelInfo> {
@@ -319,7 +381,10 @@ impl OpenAi {
             "{}{PLAN_MODELS_PATH}{CODEX_CLIENT_VERSION}",
             auth::CODING_PLAN_BASE_URL
         );
-        parse_plan_models(&self.compat.get_text(&auth, &url).await?)
+        parse_plan_models(
+            &self.compat.get_text(&auth, &url).await?,
+            plan_account_id(&auth),
+        )
     }
 }
 
@@ -429,17 +494,18 @@ impl Provider for OpenAi {
                 .map(PlanModelInfo::dialect)
                 .or_else(|| is_codex_model(&model.id).then(|| plan_dialect(&model.id).clone()));
             if let Some(dialect) = plan_dialect {
-                let mut body = super::responses::build_body(model, messages, system, tools);
-                super::responses::apply_responses_reasoning(
-                    &mut body,
-                    opts.thinking,
-                    model,
-                    &dialect,
-                );
                 let stream_timeout = self.compat.stream_timeout();
                 return self
                     .with_oauth_retry(|| async {
                         let codex_auth = self.codex_auth()?;
+                        let mut body = super::responses::build_body(model, messages, system, tools);
+                        super::responses::apply_responses_reasoning(
+                            &mut body,
+                            opts.thinking,
+                            model,
+                            &dialect,
+                        );
+                        apply_plan_fast(&mut body, opts, &codex_auth, discovered.as_deref());
                         super::responses::do_stream(
                             self.compat.client(),
                             model,
@@ -524,9 +590,11 @@ impl Provider for OpenAi {
     }
 
     fn adjust_model(&self, model: &mut Model) {
-        if self.is_oauth()
-            && let Some(context_window) = coding_plan_context_window(&model.id)
-        {
+        let oauth = self.is_oauth();
+        let info = model_registry::provider_info::<PlanModelInfo>(CONFIG.slug, &model.id);
+        let auth = self.codex_auth().ok();
+        model.supports_fast_override = Some(supports_plan_fast(auth.as_ref(), info.as_deref()));
+        if oauth && let Some(context_window) = coding_plan_context_window(&model.id) {
             model.context_window = model.context_window.min(context_window);
         }
     }
@@ -659,6 +727,19 @@ mod tests {
         ]
     }"#;
 
+    const ACCOUNT_ID: &str = "account-a";
+    const OTHER_ACCOUNT_ID: &str = "account-b";
+
+    fn plan_auth(oauth: bool, account_id: Option<&str>) -> ResolvedAuth {
+        ResolvedAuth::for_test(
+            oauth.then(|| auth::CODING_PLAN_BASE_URL.into()),
+            account_id
+                .map(|id| (ACCOUNT_ID_HEADER.into(), id.into()))
+                .into_iter()
+                .collect(),
+        )
+    }
+
     fn plan_info(info: &ModelInfo) -> Arc<PlanModelInfo> {
         info.provider_info
             .clone()
@@ -669,7 +750,7 @@ mod tests {
 
     #[test]
     fn plan_models_keep_listed_models_with_declared_metadata() {
-        let models = parse_plan_models(PLAN_MODELS_RESPONSE).unwrap();
+        let models = parse_plan_models(PLAN_MODELS_RESPONSE, Some(ACCOUNT_ID)).unwrap();
         let ids: Vec<&str> = models.iter().map(|m| m.id.as_str()).collect();
         assert_eq!(ids, ["gpt-7-nova", "gpt-5.5"]);
 
@@ -683,6 +764,8 @@ mod tests {
                 efforts: vec![Effort::Low, Effort::Medium, Effort::Max],
                 adaptive: Some(Effort::Low),
                 off: false,
+                supports_fast: false,
+                account_id: Some(ACCOUNT_ID.into()),
             }
         );
 
@@ -694,15 +777,130 @@ mod tests {
                 efforts: vec![Effort::High],
                 adaptive: None,
                 off: true,
+                supports_fast: false,
+                account_id: Some(ACCOUNT_ID.into()),
             }
         );
+    }
+
+    #[test_case(json!({}), false ; "missing_metadata")]
+    #[test_case(json!({"service_tiers": []}), false ; "empty_tiers")]
+    #[test_case(json!({"service_tiers": [{"id": "flex"}]}), false ; "other_tier")]
+    #[test_case(json!({"service_tiers": [{"id": "priority"}]}), true ; "priority_tier")]
+    #[test_case(json!({"additional_speed_tiers": ["fast"]}), true ; "legacy_fast")]
+    fn plan_models_parse_fast_capability(metadata: Value, expected: bool) {
+        let mut model = metadata;
+        model["slug"] = "gpt-7-nova".into();
+        model["visibility"] = LISTED_VISIBILITY.into();
+        let response = json!({"models": [model]}).to_string();
+        let models = parse_plan_models(&response, Some(ACCOUNT_ID)).unwrap();
+        assert_eq!(plan_info(&models[0]).supports_fast, expected);
+    }
+
+    #[test_case(true, None, FastSupport::Pending ; "oauth_waits_for_discovery")]
+    #[test_case(true, Some(true), FastSupport::Supported ; "oauth_supported")]
+    #[test_case(true, Some(false), FastSupport::Unsupported ; "oauth_unsupported")]
+    #[test_case(false, None, FastSupport::Unsupported ; "api_without_discovery")]
+    #[test_case(false, Some(true), FastSupport::Unsupported ; "api_ignores_plan_support")]
+    fn plan_fast_support(oauth: bool, supported: Option<bool>, expected: FastSupport) {
+        let info = supported.map(|supports_fast| PlanModelInfo {
+            efforts: vec![Effort::High],
+            adaptive: Some(Effort::High),
+            off: false,
+            supports_fast,
+            account_id: Some(ACCOUNT_ID.into()),
+        });
+        let auth = plan_auth(oauth, Some(ACCOUNT_ID));
+        assert_eq!(supports_plan_fast(Some(&auth), info.as_ref()), expected);
+    }
+
+    #[test_case(Some(ACCOUNT_ID), Some(ACCOUNT_ID), FastSupport::Supported ; "matching_account")]
+    #[test_case(Some(ACCOUNT_ID), Some(OTHER_ACCOUNT_ID), FastSupport::Pending ; "changed_account")]
+    #[test_case(None, Some(ACCOUNT_ID), FastSupport::Pending ; "missing_current_account")]
+    #[test_case(Some(ACCOUNT_ID), None, FastSupport::Pending ; "missing_discovery_account")]
+    #[test_case(None, None, FastSupport::Pending ; "unknown_accounts_do_not_match")]
+    #[test_case(Some(""), Some(""), FastSupport::Pending ; "empty_accounts_do_not_match")]
+    fn plan_fast_scopes_discovery_to_account(
+        current_account: Option<&str>,
+        discovered_account: Option<&str>,
+        expected: FastSupport,
+    ) {
+        let response = json!({"models": [{
+            "slug": "gpt-7-nova",
+            "visibility": LISTED_VISIBILITY,
+            "service_tiers": [{"id": FAST_SERVICE_TIER}]
+        }]})
+        .to_string();
+        let models = parse_plan_models(&response, discovered_account).unwrap();
+        let info = plan_info(&models[0]);
+        let auth = plan_auth(true, current_account);
+        assert_eq!(supports_plan_fast(Some(&auth), Some(&info)), expected);
+        let mut body = json!({});
+        apply_plan_fast(
+            &mut body,
+            RequestOptions {
+                thinking: ThinkingConfig::Off,
+                fast: true,
+            },
+            &auth,
+            Some(&info),
+        );
+        assert_eq!(
+            body["service_tier"].as_str(),
+            (expected == FastSupport::Supported).then_some(FAST_SERVICE_TIER)
+        );
+    }
+
+    #[test_case(true, true, Some(true), true ; "eligible_oauth")]
+    #[test_case(false, true, Some(true), false ; "disabled")]
+    #[test_case(true, false, Some(true), false ; "api_key")]
+    #[test_case(true, true, Some(false), false ; "unsupported")]
+    #[test_case(true, true, None, false ; "discovery_unavailable")]
+    fn plan_fast_requires_enabled_eligible_subscription(
+        fast: bool,
+        oauth: bool,
+        supported: Option<bool>,
+        expected: bool,
+    ) {
+        let info = supported.map(|supports_fast| PlanModelInfo {
+            efforts: vec![Effort::High],
+            adaptive: Some(Effort::High),
+            off: false,
+            supports_fast,
+            account_id: Some(ACCOUNT_ID.into()),
+        });
+        let mut model = Model::from_spec("openai/gpt-5.5").unwrap();
+        let auth = plan_auth(oauth, Some(ACCOUNT_ID));
+        model.supports_fast_override = Some(supports_plan_fast(Some(&auth), info.as_ref()));
+        let opts = RequestOptions {
+            thinking: ThinkingConfig::Adaptive,
+            fast,
+        };
+        assert_eq!(opts.clamped(&model).fast, expected);
+        let mut body = responses::build_body(&model, &[], "", &json!([]));
+        responses::apply_responses_reasoning(
+            &mut body,
+            opts.thinking,
+            &model,
+            plan_dialect(&model.id),
+        );
+        let standard = body.clone();
+        apply_plan_fast(&mut body, opts, &auth, info.as_ref());
+        assert_eq!(
+            body["service_tier"].as_str(),
+            expected.then_some(FAST_SERVICE_TIER)
+        );
+        body.as_object_mut().unwrap().remove("service_tier");
+        assert_eq!(body, standard);
     }
 
     #[test_case("{}")]
     #[test_case(r#"{"models": [{"slug": "x", "visibility": "hide"}]}"#)]
     fn plan_models_reject_responses_without_visible_models(response: &str) {
         assert_eq!(
-            parse_plan_models(response).unwrap_err().to_string(),
+            parse_plan_models(response, Some(ACCOUNT_ID))
+                .unwrap_err()
+                .to_string(),
             EMPTY_MODELS_ERROR
         );
     }
@@ -716,7 +914,7 @@ mod tests {
         thinking: ThinkingConfig,
         expected: Option<&str>,
     ) {
-        let models = parse_plan_models(PLAN_MODELS_RESPONSE).unwrap();
+        let models = parse_plan_models(PLAN_MODELS_RESPONSE, Some(ACCOUNT_ID)).unwrap();
         let info = plan_info(&models[index]);
         let model = Model::from_spec(&format!("openai/{}", models[index].id)).unwrap();
         let mut body = json!({});

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -54,7 +54,6 @@ const PLAN_MODELS_PATH: &str = "/models?client_version=";
 const LISTED_VISIBILITY: &str = "list";
 const ACCOUNT_ID_HEADER: &str = "chatgpt-account-id";
 const FAST_SERVICE_TIER: &str = "priority";
-const LEGACY_FAST_SPEED_TIER: &str = "fast";
 const IMAGE_MODALITY: &str = "image";
 const EMPTY_USAGE_ERROR: &str =
     "OpenAI usage response contained no plan or rate limits; the endpoint schema likely changed";
@@ -102,10 +101,10 @@ struct PlanModel {
     supported_reasoning_levels: Vec<PlanReasoningLevel>,
     input_modalities: Vec<String>,
     service_tiers: Vec<PlanServiceTier>,
-    additional_speed_tiers: Vec<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
+#[serde(default)]
 struct PlanServiceTier {
     id: String,
 }
@@ -137,9 +136,10 @@ impl PlanModelInfo {
 }
 
 impl PlanModel {
+    /// The account id rides along so a later lookup can tell whether the
+    /// listing still belongs to whoever is logged in now.
     fn into_info(self, account_id: Option<&str>) -> ModelInfo {
-        let model = self;
-        let levels = &model.supported_reasoning_levels;
+        let levels = &self.supported_reasoning_levels;
         let mut efforts: Vec<Effort> = levels
             .iter()
             .filter_map(|level| level.effort.parse().ok())
@@ -148,28 +148,24 @@ impl PlanModel {
         efforts.dedup();
         let info = PlanModelInfo {
             account_id: account_id.map(str::to_owned),
-            supports_fast: model
+            supports_fast: self
                 .service_tiers
                 .iter()
-                .any(|tier| tier.id == FAST_SERVICE_TIER)
-                || model
-                    .additional_speed_tiers
-                    .iter()
-                    .any(|tier| tier == LEGACY_FAST_SPEED_TIER),
+                .any(|tier| tier.id == FAST_SERVICE_TIER),
             off: levels.iter().any(|level| level.effort == dialect::OFF),
-            adaptive: model
+            adaptive: self
                 .default_reasoning_level
                 .and_then(|level| level.parse().ok()),
             efforts,
         };
         ModelInfo {
-            id: model.slug,
-            context_window: model.context_window,
+            id: self.slug,
+            context_window: self.context_window,
             max_output_tokens: None,
             pricing: None,
             supports_thinking: Some(!info.efforts.is_empty()),
-            supports_vision: (!model.input_modalities.is_empty())
-                .then(|| model.input_modalities.iter().any(|m| m == IMAGE_MODALITY)),
+            supports_vision: (!self.input_modalities.is_empty())
+                .then(|| self.input_modalities.iter().any(|m| m == IMAGE_MODALITY)),
             tier: None,
             provider_info: Some(Arc::new(info)),
         }
@@ -203,31 +199,44 @@ fn plan_account_id(auth: &ResolvedAuth) -> Option<&str> {
         .filter(|value| !value.is_empty())
 }
 
-fn supports_plan_fast(auth: Option<&ResolvedAuth>, info: Option<&PlanModelInfo>) -> FastSupport {
-    let Some(auth) =
-        auth.filter(|auth| auth.base_url.as_deref() == Some(auth::CODING_PLAN_BASE_URL))
-    else {
+/// Fast is a subscription perk, so it takes a coding-plan login *and* a listing
+/// that was fetched for that same account: switch accounts and yesterday's
+/// answer is worthless. `Pending` is the honest answer while the listing is
+/// still in flight, so the ui can hold on to a `/fast` typed at startup.
+fn supports_plan_fast(
+    auth: Option<&ResolvedAuth>,
+    info: Option<&PlanModelInfo>,
+    discovery_complete: bool,
+) -> FastSupport {
+    let account_id = auth
+        .filter(|auth| auth.base_url.as_deref() == Some(auth::CODING_PLAN_BASE_URL))
+        .and_then(plan_account_id);
+    let Some(account_id) = account_id else {
         return FastSupport::Unsupported;
     };
-    match (plan_account_id(auth), info) {
-        (Some(account_id), Some(info)) if info.account_id.as_deref() == Some(account_id) => {
+    match info {
+        Some(info) if info.account_id.as_deref() == Some(account_id) => {
             if info.supports_fast {
                 FastSupport::Supported
             } else {
                 FastSupport::Unsupported
             }
         }
-        _ => FastSupport::Pending,
+        None if !discovery_complete => FastSupport::Pending,
+        _ => FastSupport::Unsupported,
     }
 }
 
+/// Re-checked against the live auth rather than trusting `Model`, whose
+/// override was stamped when the model was built and may predate a re-login.
 fn apply_plan_fast(
     body: &mut Value,
-    opts: RequestOptions,
+    fast: bool,
     auth: &ResolvedAuth,
     info: Option<&PlanModelInfo>,
 ) {
-    if opts.fast && supports_plan_fast(Some(auth), info) == FastSupport::Supported {
+    let complete = model_registry::discovery_complete(CONFIG.slug);
+    if fast && supports_plan_fast(Some(auth), info, complete) == FastSupport::Supported {
         body["service_tier"] = FAST_SERVICE_TIER.into();
     }
 }
@@ -505,7 +514,7 @@ impl Provider for OpenAi {
                             model,
                             &dialect,
                         );
-                        apply_plan_fast(&mut body, opts, &codex_auth, discovered.as_deref());
+                        apply_plan_fast(&mut body, opts.fast, &codex_auth, discovered.as_deref());
                         super::responses::do_stream(
                             self.compat.client(),
                             model,
@@ -589,12 +598,21 @@ impl Provider for OpenAi {
         })
     }
 
+    /// An api-key user gets no opinion at all: stamping `Unsupported` here
+    /// would shadow the pricing gate in `Model::supports_fast` for good, and
+    /// that gate is not ours to close.
     fn adjust_model(&self, model: &mut Model) {
-        let oauth = self.is_oauth();
-        let info = model_registry::provider_info::<PlanModelInfo>(CONFIG.slug, &model.id);
+        if !self.is_oauth() {
+            return;
+        }
         let auth = self.codex_auth().ok();
-        model.supports_fast_override = Some(supports_plan_fast(auth.as_ref(), info.as_deref()));
-        if oauth && let Some(context_window) = coding_plan_context_window(&model.id) {
+        let info = model_registry::provider_info::<PlanModelInfo>(CONFIG.slug, &model.id);
+        model.supports_fast_override = Some(supports_plan_fast(
+            auth.as_ref(),
+            info.as_deref(),
+            model_registry::discovery_complete(CONFIG.slug),
+        ));
+        if let Some(context_window) = coding_plan_context_window(&model.id) {
             model.context_window = model.context_window.min(context_window);
         }
     }
@@ -787,7 +805,7 @@ mod tests {
     #[test_case(json!({"service_tiers": []}), false ; "empty_tiers")]
     #[test_case(json!({"service_tiers": [{"id": "flex"}]}), false ; "other_tier")]
     #[test_case(json!({"service_tiers": [{"id": "priority"}]}), true ; "priority_tier")]
-    #[test_case(json!({"additional_speed_tiers": ["fast"]}), true ; "legacy_fast")]
+    #[test_case(json!({"additional_speed_tiers": ["fast"]}), false ; "legacy_fast_is_not_priority")]
     fn plan_models_parse_fast_capability(metadata: Value, expected: bool) {
         let mut model = metadata;
         model["slug"] = "gpt-7-nova".into();
@@ -797,29 +815,69 @@ mod tests {
         assert_eq!(plan_info(&models[0]).supports_fast, expected);
     }
 
-    #[test_case(true, None, FastSupport::Pending ; "oauth_waits_for_discovery")]
-    #[test_case(true, Some(true), FastSupport::Supported ; "oauth_supported")]
-    #[test_case(true, Some(false), FastSupport::Unsupported ; "oauth_unsupported")]
-    #[test_case(false, None, FastSupport::Unsupported ; "api_without_discovery")]
-    #[test_case(false, Some(true), FastSupport::Unsupported ; "api_ignores_plan_support")]
-    fn plan_fast_support(oauth: bool, supported: Option<bool>, expected: FastSupport) {
-        let info = supported.map(|supports_fast| PlanModelInfo {
+    fn plan_model_info(supports_fast: bool) -> PlanModelInfo {
+        PlanModelInfo {
             efforts: vec![Effort::High],
             adaptive: Some(Effort::High),
             off: false,
             supports_fast,
             account_id: Some(ACCOUNT_ID.into()),
-        });
-        let auth = plan_auth(oauth, Some(ACCOUNT_ID));
-        assert_eq!(supports_plan_fast(Some(&auth), info.as_ref()), expected);
+        }
+    }
+
+    #[test_case(true, Some(ACCOUNT_ID), None, false, FastSupport::Pending ; "oauth_waits_for_discovery")]
+    #[test_case(true, Some(ACCOUNT_ID), None, true, FastSupport::Unsupported ; "completed_without_model_metadata")]
+    #[test_case(true, Some(ACCOUNT_ID), Some(true), true, FastSupport::Supported ; "oauth_supported")]
+    #[test_case(true, Some(ACCOUNT_ID), Some(false), true, FastSupport::Unsupported ; "oauth_unsupported")]
+    #[test_case(false, Some(ACCOUNT_ID), None, false, FastSupport::Unsupported ; "api_without_discovery")]
+    #[test_case(false, Some(ACCOUNT_ID), Some(true), true, FastSupport::Unsupported ; "api_ignores_plan_support")]
+    #[test_case(true, None, None, false, FastSupport::Unsupported ; "missing_account_never_pends")]
+    fn plan_fast_support(
+        oauth: bool,
+        account_id: Option<&str>,
+        supported: Option<bool>,
+        discovery_complete: bool,
+        expected: FastSupport,
+    ) {
+        let info = supported.map(plan_model_info);
+        let auth = plan_auth(oauth, account_id);
+        assert_eq!(
+            supports_plan_fast(Some(&auth), info.as_ref(), discovery_complete),
+            expected
+        );
+    }
+
+    /// Once the listing lands, a model it never mentioned is a definite no.
+    /// Staying `Pending` forever would leave `/fast` stuck flashing "soon".
+    #[test_case("fast-static-fallback", static_plan_models() ; "static_fallback")]
+    #[test_case("fast-omitted-model", parse_plan_models(PLAN_MODELS_RESPONSE, Some(ACCOUNT_ID)).unwrap() ; "model_omitted")]
+    fn completed_listing_without_fast_metadata(provider: &str, models: Vec<ModelInfo>) {
+        let auth = plan_auth(true, Some(ACCOUNT_ID));
+        assert_eq!(
+            supports_plan_fast(
+                Some(&auth),
+                None,
+                model_registry::discovery_complete(provider)
+            ),
+            FastSupport::Pending
+        );
+        model_registry::set_known_models(provider, models);
+        let info = model_registry::provider_info::<PlanModelInfo>(provider, PLAN_MODELS[0]);
+        assert_eq!(
+            supports_plan_fast(
+                Some(&auth),
+                info.as_deref(),
+                model_registry::discovery_complete(provider),
+            ),
+            FastSupport::Unsupported
+        );
     }
 
     #[test_case(Some(ACCOUNT_ID), Some(ACCOUNT_ID), FastSupport::Supported ; "matching_account")]
-    #[test_case(Some(ACCOUNT_ID), Some(OTHER_ACCOUNT_ID), FastSupport::Pending ; "changed_account")]
-    #[test_case(None, Some(ACCOUNT_ID), FastSupport::Pending ; "missing_current_account")]
-    #[test_case(Some(ACCOUNT_ID), None, FastSupport::Pending ; "missing_discovery_account")]
-    #[test_case(None, None, FastSupport::Pending ; "unknown_accounts_do_not_match")]
-    #[test_case(Some(""), Some(""), FastSupport::Pending ; "empty_accounts_do_not_match")]
+    #[test_case(Some(ACCOUNT_ID), Some(OTHER_ACCOUNT_ID), FastSupport::Unsupported ; "changed_account")]
+    #[test_case(None, Some(ACCOUNT_ID), FastSupport::Unsupported ; "missing_current_account")]
+    #[test_case(Some(ACCOUNT_ID), None, FastSupport::Unsupported ; "missing_discovery_account")]
+    #[test_case(Some(""), Some(""), FastSupport::Unsupported ; "empty_accounts_do_not_match")]
     fn plan_fast_scopes_discovery_to_account(
         current_account: Option<&str>,
         discovered_account: Option<&str>,
@@ -834,44 +892,32 @@ mod tests {
         let models = parse_plan_models(&response, discovered_account).unwrap();
         let info = plan_info(&models[0]);
         let auth = plan_auth(true, current_account);
-        assert_eq!(supports_plan_fast(Some(&auth), Some(&info)), expected);
+        assert_eq!(supports_plan_fast(Some(&auth), Some(&info), true), expected);
         let mut body = json!({});
-        apply_plan_fast(
-            &mut body,
-            RequestOptions {
-                thinking: ThinkingConfig::Off,
-                fast: true,
-            },
-            &auth,
-            Some(&info),
-        );
+        apply_plan_fast(&mut body, true, &auth, Some(&info));
         assert_eq!(
             body["service_tier"].as_str(),
             (expected == FastSupport::Supported).then_some(FAST_SERVICE_TIER)
         );
     }
 
-    #[test_case(true, true, Some(true), true ; "eligible_oauth")]
-    #[test_case(false, true, Some(true), false ; "disabled")]
-    #[test_case(true, false, Some(true), false ; "api_key")]
-    #[test_case(true, true, Some(false), false ; "unsupported")]
-    #[test_case(true, true, None, false ; "discovery_unavailable")]
+    /// Fast has to survive the whole trip: the option gate, then the body. And
+    /// when it is off, the request must come out byte for byte like it always
+    /// did, so nothing sneaks into a plain call.
+    #[test_case(true, true, true, true ; "eligible_oauth")]
+    #[test_case(false, true, true, false ; "disabled")]
+    #[test_case(true, false, true, false ; "api_key")]
+    #[test_case(true, true, false, false ; "unsupported")]
     fn plan_fast_requires_enabled_eligible_subscription(
         fast: bool,
         oauth: bool,
-        supported: Option<bool>,
+        supported: bool,
         expected: bool,
     ) {
-        let info = supported.map(|supports_fast| PlanModelInfo {
-            efforts: vec![Effort::High],
-            adaptive: Some(Effort::High),
-            off: false,
-            supports_fast,
-            account_id: Some(ACCOUNT_ID.into()),
-        });
+        let info = plan_model_info(supported);
         let mut model = Model::from_spec("openai/gpt-5.5").unwrap();
         let auth = plan_auth(oauth, Some(ACCOUNT_ID));
-        model.supports_fast_override = Some(supports_plan_fast(Some(&auth), info.as_ref()));
+        model.supports_fast_override = Some(supports_plan_fast(Some(&auth), Some(&info), true));
         let opts = RequestOptions {
             thinking: ThinkingConfig::Adaptive,
             fast,
@@ -885,7 +931,7 @@ mod tests {
             plan_dialect(&model.id),
         );
         let standard = body.clone();
-        apply_plan_fast(&mut body, opts, &auth, info.as_ref());
+        apply_plan_fast(&mut body, fast, &auth, Some(&info));
         assert_eq!(
             body["service_tier"].as_str(),
             expected.then_some(FAST_SERVICE_TIER)

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -332,6 +332,7 @@ mod tests {
             supports_tool_examples_override: None,
             thinking_override: None,
             supports_vision_override: None,
+            supports_fast_override: None,
             pricing: ModelPricing::default(),
             discovered_free: false,
             max_output_tokens: Some(8192),

--- a/maki-providers/src/providers/xai/platform.rs
+++ b/maki-providers/src/providers/xai/platform.rs
@@ -305,6 +305,7 @@ mod tests {
                 crate::model::ThinkingSupport::No
             }),
             supports_vision_override: Some(true),
+            supports_fast_override: None,
             pricing: ModelPricing::ZERO,
             discovered_free: false,
             max_output_tokens: Some(131_072),

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -1552,6 +1552,7 @@ mod tests {
             supports_tool_examples_override: None,
             thinking_override: None,
             supports_vision_override: Some(provider.family().supports_vision()),
+            supports_fast_override: None,
             pricing: crate::model::ModelPricing::default(),
             discovered_free: false,
             max_output_tokens: Some(8192),

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -96,6 +96,7 @@ const FLASH_NO_PLAN: &str = "No plan file";
 const FAST_UNSUPPORTED_MSG: &str = "Fast mode needs Anthropic Opus 4.6+ with an API key, or an eligible Codex model with a ChatGPT subscription";
 const THINKING_UNSUPPORTED_MSG: &str = "Thinking requires a model that supports it";
 const FAST_ON_MSG: &str = "Fast mode: on";
+const FAST_PENDING_MSG: &str = "Fast mode: pending model discovery";
 const FAST_OFF_MSG: &str = "Fast mode: off";
 const WORKFLOW_ON_MSG: &str = "Workflow mode: on";
 const WORKFLOW_OFF_MSG: &str = "Workflow mode: off";
@@ -435,11 +436,11 @@ impl App {
     }
 
     pub(crate) fn set_fast(&mut self, fast: bool) -> Result<(), String> {
-        if fast && !self.state.model.supports_fast() {
+        let model = &self.state.model;
+        if fast && !model.supports_fast() && !model.fast_pending() {
             return Err(FAST_UNSUPPORTED_MSG.into());
         }
-        self.state.fast = fast;
-        self.state.pending_fast = false;
+        self.state.set_fast(fast);
         Ok(())
     }
 
@@ -1473,9 +1474,17 @@ impl App {
                 vec![]
             }
             "/fast" => {
-                let fast = !(self.state.fast || self.state.pending_fast);
-                match self.set_fast(fast) {
-                    Ok(()) => self.flash(if fast { FAST_ON_MSG } else { FAST_OFF_MSG }.into()),
+                match self.set_fast(!self.state.fast_intent()) {
+                    Ok(()) => self.flash(
+                        if self.state.pending_fast {
+                            FAST_PENDING_MSG
+                        } else if self.state.fast {
+                            FAST_ON_MSG
+                        } else {
+                            FAST_OFF_MSG
+                        }
+                        .into(),
+                    ),
                     Err(msg) => self.flash(msg),
                 }
                 vec![]

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -93,7 +93,7 @@ const FLASH_REWIND: &str = "Press esc again to rewind...";
 const AUTH_EXPIRED_MSG: &str =
     "Token expired. Run `maki auth login` in another terminal, then press Enter to retry.";
 const FLASH_NO_PLAN: &str = "No plan file";
-const FAST_UNSUPPORTED_MSG: &str = "Fast mode requires an Anthropic Opus 4.6+ model (API only)";
+const FAST_UNSUPPORTED_MSG: &str = "Fast mode needs Anthropic Opus 4.6+ with an API key, or an eligible Codex model with a ChatGPT subscription";
 const THINKING_UNSUPPORTED_MSG: &str = "Thinking requires a model that supports it";
 const FAST_ON_MSG: &str = "Fast mode: on";
 const FAST_OFF_MSG: &str = "Fast mode: off";
@@ -439,6 +439,7 @@ impl App {
             return Err(FAST_UNSUPPORTED_MSG.into());
         }
         self.state.fast = fast;
+        self.state.pending_fast = false;
         Ok(())
     }
 
@@ -1472,7 +1473,7 @@ impl App {
                 vec![]
             }
             "/fast" => {
-                let fast = !self.state.fast;
+                let fast = !(self.state.fast || self.state.pending_fast);
                 match self.set_fast(fast) {
                     Ok(()) => self.flash(if fast { FAST_ON_MSG } else { FAST_OFF_MSG }.into()),
                     Err(msg) => self.flash(msg),

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -129,7 +129,7 @@ impl App {
                 self.recoverable_queue.clone()
             },
             thinking: Some(state.thinking.into()),
-            fast: state.fast,
+            fast: state.fast || state.pending_fast,
             workflow: state.workflow,
             yolo: self.permissions.persisted_yolo(),
         }
@@ -309,7 +309,7 @@ impl App {
         session.meta = SessionMeta {
             mode: Some(self.state.mode.into()),
             thinking: Some(self.state.thinking.into()),
-            fast: self.state.fast,
+            fast: self.state.fast || self.state.pending_fast,
             workflow: self.state.workflow,
             plan_path: None,
             plan_written: false,
@@ -419,5 +419,41 @@ impl App {
         };
         let loaded = self.apply_loaded_session(session, &self.state.model.clone());
         vec![Action::LoadSession(Box::new(loaded))]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::app::tests::test_app;
+    use crate::components::command::ParsedCommand;
+    use maki_providers::model::FastSupport;
+    use test_case::test_case;
+
+    #[test_case(false ; "pending_survives_snapshot_and_inheritance")]
+    #[test_case(true ; "explicit_off_cancels_pending")]
+    fn pending_fast_persistence(cancel: bool) {
+        let mut app = test_app();
+        app.state.model.supports_fast_override = Some(FastSupport::Pending);
+        app.state.fast = false;
+        app.state.pending_fast = true;
+        if cancel {
+            app.execute_command(
+                ParsedCommand {
+                    name: "/fast".into(),
+                    args: String::new(),
+                    bang: false,
+                },
+                0,
+            );
+        }
+        assert!(!app.state.fast);
+        assert_eq!(app.build_meta().fast, !cancel);
+        assert_eq!(app.blank_session().meta.fast, !cancel);
+        let mut model = app.state.model.clone();
+        model.supports_fast_override = Some(FastSupport::Supported);
+        app.update_model(&model);
+        assert_eq!(app.state.fast, !cancel);
+        assert!(!app.state.pending_fast);
+        assert_eq!(app.build_meta().fast, !cancel);
     }
 }

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -129,7 +129,7 @@ impl App {
                 self.recoverable_queue.clone()
             },
             thinking: Some(state.thinking.into()),
-            fast: state.fast || state.pending_fast,
+            fast: state.fast_intent(),
             workflow: state.workflow,
             yolo: self.permissions.persisted_yolo(),
         }
@@ -309,7 +309,7 @@ impl App {
         session.meta = SessionMeta {
             mode: Some(self.state.mode.into()),
             thinking: Some(self.state.thinking.into()),
-            fast: self.state.fast || self.state.pending_fast,
+            fast: self.state.fast_intent(),
             workflow: self.state.workflow,
             plan_path: None,
             plan_written: false,
@@ -425,18 +425,45 @@ impl App {
 #[cfg(test)]
 mod tests {
     use crate::app::tests::test_app;
+    use crate::app::{App, FAST_OFF_MSG, FAST_PENDING_MSG};
     use crate::components::command::ParsedCommand;
     use maki_providers::model::FastSupport;
     use test_case::test_case;
 
-    #[test_case(false ; "pending_survives_snapshot_and_inheritance")]
-    #[test_case(true ; "explicit_off_cancels_pending")]
-    fn pending_fast_persistence(cancel: bool) {
+    fn pending_app() -> App {
         let mut app = test_app();
         app.state.model.supports_fast_override = Some(FastSupport::Pending);
-        app.state.fast = false;
-        app.state.pending_fast = true;
+        app
+    }
+
+    /// A `/fast` typed before the model list lands has to outlive the snapshot
+    /// a new session inherits, otherwise the answer arrives and the wish is
+    /// already gone.
+    #[test_case(false ; "kept")]
+    #[test_case(true ; "cancelled")]
+    fn pending_fast_survives_snapshot_until_discovery_answers(cancel: bool) {
+        let mut app = pending_app();
+        app.set_fast(true).unwrap();
         if cancel {
+            app.set_fast(false).unwrap();
+        }
+        assert!(!app.state.fast);
+        assert_eq!(app.state.pending_fast, !cancel);
+        assert_eq!(app.build_meta().fast, !cancel);
+        assert_eq!(app.blank_session().meta.fast, !cancel);
+
+        let mut model = app.state.model.clone();
+        model.supports_fast_override = Some(FastSupport::Supported);
+        app.update_model(&model);
+        assert_eq!(app.state.fast, !cancel);
+        assert!(!app.state.pending_fast);
+        assert_eq!(app.build_meta().fast, !cancel);
+    }
+
+    #[test]
+    fn fast_command_flashes_pending_while_discovery_runs() {
+        let mut app = pending_app();
+        for expected in [FAST_PENDING_MSG, FAST_OFF_MSG] {
             app.execute_command(
                 ParsedCommand {
                     name: "/fast".into(),
@@ -445,15 +472,9 @@ mod tests {
                 },
                 0,
             );
+            assert_eq!(app.status_bar.flash_text(), Some(expected));
+            assert!(!app.state.fast);
         }
-        assert!(!app.state.fast);
-        assert_eq!(app.build_meta().fast, !cancel);
-        assert_eq!(app.blank_session().meta.fast, !cancel);
-        let mut model = app.state.model.clone();
-        model.supports_fast_override = Some(FastSupport::Supported);
-        app.update_model(&model);
-        assert_eq!(app.state.fast, !cancel);
         assert!(!app.state.pending_fast);
-        assert_eq!(app.build_meta().fast, !cancel);
     }
 }

--- a/maki-ui/src/app/session_state.rs
+++ b/maki-ui/src/app/session_state.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use maki_config::{Effect, ModelPolicy};
+use maki_providers::model::FastSupport;
 use maki_providers::provider::adjust_model;
 use maki_providers::{Model, RequestOptions, ThinkingConfig, Timeouts, TokenUsage, settle_session};
 use maki_storage::StateDir;
@@ -26,6 +27,7 @@ pub(crate) struct SessionState {
     pub warnings: Vec<String>,
     pub thinking: ThinkingConfig,
     pub fast: bool,
+    pub pending_fast: bool,
     pub workflow: bool,
 }
 
@@ -90,6 +92,8 @@ impl SessionState {
 
         // Saved model may differ from the live one (updated, removed, etc), so
         // reconcile before anyone reads the toggles or prices history with them.
+        let pending_fast =
+            session.meta.fast && model.supports_fast_override == Some(FastSupport::Pending);
         let (thinking, fast) = clamp(session.meta.thinking.into(), session.meta.fast, &model);
         let token_usage = session.token_usage;
         let cost = settle_session(&token_usage, session.usage_by_model_mut(), &model, fast);
@@ -98,6 +102,7 @@ impl SessionState {
         Self {
             thinking,
             fast,
+            pending_fast,
             workflow: session.meta.workflow,
             session: Arc::new(session),
             model,
@@ -115,7 +120,9 @@ impl SessionState {
     }
 
     pub fn update_model(&mut self, model: &Model) {
-        (self.thinking, self.fast) = clamp(self.thinking, self.fast, model);
+        let fast = self.fast || (self.pending_fast && self.model.spec() == model.spec());
+        self.pending_fast = fast && model.supports_fast_override == Some(FastSupport::Pending);
+        (self.thinking, self.fast) = clamp(self.thinking, fast, model);
         self.session_mut().set_model(model.spec());
         self.model = model.clone();
     }
@@ -284,6 +291,40 @@ mod tests {
 
         assert_eq!(state.fast, fast, "{FAST_FLAG_LOST}");
         state.cost
+    }
+
+    #[test_case(FastSupport::Pending, false, true ; "pending_preserves_saved_intent")]
+    #[test_case(FastSupport::Supported, true, false ; "supported_restores_fast")]
+    #[test_case(FastSupport::Unsupported, false, false ; "unsupported_clears_saved_intent")]
+    fn resume_fast_support(support: FastSupport, fast: bool, pending: bool) {
+        let mut session = session_with_counters();
+        session.meta.fast = true;
+        let mut model = test_model();
+        model.supports_fast_override = Some(support);
+        let state = resumed(session, &model);
+        assert_eq!((state.fast, state.pending_fast), (fast, pending));
+    }
+
+    #[test_case(FastSupport::Supported, false, true, false ; "discovery_enables_fast")]
+    #[test_case(FastSupport::Unsupported, false, false, false ; "discovery_rejects_fast")]
+    #[test_case(FastSupport::Pending, false, false, true ; "pending_refresh_preserves_intent")]
+    #[test_case(FastSupport::Supported, true, false, false ; "switch_discards_pending_intent")]
+    #[test_case(FastSupport::Pending, true, false, false ; "switch_to_pending_discards_intent")]
+    fn pending_fast_model_update(support: FastSupport, switch: bool, fast: bool, pending: bool) {
+        let mut session = session_with_counters();
+        session.meta.fast = true;
+        let mut model = test_model();
+        model.supports_fast_override = Some(FastSupport::Pending);
+        let mut state = resumed(session, &model);
+        if switch {
+            model.id = UNRESOLVABLE_MODEL.into();
+        }
+        model.supports_fast_override = Some(support);
+        state.update_model(&model);
+        assert_eq!((state.fast, state.pending_fast), (fast, pending));
+        model.supports_fast_override = Some(FastSupport::Supported);
+        state.update_model(&model);
+        assert_eq!(state.fast, fast || pending);
     }
 
     #[test]

--- a/maki-ui/src/app/session_state.rs
+++ b/maki-ui/src/app/session_state.rs
@@ -2,7 +2,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use maki_config::{Effect, ModelPolicy};
-use maki_providers::model::FastSupport;
 use maki_providers::provider::adjust_model;
 use maki_providers::{Model, RequestOptions, ThinkingConfig, Timeouts, TokenUsage, settle_session};
 use maki_storage::StateDir;
@@ -26,7 +25,10 @@ pub(crate) struct SessionState {
     pub plan: PlanState,
     pub warnings: Vec<String>,
     pub thinking: ThinkingConfig,
+    /// What we actually bill and send.
     pub fast: bool,
+    /// A wish parked until discovery answers, so a `/fast` typed while the
+    /// model list is still loading is not thrown on the floor.
     pub pending_fast: bool,
     pub workflow: bool,
 }
@@ -34,10 +36,12 @@ pub(crate) struct SessionState {
 const PLAN_FILE_MISSING_WARNING: &str = "Plan file was deleted \u{2014} started a new plan";
 
 /// The badge, the cost line and the request all read the same gate, so none of
-/// them can advertise a mode this model lacks, or miss one it demands.
-fn clamp(thinking: ThinkingConfig, fast: bool, model: &Model) -> (ThinkingConfig, bool) {
+/// them can advertise a mode this model lacks, or miss one it demands. Fast
+/// comes back split into "on now" and "still waiting", which is the only place
+/// those two bits are derived.
+fn clamp(thinking: ThinkingConfig, fast: bool, model: &Model) -> (ThinkingConfig, bool, bool) {
     let opts = RequestOptions { thinking, fast }.clamped(model);
-    (opts.thinking, opts.fast)
+    (opts.thinking, opts.fast, fast && model.fast_pending())
 }
 
 impl SessionState {
@@ -92,9 +96,8 @@ impl SessionState {
 
         // Saved model may differ from the live one (updated, removed, etc), so
         // reconcile before anyone reads the toggles or prices history with them.
-        let pending_fast =
-            session.meta.fast && model.supports_fast_override == Some(FastSupport::Pending);
-        let (thinking, fast) = clamp(session.meta.thinking.into(), session.meta.fast, &model);
+        let (thinking, fast, pending_fast) =
+            clamp(session.meta.thinking.into(), session.meta.fast, &model);
         let token_usage = session.token_usage;
         let cost = settle_session(&token_usage, session.usage_by_model_mut(), &model, fast);
         let context_size = session.meta.context_size;
@@ -119,10 +122,19 @@ impl SessionState {
         Arc::make_mut(&mut self.session)
     }
 
+    /// What the user asked for, whether or not the model can honour it yet.
+    /// This is the bit that gets persisted.
+    pub fn fast_intent(&self) -> bool {
+        self.fast || self.pending_fast
+    }
+
+    pub fn set_fast(&mut self, fast: bool) {
+        (self.thinking, self.fast, self.pending_fast) = clamp(self.thinking, fast, &self.model);
+    }
+
     pub fn update_model(&mut self, model: &Model) {
-        let fast = self.fast || (self.pending_fast && self.model.spec() == model.spec());
-        self.pending_fast = fast && model.supports_fast_override == Some(FastSupport::Pending);
-        (self.thinking, self.fast) = clamp(self.thinking, fast, model);
+        (self.thinking, self.fast, self.pending_fast) =
+            clamp(self.thinking, self.fast_intent(), model);
         self.session_mut().set_model(model.spec());
         self.model = model.clone();
     }
@@ -212,6 +224,7 @@ pub(crate) fn stored_to_rules(stored: &[StoredRule]) -> Vec<maki_config::Permiss
 mod tests {
     use super::*;
     use crate::components::{test_model, test_pricing};
+    use maki_providers::model::FastSupport;
     use maki_providers::{FastPricing, ModelPricing, ThinkingSupport};
     use maki_storage::sessions::StoredThinking;
     use test_case::test_case;
@@ -301,30 +314,35 @@ mod tests {
         session.meta.fast = true;
         let mut model = test_model();
         model.supports_fast_override = Some(support);
+        model.pricing.fast = Some(FastPricing {
+            input: FAST_INPUT_RATE,
+            output: test_pricing().output,
+        });
         let state = resumed(session, &model);
         assert_eq!((state.fast, state.pending_fast), (fast, pending));
+        assert_eq!(
+            state.cost,
+            Some(if fast { FAST_INPUT_RATE } else { LIST_PRICE })
+        );
     }
 
     #[test_case(FastSupport::Supported, false, true, false ; "discovery_enables_fast")]
     #[test_case(FastSupport::Unsupported, false, false, false ; "discovery_rejects_fast")]
-    #[test_case(FastSupport::Pending, false, false, true ; "pending_refresh_preserves_intent")]
-    #[test_case(FastSupport::Supported, true, false, false ; "switch_discards_pending_intent")]
-    #[test_case(FastSupport::Pending, true, false, false ; "switch_to_pending_discards_intent")]
+    #[test_case(FastSupport::Pending, false, false, true ; "still_pending_keeps_intent")]
+    #[test_case(FastSupport::Supported, true, true, false ; "switch_keeps_pending_intent")]
     fn pending_fast_model_update(support: FastSupport, switch: bool, fast: bool, pending: bool) {
         let mut session = session_with_counters();
         session.meta.fast = true;
         let mut model = test_model();
         model.supports_fast_override = Some(FastSupport::Pending);
         let mut state = resumed(session, &model);
+        assert_eq!((state.fast, state.pending_fast), (false, true));
         if switch {
             model.id = UNRESOLVABLE_MODEL.into();
         }
         model.supports_fast_override = Some(support);
         state.update_model(&model);
         assert_eq!((state.fast, state.pending_fast), (fast, pending));
-        model.supports_fast_override = Some(FastSupport::Supported);
-        state.update_model(&model);
-        assert_eq!(state.fast, fast || pending);
     }
 
     #[test]

--- a/maki-ui/src/components/command.rs
+++ b/maki-ui/src/components/command.rs
@@ -101,7 +101,7 @@ pub const BUILTIN_COMMANDS: &[BuiltinCommand] = &[
     },
     BuiltinCommand {
         name: "/fast",
-        description: "Toggle Anthropic fast mode (Opus only)",
+        description: "Toggle fast mode (Anthropic Opus or Codex subscription models)",
         max_args: 0,
         bang: false,
     },

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -418,6 +418,7 @@ pub(crate) fn test_model() -> maki_providers::Model {
         supports_tool_examples_override: None,
         thinking_override: None,
         supports_vision_override: Some(true),
+        supports_fast_override: None,
         pricing: test_pricing(),
         discovered_free: false,
         max_output_tokens: Some(8192),

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -335,6 +335,12 @@ struct SessionRuntime {
     /// so a new task would inherit the old one's status.
     last_tasks: Vec<(Arc<str>, TaskStatus)>,
     notifications: RunNotificationState,
+    /// The slot this session last synced from, compared by identity rather
+    /// than field by field: discovery fills in things like fast support long
+    /// after the model was built, and a hand written list would miss them.
+    /// `None` until the first sync, which is what pulls a restored session off
+    /// its own saved model and onto the one that is selected now.
+    slot: Option<Arc<ModelSlot>>,
 }
 
 impl SessionRuntime {
@@ -437,6 +443,7 @@ impl SpawnCtx {
             last_status: SessionStatus::Idle,
             last_tasks: Vec::new(),
             notifications: RunNotificationState::default(),
+            slot: None,
         }
     }
 }
@@ -882,20 +889,15 @@ impl<'t> EventLoop<'t> {
             }
         }
 
-        let slot_model = self.ctx.model_slot.load();
-        let spec = slot_model.model.spec();
+        let slot = self.ctx.model_slot.load_full();
         for rt in &mut self.sessions {
-            if rt.app.state.session.model != spec
-                || rt.app.state.model.context_window != slot_model.model.context_window
-                || rt.app.state.model.supports_fast_override
-                    != slot_model.model.supports_fast_override
-            {
-                rt.app.update_model(&slot_model.model);
+            if rt.slot.as_ref().is_none_or(|s| !Arc::ptr_eq(s, &slot)) {
+                rt.slot = Some(Arc::clone(&slot));
+                rt.app.update_model(&slot.model);
                 dirty = Dirty::YES;
             }
             rt.app.emit_model_change();
         }
-        drop(slot_model);
 
         // These only fire Lua autocmds. Anything a handler does comes back
         // as a `UiAction` on the next wake, which repaints then.

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -503,6 +503,28 @@ fn merge_batch(
     available.store(Some(Arc::new(merged)));
 }
 
+fn resolve_discovered_model(model_slot: &ArcSwap<ModelSlot>, timeouts: Timeouts) {
+    let spec = model_slot.load().model.spec();
+    let mut resolved = match Model::from_spec(&spec) {
+        Ok(m) => m,
+        Err(e) => {
+            warn!(spec = %spec, error = %e, "failed to resolve model after discovery");
+            return;
+        }
+    };
+    let provider = match from_model(&mut resolved, timeouts) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(spec = %spec, error = %e, "failed to create provider after discovery");
+            return;
+        }
+    };
+    model_slot.store(Arc::new(ModelSlot {
+        model: resolved,
+        provider: Arc::from(provider),
+    }));
+}
+
 fn spawn_model_fetch(
     model_slot: &Arc<ArcSwap<ModelSlot>>,
     timeouts: Timeouts,
@@ -515,27 +537,7 @@ fn spawn_model_fetch(
     let model_slot = Arc::clone(model_slot);
     let task = smol::spawn(async move {
         let warn_tx = warn_tx_bg;
-        let done = Box::new(move || {
-            let spec = model_slot.load().model.spec();
-            let mut resolved = match Model::from_spec(&spec) {
-                Ok(m) => m,
-                Err(e) => {
-                    warn!(spec = %spec, error = %e, "failed to resolve model after discovery");
-                    return;
-                }
-            };
-            let provider = match from_model(&mut resolved, timeouts) {
-                Ok(p) => p,
-                Err(e) => {
-                    warn!(spec = %spec, error = %e, "failed to create provider after discovery");
-                    return;
-                }
-            };
-            model_slot.store(Arc::new(ModelSlot {
-                model: resolved,
-                provider: Arc::from(provider),
-            }));
-        });
+        let done = Box::new(move || resolve_discovered_model(&model_slot, timeouts));
         fetch_all_models(
             &policy,
             |batch| merge_batch(&bg, batch, &warn_tx),
@@ -885,6 +887,8 @@ impl<'t> EventLoop<'t> {
         for rt in &mut self.sessions {
             if rt.app.state.session.model != spec
                 || rt.app.state.model.context_window != slot_model.model.context_window
+                || rt.app.state.model.supports_fast_override
+                    != slot_model.model.supports_fast_override
             {
                 rt.app.update_model(&slot_model.model);
                 dirty = Dirty::YES;
@@ -1677,12 +1681,16 @@ impl<'t> EventLoop<'t> {
         let available = Arc::clone(&self.ctx.available_models);
         let warn_tx = self.warn_tx.clone();
         let policy = Arc::clone(&self.ctx.model_policy);
+        let model_slot = Arc::clone(&self.ctx.model_slot);
+        let timeouts = self.ctx.timeouts;
         available.store(None);
         smol::spawn(async move {
             fetch_all_models(
                 &policy,
                 |batch| merge_batch(&available, batch, &warn_tx),
-                None,
+                Some(Box::new(move || {
+                    resolve_discovered_model(&model_slot, timeouts)
+                })),
             )
             .await;
         })

--- a/site/docs/content/commands/_index.md
+++ b/site/docs/content/commands/_index.md
@@ -25,7 +25,7 @@ Type `/` in the input box to open the command palette.
 | `/cd` | Change working directory |
 | `/btw` | Ask a quick question (no tools, no history pollution) |
 | `/yolo` | Toggle YOLO mode (skip all permission prompts) |
-| `/fast` | Toggle Anthropic fast mode (Opus only) |
+| `/fast` | Toggle fast mode (Anthropic Opus or Codex subscription models) |
 | `/workflow` | Toggle workflow mode (task callable inside code_execution) |
 | `/exit` | Exit the application |
 | `/reload` | Reload plugins and config |
@@ -46,7 +46,7 @@ Sessions run concurrently. `/new` starts a fresh session while the old one keeps
 
 - **`/yolo`**: skip permission prompts for this session (deny rules still apply). The toggle survives a resume, and `--yolo` only sets the starting value. Config: `always_yolo = true`.
 - **`/thinking`**: extended thinking. Bare, or `Alt+T`, it opens a picker of the effort levels with what each one costs in tokens; `Enter` applies the selected level and `Esc` closes without changing anything. With an argument it sets the level directly: `off`, `adaptive`, an effort level (`minimal` … `max`), or a token budget number. Config: `always_thinking`.
-- **`/fast`**: Anthropic fast mode (Opus only; ignored on other models). Config: `always_fast = true`.
+- **`/fast`**: faster responses on Anthropic Opus, and on eligible Codex models when you sign in with a ChatGPT subscription. OpenAI API keys and every other model ignore it. Config: `always_fast = true`.
 - **`/workflow`**: let `code_execution` call the `task` tool (and other workflow-only tools) from inside the Python sandbox. Config: `always_workflow = true`.
 - **Plan / build**: not a slash command. Press `Tab` in the input to toggle plan mode (plan-file writes only).
 - **`/reload`**: rebuild plugins and config without leaving the app.

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -64,7 +64,7 @@ All fields are optional. Typos in field names cause an error right away.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `always_yolo` | bool | `false` | Start every session with YOLO mode (skip permission prompts, deny rules still apply) |
-| `always_fast` | bool | `false` | Start every session with Anthropic fast mode (Opus only; ignored otherwise) |
+| `always_fast` | bool | `false` | Start every session with fast mode (Anthropic Opus or eligible Codex subscription models, ignored elsewhere) |
 | `always_workflow` | bool | `false` | Start every session with workflow mode (task callable inside code_execution) |
 | `always_thinking` | bool \| string | `false` | Start every session with extended thinking (true/"adaptive", "off", an effort level ("minimal" to "max"), or a token budget) |
 


### PR DESCRIPTION
## summary
- enable `/fast` for eligible codex subscription models using oauth
- check eligibility against the current account’s model catalog
- preserve saved fast preferences while discovery completes

separate from #839, which adds fast mode for api-key usage. this change supports subscription traffic and leaves api-key behavior unchanged.

## testing
- 2,427 tests passed across affected crates
- workspace clippy, formatting, and generated docs checks passed
- full workspace suite had one failure in an untouched permissions test