### PR TITLE
fix(providers): treat OpenCode Go's MissingSessionID as context overflow

### DIFF
--- a/maki-providers/src/error.rs
+++ b/maki-providers/src/error.rs
@@ -67,6 +67,17 @@ impl AgentError {
     /// - Mistral:    400 "too large for model with X maximum context length"  <https://docs.mistral.ai/resources/known-limitations>
     /// - OpenRouter: 400 "endpoint's maximum context length is X tokens"  <https://openrouter.ai/docs/api/reference/errors-and-debugging.mdx>
     /// - Synthetic:  400 pass-through from upstream models (OpenAI-compatible)  <https://synthetic.new>
+    /// - OpenCode Go: 400 `MissingSessionID`, worded as a missing-header
+    ///   problem rather than a size one -- in practice this is what their
+    ///   gateway does with a compaction request for a very large session
+    ///   (megabytes of previously-cached history sent in one uncached body),
+    ///   not a genuine header bug: maki always sets `x-opencode-session` (see
+    ///   `providers::opencode::QUIRKS`), and the same session id keeps
+    ///   working for every ordinary turn right up until compaction has to
+    ///   send the whole history at once. Treating it as overflow lets
+    ///   compaction's existing shrink-and-retry handle this the same way it
+    ///   already does every other provider's real overflow error, instead of
+    ///   surfacing a confusing dead end. <https://github.com/tontinton/maki/issues/935>
     pub fn is_context_overflow(&self) -> bool {
         match self {
             Self::Api { status: 413, .. } => true,
@@ -76,6 +87,9 @@ impl AgentError {
                 ..
             } => {
                 let m = message.to_lowercase();
+                if m.contains("missingsessionid") {
+                    return true;
+                }
                 // `Invalid 'max_tokens': integer above maximum value` reads as
                 // "token" plus "maximum" and would sail through the sniff
                 // below, but the caller answers an overflow by summarizing the
@@ -362,6 +376,10 @@ mod tests {
     #[test_case(400, "Invalid 'max_tokens': integer above maximum value. Expected a value <= 32768", false ; "openai_max_tokens_cap")]
     #[test_case(400, "max_completion_tokens is too large: 100000", false                                  ; "openai_max_completion_tokens_cap")]
     #[test_case(400, "max_output_tokens exceeds the model maximum", false                                 ; "max_output_tokens_cap")]
+    // OpenCode Go: https://github.com/tontinton/maki/issues/935 -- worded as
+    // a missing-header error, but the header is always sent; this is their
+    // gateway's response to a compaction request too large to route.
+    #[test_case(400, r#"{"type":"error","error":{"type":"MissingSessionID","message":"Error from provider (Console Go): Request is missing x-opencode-session and cannot be routed efficiently. Please see https://opencode.ai/docs/go/#where-can-i-use-it"}}"#, true ; "opencode_missing_session_id")]
     fn is_context_overflow(status: u16, message: &str, expected: bool) {
         assert_eq!(api_msg(status, message).is_context_overflow(), expected);
     }


### PR DESCRIPTION
## What

`/compact` on a very large session against OpenCode Go can fail with:

```
API error (400): {"type":"error","error":{"type":"MissingSessionID","message":"Error from provider (Console Go): Request is missing x-opencode-session and cannot be routed efficiently. Please see https://opencode.ai/docs/go/#where-can-i-use-it"}}
```

even though the header is always being sent (`providers::opencode::QUIRKS` applies `x-opencode-session` to every request), and ordinary chat turns on the same session keep working fine right up until this happens.

## Why

Regular turns stay small thanks to prompt caching, but `/compact` has to serialize the entire, previously-cached history into one uncached request body. On a large enough session (confirmed against a real 613K-token session log) that request is big enough that OpenCode Go's gateway rejects it -- it just words the rejection as a missing-header problem instead of a size problem.

`AgentError::is_context_overflow()` gates compaction's existing shrink-and-retry loop (`collapse_tool_results` / `truncate_oldest_round` in `maki-agent/src/agent/compaction.rs`), which already handles this exact situation for every other provider's real overflow error. It just didn't recognize OpenCode's specific phrasing, so for OpenCode Go the raw, confusing error surfaced straight to the user instead.

## Fix

Teach `is_context_overflow()` to treat a 400 `MissingSessionID` body as an overflow signal, so compaction's normal shrink-and-retry handles it the same way it already does for Anthropic/OpenAI/Gemini/etc.

Related to #935 / #936, which fixed the header itself -- this is a separate, later-observed gap: the header was already correct, but large-session `/compact` still broke because the error message wasn't recognized as an overflow.

## Testing

Added a `test_case` to the existing `is_context_overflow` parameterized test using the exact real error message from the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
