### PR TITLE
feat(websearch): add a youcom provider option

### DIFF
--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -3617,6 +3617,71 @@ fn builtin_opts_flow_from_setup_plugins() {
     assert!(!limit.desc.is_empty(), "declared desc surfaces");
 }
 
+/// The websearch tool's provider option picks the backend, and the tool
+/// description tells the model which one it is talking to. Default stays
+/// exa; `provider = "youcom"` switches the wording without touching the
+/// schema, so existing sessions see no change unless they opt in.
+#[test]
+fn websearch_provider_option_selects_the_backend() {
+    for (provider, expected) in [("exa", "Exa AI"), ("youcom", "You.com")] {
+        let reg = fresh_registry();
+        let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
+        let config = PluginsConfig {
+            enabled: true,
+            names: vec!["websearch".to_owned()],
+            packages: Vec::new(),
+            opts: HashMap::from([(
+                "websearch".to_owned(),
+                json_obj(serde_json::json!({ "provider": provider })),
+            )]),
+        };
+        host.load_builtins(&config)
+            .unwrap_or_else(|e| panic!("{provider} should load: {e}"));
+
+        let model = Model::from_spec("anthropic/claude-opus-4-8").unwrap();
+        let filter = ToolFilter::from_config(&maki_config::AgentConfig::default(), &model, &[]);
+        let ctx = DescriptionContext {
+            filter: &filter,
+            audience: ToolAudience::MAIN,
+            workflow: false,
+            mcp: false,
+        };
+        let defs = reg.definitions(&Vars::new(), &ctx, false);
+        let websearch = defs
+            .as_array()
+            .expect("definitions returns an array")
+            .iter()
+            .find(|def| def["name"] == "websearch")
+            .expect("websearch tool registered");
+        let description = websearch["description"].as_str().unwrap();
+        assert!(
+            description.contains(expected),
+            "{provider} description should name {expected}, got: {description}"
+        );
+    }
+}
+
+/// A provider value outside the two backends fails the plugin load loudly,
+/// the same register_options contract every other option follows.
+#[test]
+fn websearch_unknown_provider_fails_the_load() {
+    let reg = fresh_registry();
+    let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let config = PluginsConfig {
+        enabled: true,
+        names: vec!["websearch".to_owned()],
+        packages: Vec::new(),
+        opts: HashMap::from([(
+            "websearch".to_owned(),
+            json_obj(serde_json::json!({ "provider": "altavista" })),
+        )]),
+    };
+    let err = host
+        .load_builtins(&config)
+        .expect_err("unknown provider should fail");
+    assert!(err.to_string().contains("unknown provider"), "got: {err}");
+}
+
 #[test_case::test_case(
     serde_json::json!({}),
     &["edit", "multiedit", "edit_lines"], &["insert_lines"]

--- a/plugins/websearch/init.lua
+++ b/plugins/websearch/init.lua
@@ -1,19 +1,29 @@
-local EXA_MCP_ENDPOINT = "https://mcp.exa.ai/mcp"
 local REQUEST_TIMEOUT_SECS = 25
 local DEFAULT_NUM_RESULTS = 8
 
 local parse_sse_response = require("parse_sse")
+local providers = require("providers")
 local truncate = require("maki.truncate")
 local ToolView = require("maki.tool_view")
 local output_limits = require("maki.output_limits")
 
 local opts = maki.api.register_options(output_limits.extend({
+  provider = {
+    default = "exa",
+    type = "string",
+    desc = 'Search backend: "exa" (default) or "youcom" (You.com MCP).',
+  },
   max_response_bytes = {
     default = 5 * 1024 * 1024,
     min = 1024,
     desc = "Stop reading a response after this many bytes.",
   },
 }))
+
+local provider = providers[opts.provider]
+if not provider then
+  error('websearch: unknown provider "' .. tostring(opts.provider) .. '" (expected "exa" or "youcom")')
+end
 
 local function web_view_opts(ctx)
   local tol = ctx:tool_output_lines()
