### PR TITLE
feat(providers): configurable retry limit for provider errors

### DIFF
--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -415,10 +415,7 @@ mod tests {
     }
 
     fn overflow_error() -> AgentError {
-        AgentError::Api {
-            status: OVERFLOW_STATUS,
-            message: OVERFLOW_MESSAGE.into(),
-        }
+        AgentError::api(OVERFLOW_STATUS, OVERFLOW_MESSAGE)
     }
 
     fn text_response(stop_reason: StopReason) -> StreamResponse {

--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -1,6 +1,7 @@
 use std::env;
 
 use maki_config::AgentConfig;
+use maki_providers::retry::RetryPolicy;
 use maki_providers::{
     ContentBlock, ContextGauge, IMAGE_PLACEHOLDER, Message, Model, RequestOptions, Role,
     StreamResponse, TokenUsage,
@@ -72,6 +73,7 @@ pub(super) async fn compact_history(
     instructions: Option<&str>,
     carry_len: usize,
     session_id: Option<&SessionRef>,
+    retry: RetryPolicy,
 ) -> Result<TokenUsage, AgentError> {
     let compact_start = std::time::Instant::now();
     let summarized = history.len().saturating_sub(carry_len);
@@ -97,6 +99,7 @@ pub(super) async fn compact_history(
                 opts: RequestOptions::default(),
                 output_budget: SUMMARY_OUTPUT_BUDGET,
                 session_id,
+                retry,
             },
             // A stripped, collapsed rewrite of the transcript, far smaller than
             // it. Sizing this request as the session would trim the
@@ -186,6 +189,7 @@ pub async fn compact(
     config: &AgentConfig,
     instructions: Option<&str>,
     session_id: Option<&SessionRef>,
+    retry: RetryPolicy,
 ) -> Result<(), AgentError> {
     let cancel = CancelToken::none();
     let size_before = gauge.size();
@@ -199,6 +203,7 @@ pub async fn compact(
         instructions,
         0,
         session_id,
+        retry,
     )
     .await?;
     if let Some(post) = normalize(config.post_compaction_instructions.as_deref()) {
@@ -449,6 +454,7 @@ mod tests {
             config,
             instructions,
             None,
+            RetryPolicy::default(),
         )
         .await
     }
@@ -470,6 +476,7 @@ mod tests {
             None,
             carry_len,
             session_id,
+            RetryPolicy::default(),
         )
         .await
         .unwrap();

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -810,10 +810,7 @@ mod tests {
                     trigger.cancel();
                 }
                 match self.fail_status {
-                    Some(status) => Err(AgentError::Api {
-                        status,
-                        message: "stub".into(),
-                    }),
+                    Some(status) => Err(AgentError::api(status, "stub")),
                     None => futures_lite::future::pending().await,
                 }
             })
@@ -1389,10 +1386,7 @@ mod tests {
                 match remaining.checked_sub(1) {
                     Some(rest) => {
                         *remaining = rest;
-                        Err(AgentError::Api {
-                            status: OVERFLOW_STATUS,
-                            message: OVERFLOW_MESSAGE.into(),
-                        })
+                        Err(AgentError::api(OVERFLOW_STATUS, OVERFLOW_MESSAGE))
                     }
                     None => Ok(text_response(StopReason::EndTurn)),
                 }

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -341,6 +341,7 @@ impl<'h> Agent<'h> {
                 opts: self.opts,
                 output_budget: self.config.max_turn_output,
                 session_id: self.session_id.as_ref(),
+                retry: self.timeouts.retry,
             },
             Some(self.gauge),
             &self.event_tx,
@@ -636,6 +637,7 @@ impl<'h> Agent<'h> {
             instructions,
             carry_len,
             self.session_id.as_ref(),
+            self.timeouts.retry,
         )
         .await?;
         // The summariser can be a different model, so price this with

--- a/maki-agent/src/agent/streaming.rs
+++ b/maki-agent/src/agent/streaming.rs
@@ -556,10 +556,7 @@ mod tests {
 
     #[test]
     fn a_reported_api_error_leaves_the_provider_body_behind() {
-        let error = AgentError::Api {
-            status: 400,
-            message: SECRET_BODY.into(),
-        };
+        let error = AgentError::api(400, SECRET_BODY);
         let reported = error_description(&error);
         assert!(!reported.contains("private"));
         assert_eq!(reported, "API error (400)");
@@ -591,14 +588,14 @@ mod tests {
                 let asked = model.output_tokens().unwrap_or(0);
                 self.requests.lock().unwrap().push(asked);
                 if prompt + asked > self.window {
-                    return Err(AgentError::Api {
-                        status: 400,
-                        message: format!(
+                    return Err(AgentError::api(
+                        400,
+                        format!(
                             "This model's maximum context length is {} tokens. However, you requested {} tokens ({prompt} in the messages, {asked} in the completion).",
                             self.window,
                             prompt + asked
                         ),
-                    });
+                    ));
                 }
                 Ok(StreamResponse {
                     message: Message::user("ok".into()),

--- a/maki-agent/src/agent/streaming.rs
+++ b/maki-agent/src/agent/streaming.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
 use maki_providers::provider::Provider;
-use maki_providers::retry::{MAX_TIMEOUT_RETRIES, RetryState};
+use maki_providers::retry::{RetryPolicy, RetryState};
 use maki_providers::{
     ContentBlock, ContextGauge, Message, Model, Overflow, ProviderEvent, RequestOptions,
     StreamResponse, estimate_prompt_tokens,
@@ -172,6 +172,7 @@ pub(crate) struct StreamRequest<'a> {
     /// than a coding turn, so the caller decides.
     pub output_budget: u32,
     pub session_id: Option<&'a SessionRef>,
+    pub retry: RetryPolicy,
 }
 
 /// `gauge` is `None` for a request whose messages are not the session's, as
@@ -192,6 +193,7 @@ pub(crate) async fn stream_with_retry(
         opts,
         output_budget,
         session_id,
+        retry,
     } = req;
     let opts = opts.clamped(model);
     // The session's own size wins where it is larger, being a count a provider
@@ -215,7 +217,7 @@ pub(crate) async fn stream_with_retry(
     )
     .await?;
     let messages = &*adapted;
-    let mut retry = RetryState::new();
+    let mut retry = RetryState::new(retry);
     loop {
         // The turn budget is all that moves. What the model declares stays put:
         // the thinking a request may spend is read off the `max_tokens` this
@@ -249,17 +251,51 @@ pub(crate) async fn stream_with_retry(
                 return Ok(r);
             }
             Err(AgentError::Cancelled) => return Err(StreamError::Cancelled { streamed }),
-            Err(e) if e.is_retryable() => {
+            Err(e) => {
                 emit_api_error(model, &e, retry.attempts() + 1, started.elapsed());
+                let Some(kind) = e.retry_kind() else {
+                    // A budget overflow is the one rejection maki caused itself, by
+                    // asking for more output than the prompt left room for. Asking
+                    // for less costs nothing, so it happens here instead of falling
+                    // through to the caller, whose only remedy is to summarize the
+                    // session away.
+                    if let Some(
+                        overflow @ Overflow::Budget {
+                            prompt: measured, ..
+                        },
+                    ) = e.overflow()
+                    {
+                        // The server counted the prompt maki could only estimate.
+                        if let Some(gauge) = gauge.as_deref_mut() {
+                            gauge.record(measured.unwrap_or(0));
+                        }
+                        if budget_retries < MAX_BUDGET_RETRIES
+                            && let Some(next) =
+                                shrunk_budget(budget, overflow, model.context_window, floor)
+                        {
+                            budget_retries += 1;
+                            warn!(
+                                model = %model.id,
+                                from = budget,
+                                to = next,
+                                measured_prompt = measured,
+                                "output budget did not fit the window, retrying smaller"
+                            );
+                            budget = next;
+                            continue;
+                        }
+                    }
+                    return Err(e.into());
+                };
                 if e.should_rotate_key()
                     && let Ok(true) = provider.rotate_key().await
                 {
                     warn!("rotated API key after error: {e}");
                 }
-                let (attempt, delay) = retry.next_delay();
-                if matches!(e, AgentError::Timeout { .. }) && attempt > MAX_TIMEOUT_RETRIES {
+                let Some(delay) = retry.next_delay(kind, e.retry_after()) else {
                     return Err(e.into());
-                }
+                };
+                let attempt = retry.attempts();
                 let delay_ms = delay.as_millis() as u64;
                 warn!(attempt, delay_ms, error = %e, "retryable, will retry");
                 event_tx.send(AgentEvent::Retry {
@@ -279,41 +315,6 @@ pub(crate) async fn stream_with_retry(
                         streamed: String::new(),
                     });
                 }
-            }
-            Err(e) => {
-                emit_api_error(model, &e, retry.attempts() + 1, started.elapsed());
-                // A budget overflow is the one rejection maki caused itself, by
-                // asking for more output than the prompt left room for. Asking
-                // for less costs nothing, so it happens here instead of falling
-                // through to the caller, whose only remedy is to summarize the
-                // session away.
-                if let Some(
-                    overflow @ Overflow::Budget {
-                        prompt: measured, ..
-                    },
-                ) = e.overflow()
-                {
-                    // The server counted the prompt maki could only estimate.
-                    if let Some(gauge) = gauge.as_deref_mut() {
-                        gauge.record(measured.unwrap_or(0));
-                    }
-                    if budget_retries < MAX_BUDGET_RETRIES
-                        && let Some(next) =
-                            shrunk_budget(budget, overflow, model.context_window, floor)
-                    {
-                        budget_retries += 1;
-                        warn!(
-                            model = %model.id,
-                            from = budget,
-                            to = next,
-                            measured_prompt = measured,
-                            "output budget did not fit the window, retrying smaller"
-                        );
-                        budget = next;
-                        continue;
-                    }
-                }
-                return Err(e.into());
             }
         }
     }
@@ -651,6 +652,7 @@ mod tests {
                 opts: RequestOptions::default(),
                 output_budget: TURN_BUDGET,
                 session_id: None,
+                retry: RetryPolicy::default(),
             },
             Some(gauge),
             &EventSender::new(tx, 0),

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -50,6 +50,17 @@ pub const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 10;
 pub const DEFAULT_LOW_SPEED_TIMEOUT_SECS: u64 = 120;
 pub const DEFAULT_STREAM_TIMEOUT_SECS: u64 = 300;
 
+pub const DEFAULT_RETRY_BASE_MS: u64 = 2_000;
+/// Server errors are retried for as long as they last, so this cap sets the
+/// pace of a long outage: a minute between tries is around 180 requests over
+/// three hours, where the old eight seconds would have sent around 1350.
+pub const DEFAULT_RETRY_MAX_MS: u64 = 60_000;
+pub const DEFAULT_MAX_TIMEOUT_RETRIES: u32 = 10;
+/// Spent only on rate limits the server sent no `Retry-After` for, which is how
+/// a spend cap reads, and that one does not clear for the rest of the billing
+/// period.
+pub const DEFAULT_MAX_RETRIES: u32 = 5;
+
 pub const DEFAULT_MAX_LOG_BYTES_MB: u64 = 200;
 pub const DEFAULT_MAX_LOG_FILES: u32 = 10;
 pub const DEFAULT_INPUT_HISTORY_SIZE: usize = 100;
@@ -70,6 +81,9 @@ pub const MIN_INPUT_HISTORY_SIZE: usize = 10;
 pub const MIN_CONNECT_TIMEOUT_SECS: u64 = 1;
 pub const MIN_LOW_SPEED_TIMEOUT_SECS: u64 = 1;
 pub const MIN_STREAM_TIMEOUT_SECS: u64 = 10;
+
+pub const MIN_RETRY_BASE_MS: u64 = 1;
+pub const MIN_RETRY_MAX_MS: u64 = 1;
 
 pub const DEFAULT_BUILTINS: &[&str] = &[
     "bash",
@@ -686,6 +700,10 @@ pub struct ProviderFileConfig {
     pub connect_timeout_secs: Option<u64>,
     pub low_speed_timeout_secs: Option<u64>,
     pub stream_timeout_secs: Option<u64>,
+    pub retry_base_ms: Option<u64>,
+    pub retry_max_ms: Option<u64>,
+    pub max_retries: Option<u32>,
+    pub max_timeout_retries: Option<u32>,
 }
 
 impl ProviderFileConfig {
@@ -698,7 +716,11 @@ impl ProviderFileConfig {
             excluded_models,
             connect_timeout_secs,
             low_speed_timeout_secs,
-            stream_timeout_secs
+            stream_timeout_secs,
+            retry_base_ms,
+            retry_max_ms,
+            max_retries,
+            max_timeout_retries
         );
     }
 }
@@ -1371,6 +1393,24 @@ pub struct ProviderConfig {
              min = MIN_STREAM_TIMEOUT_SECS, val = "self.stream_timeout.as_secs()",
              desc = "Streaming response timeout (seconds)")]
     pub stream_timeout: Duration,
+
+    #[config(key = "retry_base_ms", ty = "u64", default = DEFAULT_RETRY_BASE_MS,
+             min = MIN_RETRY_BASE_MS,
+             desc = "Base delay between retries (milliseconds, grows per attempt)")]
+    pub retry_base_ms: u64,
+
+    #[config(key = "retry_max_ms", ty = "u64", default = DEFAULT_RETRY_MAX_MS,
+             min = MIN_RETRY_MAX_MS,
+             desc = "Cap on the guessed retry backoff (milliseconds)")]
+    pub retry_max_ms: u64,
+
+    #[config(key = "max_retries", ty = "u32", default = DEFAULT_MAX_RETRIES,
+             desc = "Max retries on a rate limit the server sent no Retry-After for, 0 to never retry them")]
+    pub max_retries: u32,
+
+    #[config(key = "max_timeout_retries", ty = "u32", default = DEFAULT_MAX_TIMEOUT_RETRIES,
+             desc = "Max retries on stream timeouts")]
+    pub max_timeout_retries: u32,
 }
 
 impl Default for ProviderConfig {
@@ -1383,6 +1423,10 @@ impl Default for ProviderConfig {
             connect_timeout: Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS),
             low_speed_timeout: Duration::from_secs(DEFAULT_LOW_SPEED_TIMEOUT_SECS),
             stream_timeout: Duration::from_secs(DEFAULT_STREAM_TIMEOUT_SECS),
+            retry_base_ms: DEFAULT_RETRY_BASE_MS,
+            retry_max_ms: DEFAULT_RETRY_MAX_MS,
+            max_retries: DEFAULT_MAX_RETRIES,
+            max_timeout_retries: DEFAULT_MAX_TIMEOUT_RETRIES,
         }
     }
 }
