### PR TITLE
feat: configurable per-provider top_p sampling

### DIFF
--- a/maki-config/src/providers.rs
+++ b/maki-config/src/providers.rs
@@ -14,6 +14,10 @@ const BAD_CONFIG_EXIT_CODE: i32 = 2;
 /// The only built-in that reads `enable_free_models`.
 const OPENCODE_SLUG: &str = "opencode";
 
+/// Valid `top_p` is in the open interval exclusive of 0, up to 1 inclusive.
+const TOP_P_MIN: f64 = 0.0;
+const TOP_P_MAX: f64 = 1.0;
+
 /// Coarse capability classification used by maki-providers to dispatch tiered
 /// requests. Mirrors `maki_providers::ModelTier` shape but lives here so the
 /// config layer can validate inputs without depending on maki-providers.
@@ -179,6 +183,15 @@ pub struct ProviderDef {
     pub api_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_model: Option<String>,
+    /// Nucleus sampling threshold sent as `top_p` in the request body to this
+    /// provider. When unset, no `top_p` is sent (the provider's own default
+    /// applies). Must be in `(0, 1]`.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "de_top_p"
+    )]
+    pub top_p: Option<f64>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub discover_models: bool,
     /// Extra HTTP headers sent with every request to this provider. Values
@@ -434,6 +447,27 @@ pub fn resolve_login_url(slug: &str, plan: Option<&str>) -> Option<String> {
     builtin_provider(slug).and_then(|b| b.login_url.map(|u| u.to_string()))
 }
 
+/// The `top_p` to send for a provider: the value from `providers.toml`, or
+/// `None` when unset (send nothing, let the provider use its own default).
+pub fn resolve_top_p(def: Option<&ProviderDef>) -> Option<f64> {
+    def.and_then(|d| d.top_p)
+}
+
+fn de_top_p<'de, D>(de: D) -> Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<f64>::deserialize(de)?;
+    if let Some(v) = value
+        && (v <= TOP_P_MIN || v > TOP_P_MAX)
+    {
+        return Err(serde::de::Error::custom(format!(
+            "top_p must be in ({TOP_P_MIN}, {TOP_P_MAX}], got {v}"
+        )));
+    }
+    Ok(value)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -620,6 +654,37 @@ tier = "{input}"
             ignored_builtin_fields("openrouter", &def),
             ["enable_free_models"]
         );