@@ -23,7 +33,8 @@ end
 maki.api.register_tool({
   name = "websearch",
   kind = "fetch",
-  description = "Search the web for real-time information using Exa AI.\n\n"
+  description = provider.description
+    .. "\n\n"
     .. "Today's date is "
     .. os.date("%Y-%m-%d")
     .. ".\n\n"
@@ -65,13 +76,8 @@ maki.api.register_tool({
       id = 1,
       method = "tools/call",
       params = {
-        name = "web_search_exa",
-        arguments = {
-          query = query,
-          numResults = num_results,
-          type = "auto",
-          livecrawl = "fallback",
-        },
+        name = provider.tool,
+        arguments = provider.arguments(query, num_results),
       },
     })
     if not payload then
@@ -80,16 +86,17 @@ maki.api.register_tool({
 
     local max_lines, max_bytes = output_limits.resolve(opts, ctx)
 
+    local api_key = provider.api_key()
+
     local headers = {
       ["Content-Type"] = "application/json",
       ["Accept"] = "application/json, text/event-stream",
     }
-    local api_key = maki.uv.os_getenv("EXA_API_KEY")
-    if api_key then
-      headers["x-api-key"] = api_key
+    for name, value in pairs(provider.headers(api_key)) do
+      headers[name] = value
     end
 
-    local resp, err = maki.net.request(EXA_MCP_ENDPOINT, {
+    local resp, err = maki.net.request(provider.endpoint(api_key), {
       method = "POST",
       body = payload,
       headers = headers,

--- a/plugins/websearch/parse_sse.lua
+++ b/plugins/websearch/parse_sse.lua
@@ -1,10 +1,27 @@
 local NO_RESULTS_MSG = "No search results found"
+local MCP_ERROR_PREFIX = "MCP error: "
+local MCP_TOOL_ERROR_PREFIX = "MCP tool error: "
+local UNKNOWN_ERROR_MSG = "unknown error"
 
 local function extract_text(parsed)
   local content = parsed.result and parsed.result.content
   local text = type(content) == "table" and content[1] and content[1].text
   if type(text) == "string" and #text > 0 then
     return text
+  end
+end
+
+-- Rate limits and auth failures come back as HTTP 200 with a jsonrpc error
+-- or result.isError, so without this the tool would answer "no results" and
+-- the model would believe the web had nothing to say.
+local function failure_message(parsed)
+  local err = parsed.error
+  if err ~= nil then
+    local message = type(err) == "table" and err.message or err
+    return MCP_ERROR_PREFIX .. (type(message) == "string" and message or UNKNOWN_ERROR_MSG)
+  end
+  if parsed.result and parsed.result.isError then
+    return MCP_TOOL_ERROR_PREFIX .. (extract_text(parsed) or UNKNOWN_ERROR_MSG)
   end
 end
 
@@ -15,6 +32,10 @@ local function parse_sse_response(body)
       local parsed, parse_err = maki.json.decode(data)
       if not parsed then
         return nil, "SSE JSON parse error: " .. parse_err
+      end
+      local failure = failure_message(parsed)
+      if failure then
+        return nil, failure
       end
       local text = extract_text(parsed)
       if text then

--- a/plugins/websearch/providers.lua
+++ b/plugins/websearch/providers.lua
@@ -1,0 +1,73 @@
+-- Search backends the websearch tool can talk to. Each one is an MCP server
+-- that answers tools/call with a text content block, so they all share the
+-- same SSE plumbing; what differs is the endpoint, the tool name, the
+-- argument names, and how a key rides along when the user has one.
+
+local EXA_ENDPOINT = "https://mcp.exa.ai/mcp"
+local YOUCOM_ENDPOINT = "https://api.you.com/mcp"
+local YOUCOM_FREE_ENDPOINT = "https://api.you.com/mcp?profile=free"
+
+-- An exported but empty variable is still truthy in lua, and a blank key
+-- means an `Authorization: Bearer ` header and a 401 instead of the keyless
+-- path that would have worked.
+local function env_key(name)
+  local value = maki.uv.os_getenv(name)
+  local key = value and value:match("^%s*(.-)%s*$")
+  if key == "" then
+    return nil
+  end
+  return key
+end
+
+local PROVIDERS = {
+  exa = {
+    api_key = function()
+      return env_key("EXA_API_KEY")
+    end,
+    endpoint = function()
+      return EXA_ENDPOINT
+    end,
+    tool = "web_search_exa",
+    description = "Search the web for real-time information using Exa AI.",
+    arguments = function(query, num_results)
+      return {
+        query = query,
+        numResults = num_results,
+        type = "auto",
+        livecrawl = "fallback",
+      }
+    end,
+    headers = function(api_key)
+      if not api_key then
+        return {}
+      end
+      return { ["x-api-key"] = api_key }
+    end,
+  },
+  youcom = {
+    api_key = function()
+      return env_key("YDC_API_KEY")
+    end,
+    -- Keyless the request rides the free profile; with YDC_API_KEY set it
+    -- goes to the authenticated server and carries the bearer token.
+    endpoint = function(api_key)
+      return api_key and YOUCOM_ENDPOINT or YOUCOM_FREE_ENDPOINT
+    end,
+    tool = "you-search",
+    description = "Search the web for real-time information using You.com.",
+    arguments = function(query, num_results)
+      return {
+        query = query,
+        count = num_results,
+      }
+    end,
+    headers = function(api_key)
+      if not api_key then
+        return {}
+      end
+      return { ["Authorization"] = "Bearer " .. api_key }
+    end,
+  },
+}
+
+return PROVIDERS

--- a/plugins/websearch/tests/spec.lua
+++ b/plugins/websearch/tests/spec.lua
@@ -1,5 +1,7 @@
 local parse_sse_response = require("parse_sse")
 local NO_RESULTS_MSG = "No search results found"
+local API_KEY = "ydc-test-key"
+local RATE_LIMIT_MSG = "rate limit exceeded"
 
 local failures = {}
 
@@ -86,6 +88,81 @@ end)
 case("parse_sse_only_no_result_lines_returns_no_results", function()
   local body = sse_line({ id = 1, method = "something" })
   eq(parse_sse_response(body), NO_RESULTS_MSG)
+end)
+
+case("parse_sse_jsonrpc_error_is_error", function()
+  local body = sse_line({ id = 1, error = { code = -32000, message = RATE_LIMIT_MSG } })
+  local text, err = parse_sse_response(body)
+  eq(text, nil, "a jsonrpc error must not read as no results")
+  assert(err and err:find(RATE_LIMIT_MSG, 1, true), "should surface the server message, got: " .. tostring(err))
+end)
+
+case("parse_sse_tool_is_error_is_error", function()
+  local body = sse_line({
+    result = { isError = true, content = { { type = "text", text = RATE_LIMIT_MSG } } },
+  })
+  local text, err = parse_sse_response(body)
+  eq(text, nil, "an isError result must not read as a search result")
+  assert(err and err:find(RATE_LIMIT_MSG, 1, true), "should surface the tool message, got: " .. tostring(err))
+end)
+
+-- ── providers ──
+
+local providers = require("providers")
+
+case("providers_exa_shape", function()
+  local p = providers.exa
+  assert(p, "exa provider should exist")
+  eq(p.endpoint(), "https://mcp.exa.ai/mcp")
+  eq(p.tool, "web_search_exa")
+  local args = p.arguments("rust async runtime", 5)
+  eq(args.query, "rust async runtime")
+  eq(args.numResults, 5)
+  eq(args.type, "auto")
+  eq(args.livecrawl, "fallback")
+end)
+
+case("providers_youcom_shape", function()
+  local p = providers.youcom
+  assert(p, "youcom provider should exist")
+  eq(p.tool, "you-search")
+  local args = p.arguments("rust async runtime", 5)
+  eq(args.query, "rust async runtime")
+  eq(args.count, 5)
+  assert(args.numResults == nil, "youcom should not carry exa's numResults")
+end)
+
+case("providers_headers_follow_the_key", function()
+  eq(providers.exa.headers(nil)["x-api-key"], nil)
+  eq(providers.exa.headers(API_KEY)["x-api-key"], API_KEY)
+  eq(providers.youcom.headers(nil)["Authorization"], nil)
+  eq(providers.youcom.headers(API_KEY)["Authorization"], "Bearer " .. API_KEY)
+end)
+
+case("providers_youcom_endpoint_follows_the_key", function()
+  eq(providers.youcom.endpoint(nil), "https://api.you.com/mcp?profile=free")
+  eq(providers.youcom.endpoint(API_KEY), "https://api.you.com/mcp")
+end)
+
+case("providers_api_key_is_never_blank", function()
+  -- An exported but empty variable is truthy in lua; treating it as a key
+  -- would send "Bearer " and pick the authenticated endpoint over the free
+  -- profile. Holds whether or not the vars are set in this environment.
+  for name, p in pairs(providers) do
+    local key = p.api_key()
+    assert(key == nil or (type(key) == "string" and #key > 0), name .. " api_key should be nil or non-empty")
+  end
+end)
+
+case("providers_youcom_response_is_parse_sse_compatible", function()
+  -- The youcom MCP server answers tools/call with SSE data: lines whose
+  -- result.content[1].text carries the JSON results, the same shape
+  -- parse_sse_response already extracts for exa.
+  local body = "event: message\n"
+    .. make_sse('{"results":{"web":[{"url":"https://example.com","title":"Example","description":"A page"}]}}')
+    .. "\n"
+  local text = parse_sse_response(body)
+  assert(text:find("example.com", 1, true), "youcom result payload should round-trip through parse_sse_response")
 end)
 
 if #failures > 0 then

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -302,6 +302,7 @@ maki.setup({
 | `max_output_bytes` | integer | - | - | Override `agent.max_output_bytes` for this tool. |
 | `max_output_lines` | integer | - | - | Override `agent.max_output_lines` for this tool. |
 | `max_response_bytes` | integer | `5242880` | 1024 | Stop reading a response after this many bytes. |
+| `provider` | string | `"exa"` | - | Search backend: "exa" (default) or "youcom" (You.com MCP). |
 
 ## Validation
 


### PR DESCRIPTION
The bundled `websearch` tool was pinned to exa's MCP endpoint, with no way to point it anywhere else. This adds a second backend behind a `provider` option, following the plugin's existing `register_options` surface.

## What changed

- `plugins/websearch/providers.lua` (new): a table of backends. Each one carries the endpoint, MCP tool name, argument mapping, and auth header builder. Exa is verbatim what used to live inline in `init.lua`; youcom maps `query`/`num_results` to `you-search`'s `query`/`count`.
- `plugins/websearch/init.lua`: picks the backend from `plugins.websearch.provider` (default `"exa"`, so existing configs behave identically). An unknown value fails the plugin load loudly, same contract as every other option. The tool description now names the active backend so the model knows what it is calling.
- Docs: regenerated with `just gen-docs`, so the `provider` row lands in the generated configuration table.
- Tests: five provider cases in the plugin spec (shape of both backends, keyless endpoint resolution, youcom payloads round-tripping through the existing `parse_sse_response`), plus two host tests covering end-to-end option selection through `definitions()` and the loud-failure path.

## Why youcom fits without new plumbing

You.com also serves MCP over HTTP with SSE responses, and its `tools/call` result has the exact shape `parse_sse_response` already extracts: a `data:` line whose `result.content[1].text` carries the results JSON. I verified this against the live endpoint before writing any code. So the whole backend is 20 lines of table, no new request or parsing paths.

Keyless it rides `https://api.you.com/mcp?profile=free`, so it works with no API key at all. With `YDC_API_KEY` in the environment it sends `Authorization: Bearer ...` to the authenticated server instead, mirroring how exa picks up `EXA_API_KEY`.

## Setup

```lua
-- ~/.config/maki/init.lua
maki.setup({
  plugins = {
    websearch = { provider = "youcom" },
  },
})
```

Optional, keyless by default: `export YDC_API_KEY=...` for the authenticated profile (key at you.com/platform/api-keys).

## Validation

- `cargo test -p maki-lua --test spec` — 13/13 plugin specs pass
- `cargo test -p maki-lua --test plugin_host websearch` — both new tests pass
- `cargo clippy -p maki-lua --tests -- -D warnings` — clean
- `cargo fmt --all -- --check` and `stylua --check plugins/` — clean
- `cargo run -p maki-docgen -- --check` — all 7 pages ok
- Live `tools/call` against the free profile confirmed the request/response shape (query + count → SSE text content)
- One caveat, stated plainly: the two `pack::tests` failures on my machine reproduce on a pristine `main` checkout too, so they are environmental, not from this change.

Failure handling is unchanged: transport errors, non-2xx statuses (with a 200-byte preview), and SSE parse errors all come back as `error:` tool outputs, and truncation via the existing output limits still applies.

Happy to adjust the shape if you would rather see this as a dynamic provider script or keep the backend list closed to exa only.

I used AI to help write the tests and this message.