@@ -1408,6 +1452,10 @@ impl ProviderConfig {
             stream_timeout: Duration::from_secs(
                 f.stream_timeout_secs.unwrap_or(DEFAULT_STREAM_TIMEOUT_SECS),
             ),
+            retry_base_ms: f.retry_base_ms.unwrap_or(DEFAULT_RETRY_BASE_MS),
+            retry_max_ms: f.retry_max_ms.unwrap_or(DEFAULT_RETRY_MAX_MS),
+            max_retries: f.max_retries.unwrap_or(DEFAULT_MAX_RETRIES),
+            max_timeout_retries: f.max_timeout_retries.unwrap_or(DEFAULT_MAX_TIMEOUT_RETRIES),
         })
     }
 }
@@ -2762,6 +2810,32 @@ mod tests {
         assert_eq!(provider.excluded_models, ["*/*-preview"]);
         assert!(provider.model_policy.allows("openai/gpt-5"));
         assert!(!provider.model_policy.allows("openai/gpt-5-preview"));
+    }
+
+    /// `ProviderConfig::default()` is written by hand while a config file goes
+    /// through `into_config`, and the two once disagreed on what an omitted
+    /// `max_retries` meant: five on one path, retry forever on the other.
+    #[test]
+    fn an_omitted_max_retries_is_bounded_on_every_path() {
+        let from_file = RawConfig::default().into_config(&[]).unwrap().provider;
+        assert_eq!(from_file.max_retries, DEFAULT_MAX_RETRIES);
+        assert_eq!(from_file.max_retries, ProviderConfig::default().max_retries);
+    }
+
+    #[test]
+    fn retry_knobs_read_what_the_file_asked_for() {
+        let config = RawConfig {
+            provider: ProviderFileConfig {
+                max_retries: Some(3),
+                retry_base_ms: Some(50),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+        .into_config(&[])
+        .unwrap();
+        assert_eq!(config.provider.max_retries, 3);
+        assert_eq!(config.provider.retry_base_ms, 50);
     }
 
     #[test]

--- a/maki-providers/src/error.rs
+++ b/maki-providers/src/error.rs
@@ -2,6 +2,8 @@
 //! Retryable: 429, 5xx, IO, HTTP transport. Non-retryable: other 4xx, JSON parse, config,
 //! channel closed, user cancel. `user_message()` returns human-readable text for each variant.
 
+use std::time::Duration;
+
 use isahc::AsyncReadResponseExt;
 
 use crate::providers::opencode::{self, NonLoginError};
@@ -85,7 +87,12 @@ fn budget_overflow(m: &str) -> Option<Overflow> {
 #[derive(Debug, thiserror::Error)]
 pub enum AgentError {
     #[error("API error ({status}): {message}")]
-    Api { status: u16, message: String },
+    Api {
+        status: u16,
+        message: String,
+        /// What the server's `Retry-After` header asked for, when it sent one.
+        retry_after: Option<Duration>,
+    },
     #[error("{message}")]
     Config { message: String },
     #[error("tool error in {tool}: {message}")]
@@ -109,6 +116,16 @@ pub enum AgentError {
 }
 
 impl AgentError {
+    /// An API error with no `Retry-After` behind it. Everything that is not a
+    /// response we read the headers of lands here, SSE error frames included.
+    pub fn api(status: u16, message: impl Into<String>) -> Self {
+        Self::Api {
+            status,
+            message: message.into(),
+            retry_after: None,
+        }
+    }
+
     pub fn is_retryable(&self) -> bool {
         if self.is_context_overflow() || self.is_quota_exhausted() {
             return false;
@@ -149,7 +166,10 @@ impl AgentError {
     /// - OpenRouter: 400 "endpoint's maximum context length is X tokens"  <https://openrouter.ai/docs/api/reference/errors-and-debugging.mdx>
     /// - Synthetic:  400 pass-through from upstream models (OpenAI-compatible)  <https://synthetic.new>
     pub fn overflow(&self) -> Option<Overflow> {
-        let Self::Api { status, message } = self else {
+        let Self::Api {
+            status, message, ..
+        } = self
+        else {
             return None;
         };
         if !matches!(status, 400 | 413) {
@@ -193,7 +213,10 @@ impl AgentError {
     /// OpenCode serves billing and plan failures on the statuses we otherwise
     /// read as a stale token, and only that provider knows its error types.
     fn non_login_error(&self) -> Option<NonLoginError> {
-        let Self::Api { status, message } = self else {
+        let Self::Api {
+            status, message, ..
+        } = self
+        else {
             return None;
         };
         opencode::non_login_error(*status, message)
@@ -223,7 +246,9 @@ impl AgentError {
             Self::Api { status: 401, .. } => {
                 "authentication failed, run `maki auth login` or check your API key".into()
             }
-            Self::Api { status, message } => format!("API error ({status}): {message}"),
+            Self::Api {
+                status, message, ..
+            } => format!("API error ({status}): {message}"),
             Self::Tool { tool, message } => format!("{tool}: {message}"),
             Self::Io(e) => format!("I/O error: {e}"),
             Self::Http(_) => "connection error, check your network".into(),
@@ -238,11 +263,31 @@ impl AgentError {
 
     pub async fn from_response(mut response: isahc::Response<isahc::AsyncBody>) -> Self {
         let status = response.status().as_u16();
+        let retry_after = response
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(parse_retry_after);
         let message = response
             .text()
             .await
             .unwrap_or_else(|_| "unable to read error body".into());
-        Self::Api { status, message }
+        Self::Api {
+            status,
+            message,
+            retry_after,
+        }
+    }
+
+    /// How long the server asked us to wait, when it bothered to say. Always a
+    /// positive duration: only [`Self::from_response`] ever reads headers, and
+    /// an error built any other way answers `None` and the caller falls back on
+    /// its own backoff.
+    pub fn retry_after(&self) -> Option<Duration> {
+        match self {
+            Self::Api { retry_after, .. } => *retry_after,
+            _ => None,
+        }
     }
 
     pub fn retry_message(&self) -> String {
@@ -271,11 +316,21 @@ impl From<maki_storage::StorageError> for AgentError {
         match e {
             maki_storage::StorageError::Io(io) => Self::Io(io),
             maki_storage::StorageError::Json(j) => Self::Json(j),
-            other => Self::Api {
-                status: 0,
-                message: other.to_string(),
-            },
+            other => Self::api(0, other.to_string()),
         }
+    }
+}
+
+/// Only the delta-seconds form ("30", "60"). The HTTP-date form is legal but
+/// providers do not send it, and guessing a backoff beats parsing dates.
+///
+/// `0` is not a hint. Anthropic's own usage endpoint answers a persistent 429
+/// with `Retry-After: 0`, and sleeping for zero seconds before asking the same
+/// rate limiter again is a tight loop, not a backoff.
+fn parse_retry_after(value: &str) -> Option<Duration> {
+    match value.trim().parse::<u64>() {
+        Ok(secs) if secs > 0 => Some(Duration::from_secs(secs)),
+        _ => None,
     }
 }
 
@@ -292,17 +347,11 @@ mod tests {
     const RATE_LIMITED_RETRY_MESSAGE: &str = "Rate limited";
 
     fn api(status: u16) -> AgentError {
-        AgentError::Api {
-            status,
-            message: String::new(),
-        }
+        AgentError::api(status, "")
     }
 
     fn api_msg(status: u16, message: &str) -> AgentError {
-        AgentError::Api {
-            status,
-            message: message.into(),
-        }
+        AgentError::api(status, message)
     }
 
     fn opencode_body(error_type: &str, message: &str) -> String {
@@ -401,16 +450,24 @@ mod tests {
     #[test_case(401, "authentication failed, run `maki auth login` or check your API key" ; "user_msg_401")]
     #[test_case(400, "API error (400): bad input"                                         ; "user_msg_400")]
     fn user_message_api(status: u16, expected: &str) {
-        let err = AgentError::Api {
-            status,
-            message: "bad input".into(),
-        };
+        let err = AgentError::api(status, "bad input");
         assert_eq!(err.user_message(), expected);
     }
 
     #[test]
     fn timeout_is_retryable() {
         assert!(AgentError::Timeout { secs: 30 }.is_retryable());
+    }
+
+    #[test_case("30", Some(Duration::from_secs(30)) ; "delta_seconds")]
+    #[test_case(" 5 ", Some(Duration::from_secs(5))  ; "whitespace")]
+    #[test_case("Wed, 21 Oct 2015 07:28:00 GMT", None ; "http_date")]
+    #[test_case("", None                             ; "empty")]
+    #[test_case("-3", None                           ; "negative")]
+    // A zero would be slept on and come straight back with the same 429.
+    #[test_case("0", None                            ; "zero")]
+    fn retry_after_header_is_read_as_seconds(value: &str, expected: Option<Duration>) {
+        assert_eq!(parse_retry_after(value), expected);
     }
 
     // llama.cpp: https://github.com/ggml-org/llama.cpp/blob/master/tools/server/server-context.cpp

--- a/maki-providers/src/error.rs
+++ b/maki-providers/src/error.rs
@@ -1,12 +1,18 @@
 //! Provider error types with retry semantics.
 //! Retryable: 429, 5xx, IO, HTTP transport. Non-retryable: other 4xx, JSON parse, config,
-//! channel closed, user cancel. `user_message()` returns human-readable text for each variant.
+//! channel closed, user cancel. `retry_kind()` says which budget a retry draws
+//! from, so a connection that was never made can stop while a connection that
+//! dropped is waited out. `user_message()` returns human-readable text for each
+//! variant.
 
-use std::time::Duration;
+use std::{io, time::Duration};
 
-use isahc::AsyncReadResponseExt;
+use isahc::{AsyncReadResponseExt, error::ErrorKind as HttpErrorKind};
 
-use crate::providers::opencode::{self, NonLoginError};
+use crate::{
+    providers::opencode::{self, NonLoginError},
+    retry::RetryKind,
+};
 
 /// Request fields that cap the *output*. A 400 naming one of them is about the
 /// cap we sent, never about the prompt being too big.
@@ -16,6 +22,9 @@ const OUTPUT_CAP_FIELDS: [&str; 3] = ["max_tokens", "max_completion_tokens", "ma
 const MESSAGES_HALF: &str = " in the messages";
 const COMPLETION_HALF: &str = " in the completion";
 const OPENAI_LIMIT: &str = "maximum context length is ";
+const CONNECT_FAILED_MESSAGE: &str =
+    "could not connect, check the server is running and the base URL is correct";
+const NETWORK_ERROR_MESSAGE: &str = "connection error, check your network";
 
 /// Why a provider refused a request for size.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -126,21 +135,33 @@ impl AgentError {
         }
     }
 
-    pub fn is_retryable(&self) -> bool {
+    /// Which budget trying again would draw from, or `None` when trying again
+    /// is pointless. The kinds are priced differently, so the retry loop needs
+    /// more than a yes or no.
+    pub fn retry_kind(&self) -> Option<RetryKind> {
         if self.is_context_overflow() || self.is_quota_exhausted() {
-            return false;
+            return None;
         }
         match self {
-            Self::Api { status, .. } => *status == 429 || *status >= 500,
-            Self::Io(_) | Self::Http(_) | Self::Timeout { .. } => true,
-            Self::Config { .. }
+            Self::Api { status: 429, .. } => Some(RetryKind::RateLimit),
+            Self::Api { status, .. } if *status >= 500 => Some(RetryKind::Transient),
+            Self::Http(e) if is_connect_failure(e) => Some(RetryKind::Connect),
+            Self::Io(e) if e.kind() == io::ErrorKind::ConnectionRefused => Some(RetryKind::Connect),
+            Self::Io(_) | Self::Http(_) => Some(RetryKind::Transient),
+            Self::Timeout { .. } => Some(RetryKind::Timeout),
+            Self::Api { .. }
+            | Self::Config { .. }
             | Self::Tool { .. }
             | Self::Channel
             | Self::Json(_)
             | Self::Cancelled
             | Self::EmptySummary
-            | Self::HttpRequest(_) => false,
+            | Self::HttpRequest(_) => None,
         }
+    }
+
+    pub fn is_retryable(&self) -> bool {
+        self.retry_kind().is_some()
     }
 
     /// Refused for size, either cause.
@@ -250,8 +271,12 @@ impl AgentError {
                 status, message, ..
             } => format!("API error ({status}): {message}"),
             Self::Tool { tool, message } => format!("{tool}: {message}"),
+            Self::Io(e) if e.kind() == io::ErrorKind::ConnectionRefused => {
+                CONNECT_FAILED_MESSAGE.into()
+            }
             Self::Io(e) => format!("I/O error: {e}"),
-            Self::Http(_) => "connection error, check your network".into(),
+            Self::Http(e) if is_connect_failure(e) => CONNECT_FAILED_MESSAGE.into(),
+            Self::Http(_) => NETWORK_ERROR_MESSAGE.into(),
             Self::Timeout { .. } => "stream timed out, retrying".into(),
             Self::HttpRequest(e) => format!("request error: {e}"),
             Self::Json(_) => "received an invalid response from the API".into(),
@@ -321,6 +346,17 @@ impl From<maki_storage::StorageError> for AgentError {
     }
 }
 
+/// Nothing answered at the other end, either because no socket is listening or
+/// because the host name does not resolve. isahc folds a refused connection and
+/// a dead provider edge into the same `ConnectionFailed`, and telling them
+/// apart is not possible from here.
+fn is_connect_failure(e: &isahc::Error) -> bool {
+    matches!(
+        e.kind(),
+        HttpErrorKind::ConnectionFailed | HttpErrorKind::NameResolution
+    )
+}
+
 /// Only the delta-seconds form ("30", "60"). The HTTP-date form is legal but
 /// providers do not send it, and guessing a backoff beats parsing dates.
 ///
@@ -336,15 +372,22 @@ fn parse_retry_after(value: &str) -> Option<Duration> {
 
 #[cfg(test)]
 mod tests {
+    use maki_config::DEFAULT_MAX_RETRIES;
     use serde_json::{Value, json};
     use test_case::test_case;
 
     use super::*;
-    use crate::providers::opencode::{NON_LOGIN_FALLBACK_MESSAGE, QUOTA_FALLBACK_MESSAGE};
+    use crate::{
+        providers::opencode::{NON_LOGIN_FALLBACK_MESSAGE, QUOTA_FALLBACK_MESSAGE},
+        retry::{RetryPolicy, RetryState},
+    };
 
     const QUOTA_MESSAGE: &str = "Weekly usage limit reached. Resets in 3 hours.";
     const MODEL_MESSAGE: &str = "Your trial has ended.";
     const RATE_LIMITED_RETRY_MESSAGE: &str = "Rate limited";
+    /// More rounds than any bounded budget allows, so a budget that survives
+    /// all of them is the unbounded one.
+    const ROUNDS: u32 = DEFAULT_MAX_RETRIES * 2;
 
     fn api(status: u16) -> AgentError {
         AgentError::api(status, "")
@@ -454,9 +497,53 @@ mod tests {
         assert_eq!(err.user_message(), expected);
     }
 
+    #[test_case(429, RetryKind::RateLimit ; "rate_limit")]
+    #[test_case(500, RetryKind::Transient  ; "server_error")]
+    #[test_case(529, RetryKind::Transient  ; "overloaded")]
+    fn api_retry_kind(status: u16, expected: RetryKind) {
+        assert_eq!(api(status).retry_kind(), Some(expected));
+    }
+
     #[test]
-    fn timeout_is_retryable() {
-        assert!(AgentError::Timeout { secs: 30 }.is_retryable());
+    fn a_timeout_is_its_own_kind() {
+        assert_eq!(
+            AgentError::Timeout { secs: 30 }.retry_kind(),
+            Some(RetryKind::Timeout)
+        );
+    }
+
+    /// Retries this error is granted before the loop has to give up, stopping
+    /// at `ROUNDS` for a budget with no ceiling.
+    fn retries_granted(error: &AgentError) -> u32 {
+        let kind = error.retry_kind().expect("a transport failure retries");
+        let mut state = RetryState::new(RetryPolicy::default());
+        (0..ROUNDS)
+            .take_while(|_| state.next_delay(kind, error.retry_after()).is_some())
+            .count() as u32
+    }
+
+    /// A dead provider edge and a local server nobody started both land in
+    /// `ConnectionFailed`, so the run has to give up on it, while a failure on
+    /// a connection that was made is the network being the network and is
+    /// waited out.
+    #[test_case(HttpErrorKind::ConnectionFailed, DEFAULT_MAX_RETRIES ; "a_refused_connection_gives_up")]
+    #[test_case(HttpErrorKind::NameResolution, DEFAULT_MAX_RETRIES   ; "an_unresolvable_host_gives_up")]
+    #[test_case(HttpErrorKind::Io, ROUNDS                            ; "a_read_error_keeps_retrying")]
+    #[test_case(HttpErrorKind::TlsEngine, ROUNDS                     ; "a_tls_failure_keeps_retrying")]
+    fn a_transport_failure_is_waited_out_only_once_connected(kind: HttpErrorKind, expected: u32) {
+        assert_eq!(retries_granted(&AgentError::Http(kind.into())), expected);
+    }
+
+    #[test_case(io::ErrorKind::ConnectionRefused, DEFAULT_MAX_RETRIES ; "a_refused_socket_gives_up")]
+    #[test_case(io::ErrorKind::UnexpectedEof, ROUNDS                  ; "a_truncated_read_keeps_retrying")]
+    fn an_io_failure_gives_up_when_nothing_is_listening(kind: io::ErrorKind, expected: u32) {
+        assert_eq!(retries_granted(&AgentError::Io(kind.into())), expected);
+    }
+
+    #[test_case(HttpErrorKind::ConnectionFailed, CONNECT_FAILED_MESSAGE ; "connect_failure_names_the_server")]
+    #[test_case(HttpErrorKind::TlsEngine, NETWORK_ERROR_MESSAGE         ; "other_transport_blames_the_network")]
+    fn user_message_transport(kind: HttpErrorKind, expected: &str) {
+        assert_eq!(AgentError::Http(kind.into()).user_message(), expected);
     }
 
     #[test_case("30", Some(Duration::from_secs(30)) ; "delta_seconds")]

--- a/maki-providers/src/providers/anthropic/bedrock.rs
+++ b/maki-providers/src/providers/anthropic/bedrock.rs
@@ -466,7 +466,7 @@ fn decode_eventstream_frame(buf: &[u8]) -> Result<(usize, Option<Vec<u8>>), Agen
             "ValidationException" => 400,
             _ => 500,
         };
-        return Err(AgentError::Api { status, message });
+        return Err(AgentError::api(status, message));
     }
 
     let payload = if event_type.as_deref() == Some("chunk") && !payload_bytes.is_empty() {
@@ -876,7 +876,9 @@ mod tests {
         let frame = build_eventstream_frame(":exception-type", exc_type, msg.as_bytes());
         let err = decode_eventstream_frame(&frame).unwrap_err();
         match err {
-            AgentError::Api { status, message } => {
+            AgentError::Api {
+                status, message, ..
+            } => {
                 assert_eq!(status, expected_status);
                 assert_eq!(message, msg);
             }

--- a/maki-providers/src/providers/anthropic/mod.rs
+++ b/maki-providers/src/providers/anthropic/mod.rs
@@ -1029,7 +1029,9 @@ data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":5}}\n";
                 .await
                 .unwrap_err();
             match err {
-                AgentError::Api { status, message } => {
+                AgentError::Api {
+                    status, message, ..
+                } => {
                     assert_eq!(status, 529);
                     assert_eq!(message, "Overloaded");
                 }
@@ -1047,7 +1049,9 @@ data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":5}}\n";
                 .await
                 .unwrap_err();
             match err {
-                AgentError::Api { status, message } => {
+                AgentError::Api {
+                    status, message, ..
+                } => {
                     assert_eq!(status, 400);
                     assert_eq!(message, "not-json");
                 }

--- a/maki-providers/src/providers/anthropic/shared.rs
+++ b/maki-providers/src/providers/anthropic/shared.rs
@@ -379,10 +379,7 @@ impl EventParser {
                     return Err(ev.into_agent_error());
                 }
                 warn!(raw = %data, "unparseable SSE error event");
-                return Err(AgentError::Api {
-                    status: 400,
-                    message: data.to_string(),
-                });
+                return Err(AgentError::api(400, data.to_string()));
             }
             "message_stop" => return Ok(ControlFlow::Break(())),
             _ => {}

--- a/maki-providers/src/providers/catalog.rs
+++ b/maki-providers/src/providers/catalog.rs
@@ -581,10 +581,10 @@ async fn fetch_remote_catalog_async(
     if status != 200 {
         // Drain the body so isahc can reuse the connection
         let _ = resp.text().await;
-        return Err(AgentError::Api {
+        return Err(AgentError::api(
             status,
-            message: format!("catalog fetch returned HTTP {status}"),
-        });
+            format!("catalog fetch returned HTTP {status}"),
+        ));
     }
 
     let text = resp

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -701,8 +701,7 @@ mod tests {
     fn test_timeouts() -> super::super::Timeouts {
         super::super::Timeouts {
             connect: Duration::from_secs(5),
-            low_speed: Duration::from_secs(30),
-            stream: Duration::from_secs(300),
+            ..Default::default()
         }
     }
 

--- a/maki-providers/src/providers/local.rs
+++ b/maki-providers/src/providers/local.rs
@@ -567,17 +567,12 @@ pub(crate) const LLAMACPP: LocalEndpointConfig = LocalEndpointConfig {
 
 #[cfg(test)]
 mod tests {
+    use super::super::Timeouts;
     use super::*;
-
-    const TEST_TIMEOUTS: super::super::Timeouts = super::super::Timeouts {
-        connect: std::time::Duration::from_secs(10),
-        low_speed: std::time::Duration::from_secs(30),
-        stream: std::time::Duration::from_secs(300),
-    };
 
     #[test]
     fn from_env_without_host_or_api_key_errors() {
-        match LocalEndpoint::build(&OLLAMA, TEST_TIMEOUTS, None, None, None) {
+        match LocalEndpoint::build(&OLLAMA, Timeouts::default(), None, None, None) {
             Err(AgentError::Config { message }) => {
                 assert_eq!(message, "OLLAMA_HOST not set");
             }
@@ -589,7 +584,7 @@ mod tests {
     fn from_env_with_host_builds_auth() {
         let ep = LocalEndpoint::build(
             &OLLAMA,
-            TEST_TIMEOUTS,
+            Timeouts::default(),
             None,
             Some("http://x:1234".into()),
             None,
@@ -603,7 +598,8 @@ mod tests {
     #[test]
     fn from_env_with_api_key_uses_cloud_for_ollama() {
         let pool = KeyPool::from_keys(vec!["test-key".into()]);
-        let ep = LocalEndpoint::build(&OLLAMA, TEST_TIMEOUTS, Some(pool), None, None).unwrap();
+        let ep =
+            LocalEndpoint::build(&OLLAMA, Timeouts::default(), Some(pool), None, None).unwrap();
         let auth = ep.auth.lock().unwrap();
         assert_eq!(auth.base_url.as_deref(), Some("https://ollama.com/v1"));
         assert_eq!(auth.headers.len(), 1);
@@ -615,7 +611,7 @@ mod tests {
         let pool = KeyPool::from_keys(vec!["test-key".into()]);
         let ep = LocalEndpoint::build(
             &OLLAMA,
-            TEST_TIMEOUTS,
+            Timeouts::default(),
             Some(pool),
             Some("http://local:1234".into()),
             None,
@@ -629,7 +625,7 @@ mod tests {
 
     #[test]
     fn llamacpp_without_host_errors() {
-        match LocalEndpoint::build(&LLAMACPP, TEST_TIMEOUTS, None, None, None) {
+        match LocalEndpoint::build(&LLAMACPP, Timeouts::default(), None, None, None) {
             Err(AgentError::Config { message }) => {
                 assert_eq!(message, "LLAMA_CPP_HOST not set");
             }
@@ -641,7 +637,7 @@ mod tests {
     fn llamacpp_with_host_builds_auth() {
         let ep = LocalEndpoint::build(
             &LLAMACPP,
-            TEST_TIMEOUTS,
+            Timeouts::default(),
             None,
             Some("http://x:1234".into()),
             None,
@@ -655,7 +651,7 @@ mod tests {
     #[test]
     fn llamacpp_no_cloud_fallback() {
         let pool = KeyPool::from_keys(vec!["key".into()]);
-        match LocalEndpoint::build(&LLAMACPP, TEST_TIMEOUTS, Some(pool), None, None) {
+        match LocalEndpoint::build(&LLAMACPP, Timeouts::default(), Some(pool), None, None) {
             Err(AgentError::Config { message }) => {
                 assert_eq!(message, "LLAMA_CPP_HOST not set");
             }
@@ -667,7 +663,7 @@ mod tests {
     fn ollama_uses_ollama_discovery() {
         let ep = LocalEndpoint::build(
             &OLLAMA,
-            TEST_TIMEOUTS,
+            Timeouts::default(),
             None,
             Some("http://x:1234".into()),
             None,
@@ -680,7 +676,7 @@ mod tests {
     fn llamacpp_uses_llamacpp_discovery() {
         let ep = LocalEndpoint::build(
             &LLAMACPP,
-            TEST_TIMEOUTS,
+            Timeouts::default(),
             None,
             Some("http://x:1234".into()),
             None,

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -15,6 +15,7 @@ use maki_storage::StateDir;
 use maki_storage::auth::{OAuthTokens, load_tokens, lock_tokens, save_tokens};
 
 use crate::AgentError;
+use crate::retry::RetryPolicy;
 
 pub(crate) mod anthropic;
 pub(crate) mod aperture;
@@ -64,6 +65,7 @@ pub struct Timeouts {
     pub connect: Duration,
     pub stream: Duration,
     pub low_speed: Duration,
+    pub retry: RetryPolicy,
 }
 
 impl Default for Timeouts {
@@ -72,6 +74,18 @@ impl Default for Timeouts {
             connect: Duration::from_secs(10),
             stream: Duration::from_secs(300),
             low_speed: Duration::from_secs(30),
+            retry: RetryPolicy::default(),
+        }
+    }
+}
+
+impl From<&maki_config::ProviderConfig> for Timeouts {
+    fn from(config: &maki_config::ProviderConfig) -> Self {
+        Self {
+            connect: config.connect_timeout,
+            stream: config.stream_timeout,
+            low_speed: config.low_speed_timeout,
+            retry: config.into(),
         }
     }
 }

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -94,9 +94,11 @@ pub(crate) fn refreshed_tokens(
     refresh: impl FnOnce(&OAuthTokens) -> Result<OAuthTokens, AgentError>,
 ) -> Result<OAuthTokens, AgentError> {
     let _lock = lock_tokens(dir, provider);
-    let current = load_tokens(dir, provider).ok_or_else(|| AgentError::Api {
-        status: UNAUTHORIZED_STATUS,
-        message: format!("{provider} OAuth tokens not found on disk"),
+    let current = load_tokens(dir, provider).ok_or_else(|| {
+        AgentError::api(
+            UNAUTHORIZED_STATUS,
+            format!("{provider} OAuth tokens not found on disk"),
+        )
     })?;
     if rejected.is_none_or(|stale| current.access != stale) && !current.is_expired() {
         return Ok(current);
@@ -322,10 +324,7 @@ impl SseErrorPayload {
                     .and_then(|m| sse_error_status(&m.error_type))
             })
             .unwrap_or(UNMAPPED_SSE_ERROR_STATUS);
-        AgentError::Api {
-            status,
-            message: self.error.message,
-        }
+        AgentError::api(status, self.error.message)
     }
 }
 

--- a/maki-providers/src/providers/openai/responses.rs
+++ b/maki-providers/src/providers/openai/responses.rs
@@ -245,10 +245,7 @@ pub(crate) async fn parse_sse(
                 .as_str()
                 .unwrap_or("unknown error")
                 .to_string();
-            return Err(AgentError::Api {
-                status: 500,
-                message,
-            });
+            return Err(AgentError::api(500, message));
         }
 
         let parsed_event = if current_event.is_empty() {
@@ -489,7 +486,7 @@ pub(crate) async fn parse_sse(
                     .as_str()
                     .and_then(sse_error_status)
                     .unwrap_or(FAILED_RESPONSE_STATUS);
-                return Err(AgentError::Api { status, message });
+                return Err(AgentError::api(status, message));
             }
 
             _ => {}

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -1096,7 +1096,9 @@ data: {\"error\":{\"message\":\"Server overloaded\",\"type\":\"overloaded_error\
                 .unwrap_err();
 
             match err {
-                AgentError::Api { status, message } => {
+                AgentError::Api {
+                    status, message, ..
+                } => {
                     assert_eq!(status, 529);
                     assert_eq!(message, "Server overloaded");
                 }

--- a/maki-providers/src/providers/xai/catalog.rs
+++ b/maki-providers/src/providers/xai/catalog.rs
@@ -137,10 +137,7 @@ fn select_models(access: Option<&str>, force: bool) -> Result<Vec<CachedModel>, 
             save_cache(&models, now);
             Ok(models)
         }
-        FetchOutcome::Auth => Err(AgentError::Api {
-            status: 401,
-            message: CATALOG_UNAUTHORIZED.into(),
-        }),
+        FetchOutcome::Auth => Err(AgentError::api(401, CATALOG_UNAUTHORIZED)),
         FetchOutcome::Permanent => {
             warn!("xAI catalog refresh rejected, using curated fallback");
             invalidate();

--- a/maki-providers/src/providers/zai/mod.rs
+++ b/maki-providers/src/providers/zai/mod.rs
@@ -369,15 +369,13 @@ impl Provider for Zai {
                 .do_stream(model, &[], &body, event_tx, &auth)
                 .await
             {
-                Err(AgentError::Api { status, message })
-                    if (status == 429 || status >= 500)
-                        && (message.contains("1113") || message.contains("nsufficien")) =>
+                Err(AgentError::Api {
+                    status, message, ..
+                }) if (status == 429 || status >= 500)
+                    && (message.contains("1113") || message.contains("nsufficien")) =>
                 {
                     warn!(status, "insufficient funds, bailing out");
-                    Err(AgentError::Api {
-                        status: 402,
-                        message,
-                    })
+                    Err(AgentError::api(402, message))
                 }
                 result => result,
             }

--- a/maki-providers/src/retry.rs
+++ b/maki-providers/src/retry.rs
@@ -1,29 +1,284 @@
 use std::time::Duration;
 
-const DELAY: Duration = Duration::from_secs(2);
-const MAX_DELAY: Duration = Duration::from_secs(8);
-pub const MAX_TIMEOUT_RETRIES: u32 = 10;
+use maki_config::{
+    DEFAULT_MAX_RETRIES, DEFAULT_MAX_TIMEOUT_RETRIES, DEFAULT_RETRY_BASE_MS, DEFAULT_RETRY_MAX_MS,
+    ProviderConfig,
+};
+use tracing::warn;
 
-#[derive(Default)]
+/// Ceiling for a server sent `Retry-After`. Generous, because the whole point
+/// of obeying the header is to sit out a window only the server knows the
+/// length of, but `Retry-After: 86400` is a real thing servers send and parking
+/// a headless or acp turn for a day with nobody around to press esc is not an
+/// option.
+const RETRY_AFTER_CAP: Duration = Duration::from_secs(60 * 60);
+
+/// What kind of failure a retry is paying for. The ways out of here are not
+/// the same: some errors say "the provider is having a bad day", one says "you
+/// are out of money until next month", one says "we may already have billed
+/// you for this", and one says "there may be nothing at that address at all".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetryKind {
+    /// 5xx and network failures on a connection that was made. Nothing came
+    /// back, so trying again only costs time.
+    Transient,
+    /// A connection that was never established: refused, or a host name that
+    /// does not resolve.
+    Connect,
+    /// A 429. Whether the server sent a `Retry-After` decides which budget it
+    /// draws from, so [`RetryState`] splits it further.
+    RateLimit,
+    /// A stream that went quiet. The request was accepted and output tokens may
+    /// already be on the bill, so every retry costs real money.
+    Timeout,
+}
+
+/// Which counter a failure draws from, and whether that counter has a ceiling.
+#[derive(Debug, Clone, Copy)]
+enum Budget {
+    /// Unbounded: a provider outage can outlast any attempt count, and an agent
+    /// left running overnight should still be there in the morning.
+    Transient,
+    /// Unbounded: the server named the moment to come back, so waiting it out
+    /// is what it asked for. Anthropic's Claude Code workspace limits arrive
+    /// this way and clear on their own.
+    HintedRateLimit,
+    /// Bounded: a 429 with no `Retry-After` is how a spend cap reads, and that
+    /// one does not clear until the next billing period, so retrying is
+    /// documented not to help.
+    RateLimit,
+    /// Bounded: see [`RetryKind::Timeout`].
+    Timeout,
+    /// Bounded, on the same limit as [`Self::RateLimit`] but its own counter.
+    ///
+    /// "Could not connect" is ambiguous: a cloud provider whose edge is down
+    /// reads exactly like a local server nobody started. We bound it because
+    /// nothing listening is by far the more common cause, and a typo in a
+    /// `base_url` has to end in an error rather than a run that never stops
+    /// trying.
+    Connect,
+}
+
+const BUDGETS: usize = 5;
+
+impl Budget {
+    fn of(kind: RetryKind, hint: Option<Duration>) -> Self {
+        match kind {
+            RetryKind::Transient => Self::Transient,
+            RetryKind::Connect => Self::Connect,
+            RetryKind::RateLimit if hint.is_some() => Self::HintedRateLimit,
+            RetryKind::RateLimit => Self::RateLimit,
+            RetryKind::Timeout => Self::Timeout,
+        }
+    }
+
+    fn limit(self, policy: &RetryPolicy) -> Option<u32> {
+        match self {
+            Self::Transient | Self::HintedRateLimit => None,
+            Self::RateLimit | Self::Connect => Some(policy.max_retries),
+            Self::Timeout => Some(policy.max_timeout_retries),
+        }
+    }
+}
+
+/// How patient a run is with a provider that keeps failing. Read from user
+/// config, because a rate limited cloud endpoint and a local llama.cpp want
+/// very different numbers.
+#[derive(Debug, Clone, Copy)]
+pub struct RetryPolicy {
+    pub base_delay: Duration,
+    pub max_delay: Duration,
+    /// Budget for rate limits the server gave no `Retry-After` for, and,
+    /// counted separately, for connections that were never established. `0`
+    /// never retries either.
+    pub max_retries: u32,
+    pub max_timeout_retries: u32,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            base_delay: Duration::from_millis(DEFAULT_RETRY_BASE_MS),
+            max_delay: Duration::from_millis(DEFAULT_RETRY_MAX_MS),
+            max_retries: DEFAULT_MAX_RETRIES,
+            max_timeout_retries: DEFAULT_MAX_TIMEOUT_RETRIES,
+        }
+    }
+}
+
+impl From<&ProviderConfig> for RetryPolicy {
+    fn from(config: &ProviderConfig) -> Self {
+        Self {
+            base_delay: Duration::from_millis(config.retry_base_ms),
+            max_delay: Duration::from_millis(config.retry_max_ms),
+            max_retries: config.max_retries,
+            max_timeout_retries: config.max_timeout_retries,
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct RetryState {
-    attempt: u32,
+    policy: RetryPolicy,
+    spent: [u32; BUDGETS],
 }
 
 impl RetryState {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(policy: RetryPolicy) -> Self {
+        Self {
+            policy,
+            spent: [0; BUDGETS],
+        }
     }
 
     /// Retries burned so far; the attempt currently failing is this plus one.
+    /// One number across every budget, so a 429 after three timeouts reads as
+    /// the 4th attempt in the UI and in otel, not the 1st.
     pub fn attempts(&self) -> u32 {
-        self.attempt
+        self.spent.iter().sum()
     }
 
-    pub fn next_delay(&mut self) -> (u32, Duration) {
-        self.attempt += 1;
-        let delay = (DELAY.saturating_mul(self.attempt)).min(MAX_DELAY);
-        let half = delay / 2;
+    /// Books the next retry and says how long to wait, or `None` once this
+    /// failure's budget is spent.
+    ///
+    /// Budgets never touch: a flaky connection that burns its whole budget must
+    /// not leave a later rate limit with nothing left to spend. `hint` is a
+    /// `Retry-After` the server sent, and it knows its own window better than
+    /// we do, within [`RetryPolicy::base_delay`] and [`RETRY_AFTER_CAP`].
+    pub fn next_delay(&mut self, kind: RetryKind, hint: Option<Duration>) -> Option<Duration> {
+        let budget = Budget::of(kind, hint);
+        let spent = &mut self.spent[budget as usize];
+        if budget
+            .limit(&self.policy)
+            .is_some_and(|limit| *spent >= limit)
+        {
+            return None;
+        }
+        *spent += 1;
+        let attempt = *spent;
+
+        let Some(after) = hint else {
+            return Some(self.backoff(attempt));
+        };
+        if after > RETRY_AFTER_CAP {
+            warn!(
+                retry_after_ms = after.as_millis() as u64,
+                cap_ms = RETRY_AFTER_CAP.as_millis() as u64,
+                "Retry-After above cap, trimming"
+            );
+        }
+        // The floor matters as much as the cap: this budget is unbounded, and a
+        // server answering `Retry-After: 1` forever would otherwise become a
+        // one-request-per-second hammer on the rate limiter that is already
+        // saying no.
+        Some(after.clamp(self.policy.base_delay.min(RETRY_AFTER_CAP), RETRY_AFTER_CAP))
+    }
+
+    /// Half the backoff, plus jitter on top, so a fleet of clients knocked back
+    /// by the same 429 does not all come back at the same moment.
+    fn backoff(&self, attempt: u32) -> Duration {
+        let half = self
+            .policy
+            .base_delay
+            .saturating_mul(attempt)
+            .min(self.policy.max_delay)
+            / 2;
         let jitter = Duration::from_millis(fastrand::u64(0..=half.as_millis() as u64));
-        (self.attempt, half + jitter)
+        half + jitter
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    const BASE: Duration = Duration::from_millis(100);
+    const MAX: Duration = Duration::from_millis(250);
+    /// Enough rounds that anything unbounded is obviously unbounded, cheap
+    /// because nothing here sleeps.
+    const MANY: u32 = 1_000;
+
+    fn state(max_retries: u32, max_timeout_retries: u32) -> RetryState {
+        RetryState::new(RetryPolicy {
+            base_delay: BASE,
+            max_delay: MAX,
+            max_retries,
+            max_timeout_retries,
+        })
+    }
+
+    /// Retries until the budget runs out or `MANY` rounds pass, checking on the
+    /// way that every delay lands in the half-to-full band the backoff promises
+    /// for that attempt.
+    fn spend(state: &mut RetryState, kind: RetryKind) -> u32 {
+        let mut retried = 0;
+        while retried < MANY
+            && let Some(delay) = state.next_delay(kind, None)
+        {
+            let want = BASE.saturating_mul(retried + 1).min(MAX) / 2;
+            assert!((want..=want * 2).contains(&delay), "{delay:?}");
+            retried += 1;
+        }
+        retried
+    }
+
+    #[test_case(0, RetryKind::RateLimit, 0    ; "zero_budget_never_retries_an_unhinted_rate_limit")]
+    #[test_case(2, RetryKind::RateLimit, 2    ; "an_unhinted_rate_limit_stops_at_its_budget")]
+    #[test_case(2, RetryKind::Timeout, 3      ; "timeouts_have_their_own_budget")]
+    #[test_case(0, RetryKind::Transient, MANY ; "a_5xx_outlives_every_budget")]
+    #[test_case(0, RetryKind::Connect, 0      ; "zero_budget_never_retries_a_refused_connection")]
+    #[test_case(2, RetryKind::Connect, 2      ; "a_refused_connection_stops_at_its_budget")]
+    fn budget_is_spent_then_exhausted(max_retries: u32, kind: RetryKind, expected: u32) {
+        assert_eq!(spend(&mut state(max_retries, 3), kind), expected);
+    }
+
+    #[test]
+    fn budgets_cannot_eat_each_other() {
+        let mut state = state(2, 3);
+        assert_eq!(spend(&mut state, RetryKind::Timeout), 3);
+        assert_eq!(spend(&mut state, RetryKind::Connect), 2);
+        assert_eq!(spend(&mut state, RetryKind::RateLimit), 2);
+        assert_eq!(state.attempts(), 7, "reported attempt spans every budget");
+    }
+
+    /// A hinted 429 is unbounded and must not spend the budget kept for the
+    /// unhinted kind, which is the one that means "out of money".
+    #[test]
+    fn a_hinted_rate_limit_leaves_the_unhinted_budget_alone() {
+        let mut state = state(2, 3);
+        let hint = Some(Duration::from_secs(5));
+        for _ in 0..MANY {
+            assert!(state.next_delay(RetryKind::RateLimit, hint).is_some());
+        }
+        assert_eq!(spend(&mut state, RetryKind::RateLimit), 2);
+        assert_eq!(state.attempts(), MANY + 2);
+    }
+
+    #[test_case(Duration::from_secs(5), Duration::from_secs(5)  ; "sane_hint_beats_the_guess")]
+    #[test_case(Duration::from_secs(86_400), RETRY_AFTER_CAP    ; "absurd_hint_is_trimmed")]
+    // An unbounded budget plus a zero or near-zero hint is a tight loop against
+    // a rate limiter, so the floor is load bearing, not decoration.
+    #[test_case(Duration::ZERO, BASE                            ; "zero_hint_is_raised_to_the_base_delay")]
+    #[test_case(Duration::from_millis(1), BASE                  ; "tiny_hint_is_raised_to_the_base_delay")]
+    fn server_hint_is_honored_between_the_floor_and_the_cap(hint: Duration, expected: Duration) {
+        assert_eq!(
+            state(1, 1).next_delay(RetryKind::RateLimit, Some(hint)),
+            Some(expected)
+        );
+    }
+
+    /// A base delay above the cap must clamp, not panic on an inverted range.
+    #[test]
+    fn a_base_delay_above_the_cap_still_clamps() {
+        let mut state = RetryState::new(RetryPolicy {
+            base_delay: RETRY_AFTER_CAP * 2,
+            ..RetryPolicy::default()
+        });
+        let hint = Some(Duration::from_secs(1));
+        assert_eq!(
+            state.next_delay(RetryKind::RateLimit, hint),
+            Some(RETRY_AFTER_CAP)
+        );
     }
 }

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -202,6 +202,7 @@ impl AgentLoop {
             &self.config,
             instructions,
             self.session_id.as_ref(),
+            self.timeouts.retry,
         )
         .await
     }

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -139,6 +139,10 @@ How many lines of output to show per tool in the UI. All values are `usize` with
 | `connect_timeout_secs` | u64 | `10` | 1 | HTTP connect timeout (seconds) |
 | `low_speed_timeout_secs` | u64 | `120` | 1 | Low speed timeout (seconds with less than 1 byte received) |
 | `stream_timeout_secs` | u64 | `300` | 10 | Streaming response timeout (seconds) |
+| `retry_base_ms` | u64 | `2000` | 1 | Base delay between retries (milliseconds, grows per attempt) |
+| `retry_max_ms` | u64 | `60000` | 1 | Cap on the guessed retry backoff (milliseconds) |
+| `max_retries` | u32 | `5` | - | Max retries on a rate limit the server sent no Retry-After for, 0 to never retry them |
+| `max_timeout_retries` | u32 | `10` | - | Max retries on stream timeouts |
 
 ### `storage`
 

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -51,11 +51,7 @@ pub fn run(
     )?;
     super::report_warnings(warnings);
 
-    let timeouts = maki_providers::Timeouts {
-        connect: config.provider.connect_timeout,
-        low_speed: config.provider.low_speed_timeout,
-        stream: config.provider.stream_timeout,
-    };
+    let timeouts = maki_providers::Timeouts::from(&config.provider);
 
     let model = setup::resolve_model(model_arg.as_deref(), &config.provider, &storage)?;
 

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -40,11 +40,7 @@ struct Stack {
 
 impl Stack {
     fn timeouts(&self) -> maki_providers::Timeouts {
-        maki_providers::Timeouts {
-            connect: self.config.provider.connect_timeout,
-            low_speed: self.config.provider.low_speed_timeout,
-            stream: self.config.provider.stream_timeout,
-        }
+        maki_providers::Timeouts::from(&self.config.provider)
     }
 }
 


### PR DESCRIPTION
Resolves https://github.com/tontinton/maki/issues/959

Adds a configurable maximum retry count for retryable provider errors (429, 5xx, network), so a persistent provider failure fails in bounded time instead of retrying forever.

## Changes

- **`max_retries`** config: caps retries on retryable (rate-limit/5xx) errors. Defaults to `5`. Timeouts keep their separate `max_timeout_retries` budget.
- **Configurable backoff** (`retry_base_ms`, `retry_max_ms`): the exponential backoff base and cap are now tunable per provider instead of hardcoded.
- **Honor `Retry-After`**: the server's `Retry-After` header on 429/5xx is parsed and preferred over the guessed backoff (clamped to its own 120s ceiling rather than `retry_max_ms`, with a warning when trimmed).
- Applies to all retryable errors and propagates the final error back to the caller, including `task`/subagent failures.

## Context

- `max_retries` is a plain `u32` (`0` never retries those errors); the hand written `ProviderConfig::default()` and the config-file path both use `5` now.
- Docs updated.