+    }
+
+    #[test]
+    fn resolve_top_p_is_none_when_unset() {
+        assert_eq!(resolve_top_p(None), None);
+        assert_eq!(resolve_top_p(Some(&ProviderDef::default())), None);
+    }
+
+    #[test]
+    fn resolve_top_p_uses_provider_value() {
+        let def = ProviderDef {
+            top_p: Some(0.8),
+            ..Default::default()
+        };
+        assert_eq!(resolve_top_p(Some(&def)), Some(0.8));
+    }
+
+    #[test_case(0.0; "zero")]
+    #[test_case(-0.1; "negative")]
+    #[test_case(1.5; "above_one")]
+    fn top_p_out_of_range_rejected(value: f64) {
+        let res = toml::from_str::<ProviderDef>(&format!("top_p = {value}"));
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn top_p_boundaries_accepted() {
+        let def: ProviderDef = toml::from_str("top_p = 1.0").unwrap();
+        assert_eq!(def.top_p, Some(1.0));
+        let def2: ProviderDef = toml::from_str("top_p = 0.0000001").unwrap();
+        assert!(def2.top_p.unwrap() > 0.0);
     }
 
     #[test_case("MyProvider", "myprovider"; "mixed_case")]

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -221,6 +221,7 @@ supports_vision = false
 | `api_key` | string | Inline key (prefer the env var or `maki auth login`) |
 | `headers` | table | Extra HTTP headers sent on every request to this provider. Values expand `${{VAR}}` from the environment; an unset or empty variable fails the provider instead of sending a half-filled header. A same-name header (case-insensitive) replaces the built-in auth header and survives key rotation |
 | `default_model` | string | Used after login when no model is saved yet |
+| `top_p` | f64 | Nucleus sampling probability, sent as `top_p` in the request body. Only sent when set; the provider's own default applies otherwise. Must be in `(0, 1]` |
 | `discover_models` | bool | When true, also probe the provider's model list endpoint (default false) |
 | `enable_free_models` | bool | Opencode only. Show free catalog models (default false) |
 | `models` | array | Declared models for custom providers (see below) |

--- a/maki-providers/src/providers/anthropic/bedrock.rs
+++ b/maki-providers/src/providers/anthropic/bedrock.rs
@@ -57,6 +57,11 @@ pub(crate) fn is_enabled() -> bool {
     env::var("CLAUDE_CODE_USE_BEDROCK").is_ok_and(|v| v == "1")
 }
 
+fn resolve_bedrock_top_p() -> Option<f64> {
+    let config = maki_config::providers::ProvidersConfig::load();
+    maki_config::providers::resolve_top_p(config.get("bedrock"))
+}
+
 fn resolve_bedrock_auth() -> Result<BedrockAuth, AgentError> {
     let region = env::var("AWS_REGION").map_err(|_| AgentError::Config {
         message: "AWS_REGION must be set when using Bedrock".into(),
@@ -482,6 +487,7 @@ pub(crate) struct Bedrock {
     client: HttpClient,
     auth: Arc<Mutex<BedrockAuth>>,
     base_url: Option<String>,
+    top_p: Option<f64>,
 }
 
 impl Bedrock {
@@ -497,6 +503,7 @@ impl Bedrock {
             client: super::super::http_client(timeouts),
             auth: Arc::new(Mutex::new(auth)),
             base_url,
+            top_p: resolve_bedrock_top_p(),
         })
     }
 
@@ -549,6 +556,7 @@ impl Provider for Bedrock {
                 }],
                 tools,
                 opts.thinking,
+                self.top_p,
             );
             // Fast mode lives only on the direct API, so Bedrock skips `opts.fast`
             // and never sends the `speed` param.

--- a/maki-providers/src/providers/anthropic/mod.rs
+++ b/maki-providers/src/providers/anthropic/mod.rs
@@ -245,6 +245,11 @@ fn resolve_anthropic_base_url() -> Option<String> {
     maki_config::providers::resolve_base_url("anthropic", config.get("anthropic"))
 }
 
+fn resolve_anthropic_top_p() -> Option<f64> {
+    let config = maki_config::providers::ProvidersConfig::load();
+    maki_config::providers::resolve_top_p(config.get("anthropic"))
+}
+
 fn resolve_auth_from_key(
     key: &str,
     base_url: Option<String>,
@@ -264,6 +269,7 @@ pub struct Anthropic {
     /// Env / `providers.toml` / inventory default, resolved once at construction.
     /// Reused by key rotation / reload so they do not re-parse providers.toml.
     resolved_base_url: Option<String>,
+    top_p: Option<f64>,
 }
 
 impl Anthropic {
@@ -279,12 +285,14 @@ impl Anthropic {
             system_prefix: None,
             stream_timeout: timeouts.stream,
             resolved_base_url,
+            top_p: resolve_anthropic_top_p(),
         })
     }
 
     pub(crate) fn with_auth(
         auth: Arc<Mutex<super::ResolvedAuth>>,
         timeouts: super::Timeouts,
+        top_p: Option<f64>,
     ) -> Self {
         Self {
             client: super::http_client(timeouts),
@@ -296,6 +304,7 @@ impl Anthropic {
             // anthropic override would make every third-party endpoint look
             // first party and poll `/api/oauth/usage` against it.
             resolved_base_url: None,
+            top_p,
         }
     }
 
@@ -428,6 +437,7 @@ impl Provider for Anthropic {
                 &system_blocks,
                 tools,
                 opts.thinking,
+                self.top_p,
             );
             body["model"] = json!(shared::strip_long_context(&model.id));
             body["stream"] = json!(true);
@@ -646,6 +656,7 @@ mod tests {
         let provider = Anthropic::with_auth(
             Arc::new(Mutex::new(auth)),
             crate::providers::Timeouts::default(),
+            None,
         );
         assert!(provider.resolved_base_url.is_none());
         assert!(!usage_eligible(

--- a/maki-providers/src/providers/anthropic/shared.rs
+++ b/maki-providers/src/providers/anthropic/shared.rs
@@ -224,6 +224,7 @@ pub(crate) fn build_request_body_with_system(
     system_blocks: &[SystemBlock<'_>],
     tools: &Value,
     thinking: ThinkingConfig,
+    top_p: Option<f64>,
 ) -> Value {
     let wire_messages = build_wire_messages(messages);
     let wire_tools = build_wire_tools(tools);
@@ -234,6 +235,9 @@ pub(crate) fn build_request_body_with_system(
         "messages": wire_messages,
         "tools": wire_tools,
     });
+    if let Some(top_p) = top_p {
+        body["top_p"] = json!(top_p);
+    }
 
     thinking.apply_to_body(&mut body, model);
     body

--- a/maki-providers/src/providers/aperture.rs
+++ b/maki-providers/src/providers/aperture.rs
@@ -256,9 +256,9 @@ fn build_routed_provider(
             Box::new(Regolo::with_auth(auth, timeouts).with_system_prefix(system_prefix))
         }
         ProviderKind::Anthropic => {
-            Box::new(Anthropic::with_auth(auth, timeouts).with_system_prefix(system_prefix))
+            Box::new(Anthropic::with_auth(auth, timeouts, None).with_system_prefix(system_prefix))
         }
-        ProviderKind::Google => Box::new(Google::with_auth(auth, timeouts)),
+        ProviderKind::Google => Box::new(Google::with_auth(auth, timeouts, None)),
         // Excluded by `compat_kind`: routing to native OpenAI would bypass the
         // gateway for codex models, and the rest have no clean proxy story. A
         // new kind must pick a side here.

--- a/maki-providers/src/providers/catalog.rs
+++ b/maki-providers/src/providers/catalog.rs
@@ -727,10 +727,14 @@ impl CatalogTransport {
         event_tx: &Sender<ProviderEvent>,
         auth: &ResolvedAuth,
         opts: &RequestOptions,
+        top_p: Option<f64>,
     ) -> Result<StreamResponse, AgentError> {
         match api_format {
             EndpointType::ChatCompletions => {
                 let mut body = self.chat_compat.build_body(model, messages, system, tools);
+                if let Some(top_p) = top_p {
+                    body["top_p"] = serde_json::json!(top_p);
+                }
                 opts.thinking
                     .apply_reasoning_effort(&mut body, &dialect::PREFER_HIGH, model);
                 self.chat_compat
@@ -749,6 +753,7 @@ impl CatalogTransport {
                     &system_blocks,
                     tools,
                     opts.thinking,
+                    top_p,
                 );
                 body["model"] = serde_json::json!(model.id);
                 body["stream"] = serde_json::json!(true);
@@ -869,6 +874,9 @@ impl Provider for CatalogProvider {
                     event_tx,
                     &auth,
                     &opts,
+                    maki_config::providers::resolve_top_p(
+                        ProvidersConfig::load().get(&self.data.slug),
+                    ),
                 )
                 .await
         })

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -77,14 +77,21 @@ pub fn create(slug: &str, timeouts: Timeouts) -> Result<Box<dyn Provider>, Agent
 
     match kind {
         ProviderKind::Anthropic => Ok(Box::new(super::anthropic::Anthropic::with_auth(
-            auth, timeouts,
+            auth,
+            timeouts,
+            maki_config::providers::resolve_top_p(config.get(slug)),
         ))),
         ProviderKind::OpenAi => Ok(Box::new(CustomOpenAiProvider {
             compat: OpenAiCompatProvider::new(&CUSTOM_OPENAI_CONFIG, timeouts),
             auth,
             protocol,
+            top_p: maki_config::providers::resolve_top_p(config.get(slug)),
         })),
-        ProviderKind::Google => Ok(Box::new(super::google::Google::with_auth(auth, timeouts))),
+        ProviderKind::Google => Ok(Box::new(super::google::Google::with_auth(
+            auth,
+            timeouts,
+            maki_config::providers::resolve_top_p(config.get(slug)),
+        ))),
         _ => Err(AgentError::Config {
             message: format!(
                 "unsupported protocol for custom provider '{slug}', only openai/anthropic/google are supported"
@@ -269,6 +276,7 @@ struct CustomOpenAiProvider {
     compat: OpenAiCompatProvider,
     auth: Arc<Mutex<ResolvedAuth>>,
     protocol: Protocol,
+    top_p: Option<f64>,
 }
 
 impl Provider for CustomOpenAiProvider {
@@ -300,6 +308,9 @@ impl Provider for CustomOpenAiProvider {
             }
 
             let mut body = self.compat.build_body(model, messages, system, tools);
+            if let Some(top_p) = self.top_p {
+                body["top_p"] = serde_json::json!(top_p);
+            }
             if matches!(opts.thinking, ThinkingConfig::Off) {
                 body["thinking"] = serde_json::json!({"type": "disabled"});
             }

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -550,14 +550,26 @@ pub fn create(slug: &str, timeouts: super::Timeouts) -> Result<Box<dyn Provider>
 
     let inner: Box<dyn Provider> = match meta.base {
         ProviderKind::Anthropic => Box::new(
-            Anthropic::with_auth(auth.clone(), timeouts)
-                .with_system_prefix(meta.system_prefix.clone()),
+            Anthropic::with_auth(
+                auth.clone(),
+                timeouts,
+                maki_config::providers::resolve_top_p(
+                    maki_config::providers::ProvidersConfig::load().get(slug),
+                ),
+            )
+            .with_system_prefix(meta.system_prefix.clone()),
         ),
         ProviderKind::OpenAi => Box::new(
             OpenAi::with_auth(auth.clone(), timeouts)
                 .with_system_prefix(meta.system_prefix.clone()),
         ),
-        ProviderKind::Google => Box::new(Google::with_auth(auth.clone(), timeouts)),
+        ProviderKind::Google => Box::new(Google::with_auth(
+            auth.clone(),
+            timeouts,
+            maki_config::providers::resolve_top_p(
+                maki_config::providers::ProvidersConfig::load().get(slug),
+            ),
+        )),
         ProviderKind::Copilot => Box::new(
             Copilot::with_auth(auth.clone(), timeouts)
                 .with_system_prefix(meta.system_prefix.clone()),

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -105,6 +105,11 @@ fn resolve_google_base_url() -> Option<String> {
     maki_config::providers::resolve_base_url("google", config.get("google"))
 }
 
+fn resolve_google_top_p() -> Option<f64> {
+    let config = maki_config::providers::ProvidersConfig::load();
+    maki_config::providers::resolve_top_p(config.get("google"))
+}
+
 fn resolve_auth_from_key(key: &str, base_url: Option<String>) -> Result<ResolvedAuth, AgentError> {
     Ok(
         ResolvedAuth::new("google", vec![(API_KEY_HEADER.into(), key.to_string())])?
@@ -119,6 +124,7 @@ pub struct Google {
     stream_timeout: Duration,
     /// Env / `providers.toml` / inventory default, resolved once at construction.
     resolved_base_url: Option<String>,
+    top_p: Option<f64>,
 }
 
 impl Google {
@@ -132,12 +138,14 @@ impl Google {
             key_pool: Some(pool),
             stream_timeout: timeouts.stream,
             resolved_base_url,
+            top_p: resolve_google_top_p(),
         })
     }
 
     pub(crate) fn with_auth(
         auth: Arc<Mutex<super::ResolvedAuth>>,
         timeouts: super::Timeouts,
+        top_p: Option<f64>,
     ) -> Self {
         let resolved_base_url = auth.lock().unwrap().base_url.clone();
         Self {
@@ -146,6 +154,7 @@ impl Google {
             key_pool: None,
             stream_timeout: timeouts.stream,
             resolved_base_url,
+            top_p,
         }
     }
 
@@ -206,6 +215,9 @@ impl Google {
 
         if let Some(max_output) = model.output_tokens() {
             body["generationConfig"]["maxOutputTokens"] = json!(max_output);
+        }
+        if let Some(top_p) = self.top_p {
+            body["generationConfig"]["topP"] = json!(top_p);
         }
 
         let tool_decls = convert_tools(tools);
@@ -761,7 +773,7 @@ mod tests {
 
     #[test]
     fn google_build_body_basic() {
-        let google = Google::with_auth(test_auth(), test_timeouts());
+        let google = Google::with_auth(test_auth(), test_timeouts(), None);
         let model = test_model();
         let messages = vec![Message::user("hello".into())];
         let body = google.build_body(
@@ -776,11 +788,26 @@ mod tests {
         assert_eq!(body["systemInstruction"]["parts"][0]["text"], "be helpful");
         assert_eq!(body["generationConfig"]["maxOutputTokens"], 8192);
         assert!(body.get("tools").is_none());
+        assert!(body["generationConfig"].get("topP").is_none());
+    }
+
+    #[test]
+    fn google_build_body_sends_top_p_when_configured() {
+        let google = Google::with_auth(test_auth(), test_timeouts(), Some(0.8));
+        let messages = vec![Message::user("hello".into())];
+        let body = google.build_body(
+            &test_model(),
+            &messages,
+            "",
+            &json!([]),
+            ThinkingConfig::Off,
+        );
+        assert_eq!(body["generationConfig"]["topP"], 0.8);
     }
 
     #[test]
     fn google_build_body_thinking_adaptive() {
-        let google = Google::with_auth(test_auth(), test_timeouts());
+        let google = Google::with_auth(test_auth(), test_timeouts(), None);
         let messages = vec![Message::user("think".into())];
         let body = google.build_body(
             &test_model(),
@@ -798,7 +825,7 @@ mod tests {
 
     #[test]
     fn google_build_body_thinking_budget() {
-        let google = Google::with_auth(test_auth(), test_timeouts());
+        let google = Google::with_auth(test_auth(), test_timeouts(), None);
         let messages = vec![Message::user("think hard".into())];
         let body = google.build_body(
             &test_model(),

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -42,21 +42,24 @@ pub(crate) struct OpenAiCompatProvider {
     /// bare ollama host). Request-time `auth.base_url` still wins (custom,
     /// local, dynamic).
     resolved_base_url: Option<String>,
+    top_p: Option<f64>,
 }
 
 impl OpenAiCompatProvider {
     pub fn new(config: &'static OpenAiCompatConfig, timeouts: super::Timeouts) -> Self {
+        let providers = maki_config::providers::ProvidersConfig::load();
         let resolved_base_url = if config.slug.is_empty() {
             None
         } else {
-            let providers = maki_config::providers::ProvidersConfig::load();
             maki_config::providers::configured_base_url(config.slug, providers.get(config.slug))
         };
+        let top_p = maki_config::providers::resolve_top_p(providers.get(config.slug));
         Self {
             client: super::http_client(timeouts),
             config,
             stream_timeout: timeouts.stream,
             resolved_base_url,
+            top_p,
         }
     }
 
@@ -131,6 +134,9 @@ impl OpenAiCompatProvider {
             "messages": wire_messages,
             "stream": true,
         });
+        if let Some(top_p) = self.top_p {
+            body["top_p"] = json!(top_p);
+        }
         if let Some(max_output) = model.output_tokens() {
             body[self.config.max_tokens_field] = json!(max_output);
         }

--- a/maki-providers/src/providers/opencode.rs
+++ b/maki-providers/src/providers/opencode.rs
@@ -165,6 +165,9 @@ impl Provider for Opencode {
                     event_tx,
                     &auth,
                     &opts,
+                    maki_config::providers::resolve_top_p(
+                        maki_config::providers::ProvidersConfig::load().get(sub_provider),
+                    ),
                 )
                 .await
         })

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -412,6 +412,7 @@ supports_vision = false
 | `api_key` | string | Inline key (prefer the env var or `maki auth login`) |
 | `headers` | table | Extra HTTP headers sent on every request to this provider. Values expand `${VAR}` from the environment; an unset or empty variable fails the provider instead of sending a half-filled header. A same-name header (case-insensitive) replaces the built-in auth header and survives key rotation |
 | `default_model` | string | Used after login when no model is saved yet |
+| `top_p` | f64 | Nucleus sampling probability, sent as `top_p` in the request body. Only sent when set; the provider's own default applies otherwise. Must be in `(0, 1]` |
 | `discover_models` | bool | When true, also probe the provider's model list endpoint (default false) |
 | `enable_free_models` | bool | Opencode only. Show free catalog models (default false) |
 | `models` | array | Declared models for custom providers (see below) |


### PR DESCRIPTION
## Summary

Add a configurable per-provider `top_p` field (nucleus sampling threshold) sent in the request body to every provider.

## Changes

- **config**: add `top_p` to per-provider config (providers.toml). When unset, no `top_p` is sent and the provider's own default applies. Must be in `(0, 1]`. Resolved once at provider construction, never per request.
- **providers**: send `top_p` in OpenAI-compat Chat Completions, the Anthropic Messages builder (Anthropic, Bedrock, Messages endpoint), Google `generationConfig.topP`, plus per-sub-provider resolution in the catalog and opencode.
- **docs**: document the `top_p` field in the providers table.

## Commit messages

- feat(config): add configurable per-provider top_p sampling
- feat(providers): send top_p in OpenAI, Anthropic, Google and Bedrock bodies
- docs(providers): document the per-provider top_p field