### PR TITLE
feat(ui): render inline images in supported terminals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -303,7 +303,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -329,7 +329,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -438,6 +438,16 @@ name = "base64"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bincode"
@@ -582,6 +592,20 @@ name = "bytemuck"
 version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "byteorder"
@@ -933,7 +957,7 @@ dependencies = [
  "derive_more",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1508,7 +1532,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1660,7 +1684,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-link",
 ]
 
@@ -1941,7 +1965,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2033,6 +2057,16 @@ dependencies = [
  "zerofrom",
  "zerotrie",
  "zerovec",
+]
+
+[[package]]
+name = "icy_sixel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfb5a63225620b59df34a235d1fb56ff7b766909c3212a8ff927511a22b181d"
+dependencies = [
+ "quantette",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2569,6 +2603,12 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -2815,7 +2855,7 @@ dependencies = [
  "mlua",
  "pin-project-lite",
  "regex",
- "rustix",
+ "rustix 1.1.4",
  "semver",
  "serde",
  "serde_json",
@@ -2999,6 +3039,7 @@ dependencies = [
  "nucleo-matcher",
  "open",
  "ratatui",
+ "ratatui-image",
  "serde",
  "serde_json",
  "shell-words",
@@ -3437,6 +3478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3615,6 +3657,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c860fd3227ca4ac3cc032e2cd20cba3f02ccdf4b610538f8ee6584d56bb62e96"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3662,6 +3713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
 dependencies = [
  "approx",
+ "bytemuck",
  "fast-srgb8",
  "libm",
  "palette_derive",
@@ -3815,7 +3867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -3979,7 +4031,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4158,6 +4210,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "quantette"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5d37e94c17b8870a5b936001d2845a6782a22ebdb1706c84294eca777f6729"
+dependencies = [
+ "bitvec",
+ "bytemuck",
+ "libm",
+ "num-traits",
+ "ordered-float 5.4.0",
+ "palette",
+ "rand 0.10.2",
+ "rand_xoshiro",
+ "ref-cast",
+ "wide",
+]
+
+[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4238,7 +4308,16 @@ checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4248,7 +4327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4258,6 +4337,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662effc7698e08ea324d3acccf8d9d7f7bf79b9785e270a174ea36e56900c91d"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4308,6 +4402,23 @@ dependencies = [
  "crossterm",
  "instability",
  "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-image"
+version = "11.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399baa06251282b0c1bbb5762848cf98a6b7b84f44af7f0daf3213ace16df4f0"
+dependencies = [
+ "base64-simd",
+ "icy_sixel",
+ "image",
+ "rand 0.8.7",
+ "ratatui",
+ "rustix 0.38.44",
+ "self_cell",
+ "thiserror 1.0.69",
+ "windows",
 ]
 
 [[package]]
@@ -4585,6 +4696,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -4592,7 +4716,7 @@ dependencies = [
  "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4607,6 +4731,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42c6efa15875e6ecb39ca61fb0b0c1a40b84fac5a5ffe71eef7d1000c8eb3f5f"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -4710,6 +4843,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -5188,7 +5327,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5209,7 +5348,7 @@ checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
 dependencies = [
  "bitflags 2.13.1",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "windows-sys 0.61.2",
 ]
@@ -6057,7 +6196,7 @@ dependencies = [
  "getopts",
  "log",
  "phf_codegen 0.11.3",
- "rand",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -6240,7 +6379,7 @@ checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "rustix 1.1.4",
  "smallvec",
  "wayland-sys",
 ]
@@ -6252,7 +6391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags 2.13.1",
- "rustix",
+ "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -6413,6 +6552,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf05ca94c9fba0c51316899caa1d1e74a064fc310a5efa7375e614343d415be"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6444,16 +6593,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6461,6 +6644,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6499,11 +6693,30 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6517,11 +6730,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -6535,20 +6757,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -6558,9 +6802,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6570,9 +6826,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6582,15 +6850,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6631,7 +6917,7 @@ dependencies = [
  "libc",
  "log",
  "os_pipe",
- "rustix",
+ "rustix 1.1.4",
  "thiserror 2.0.18",
  "tree_magic_mini",
  "wayland-backend",
@@ -6662,7 +6948,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 
@@ -6742,7 +7028,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ serde_json = "1"
 bs58 = "0.5"
 uuid = { version = "1", default-features = false, features = ["std", "v7"] }
 ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
+ratatui-image = { version = "11.0.8", default-features = false, features = ["crossterm"] }
 crossterm = { version = "0.29", features = ["osc52"] }
 color-eyre = { version = "0.6", default-features = false, features = ["track-caller"] }
 termini = "1"

--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -2,7 +2,8 @@ use std::env;
 
 use maki_config::{AgentConfig, CompactionBuffer};
 use maki_providers::{
-    ContentBlock, Message, Model, RequestOptions, Role, StreamResponse, TokenUsage,
+    ContentBlock, IMAGE_PLACEHOLDER, Message, Model, RequestOptions, Role, StreamResponse,
+    TokenUsage,
 };
 use maki_storage::id::SessionRef;
 use tracing::info;
@@ -14,7 +15,6 @@ use crate::prompt::COMPACTION_USER;
 use crate::{AgentError, AgentEvent, DoneReason, EventSender, TurnCompleteEvent};
 
 const CONTINUE_AFTER_COMPACT: &str = "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed. If the summary contains a todo list, restore it with todo_write and keep it updated. If you learned important project context during this session, consider saving it to memory before it's lost.";
-const IMAGE_PLACEHOLDER: &str = "[image]";
 const TOOL_RESULT_PLACEHOLDER: &str = "[tool result]";
 /// How much of the newest tool output survives a compaction verbatim. This
 /// used to be a count, which kept three huge results and threw away thirty

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -7,7 +7,8 @@ use tracing::{error, info, warn};
 
 use maki_providers::provider::Provider;
 use maki_providers::{
-    ContentBlock, Message, Model, RequestOptions, Role, StopReason, StreamResponse, TokenUsage,
+    ContentBlock, IMAGE_PLACEHOLDER, Message, Model, RequestOptions, Role, StopReason,
+    StreamResponse, TokenUsage,
 };
 
 use super::compaction;
@@ -687,7 +688,7 @@ impl<'h> Agent<'h> {
                 for input in inputs {
                     self.event_tx.send(AgentEvent::QueueItemConsumed {
                         text: input.message.clone(),
-                        image_count: input.images.len(),
+                        images: input.images.clone(),
                     })?;
                     self.push_input_context(input.preamble);
                     self.mode = input.mode;
@@ -696,7 +697,13 @@ impl<'h> Agent<'h> {
                         input.message
                     );
                     self.history.push(Message {
-                        display_text: Some(input.message),
+                        display_text: Some(
+                            if input.message.is_empty() && !input.images.is_empty() {
+                                IMAGE_PLACEHOLDER.into()
+                            } else {
+                                input.message
+                            },
+                        ),
                         ..Message::user_with_images(wrapped, input.images)
                     });
                 }

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -7,7 +7,8 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use flume::{Receiver, Sender};
 use maki_config::ToolKey;
 use maki_providers::{
-    AgentError, ContentBlock, Message, RequestOptions, Role, StopReason, TokenUsage, add_cost,
+    AgentError, ContentBlock, ImageSource, Message, RequestOptions, Role, StopReason, TokenUsage,
+    add_cost,
 };
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
@@ -622,7 +623,7 @@ pub enum AgentEvent {
     },
     QueueItemConsumed {
         text: String,
-        image_count: usize,
+        images: Vec<ImageSource>,
     },
     QueueDrained,
     Done {

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -474,6 +474,7 @@ pub struct PluginFileConfig {
 pub struct UiFileConfig {
     pub splash_animation: Option<bool>,
     pub scrollbar: Option<bool>,
+    pub inline_images: Option<bool>,
     pub notifications: Option<NotificationMethod>,
     pub flash_duration_ms: Option<u64>,
     pub typewriter_ms_per_char: Option<u64>,
@@ -492,6 +493,7 @@ impl UiFileConfig {
             overlay,
             splash_animation,
             scrollbar,
+            inline_images,
             notifications,
             flash_duration_ms,
             typewriter_ms_per_char,
@@ -1013,6 +1015,12 @@ pub struct UiConfig {
     pub scrollbar: bool,
 
     #[config(
+        default = true,
+        desc = "Render inline images in terminals with graphics support, falling back to an [image] line when off"
+    )]
+    pub inline_images: bool,
+
+    #[config(
         default = NotificationMethod::Auto,
         ty = "string",
         default_doc = "auto",
@@ -1057,6 +1065,7 @@ impl UiConfig {
         Self {
             splash_animation: f.splash_animation.unwrap_or(true),
             scrollbar: f.scrollbar.unwrap_or(true),
+            inline_images: f.inline_images.unwrap_or(true),
             notifications: f.notifications.unwrap_or_default(),
             flash_duration_ms: f.flash_duration_ms.unwrap_or(DEFAULT_FLASH_DURATION_MS),
             typewriter_ms_per_char: f

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -26,8 +26,8 @@ pub use providers::dynamic;
 pub use providers::openai::auth as openai_auth;
 pub use providers::xai::auth as xai_auth;
 pub use types::{
-    ContentBlock, EMPTY_RESPONSE_MARKER, Effort, EffortDialect, IMAGE_OMITTED_NOTE, ImageMediaType,
-    ImageSource, Message, MessageKind, ModelUsageRow, ProviderEvent, ProviderUsage, RequestOptions,
-    Role, StopReason, StreamResponse, THINKING_USAGE, ThinkingConfig, UsageLimit,
-    adapt_images_for_model, dialect,
+    ContentBlock, EMPTY_RESPONSE_MARKER, Effort, EffortDialect, IMAGE_OMITTED_NOTE,
+    IMAGE_PLACEHOLDER, ImageMediaType, ImageSource, Message, MessageKind, ModelUsageRow,
+    ProviderEvent, ProviderUsage, RequestOptions, Role, StopReason, StreamResponse, THINKING_USAGE,
+    ThinkingConfig, UsageLimit, adapt_images_for_model, dialect,
 };

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -110,6 +110,9 @@ impl ImageSource {
 
 pub const IMAGE_OMITTED_NOTE: &str =
     "[image omitted: the current model does not support image input]";
+/// Stands in for the text of a message that carries only images, both in model
+/// context and in the transcript. One const so the two can never drift apart.
+pub const IMAGE_PLACEHOLDER: &str = "[image]";
 /// See [`Message::empty_marker`].
 pub const EMPTY_RESPONSE_MARKER: &str = "(empty)";
 

--- a/maki-ui/Cargo.toml
+++ b/maki-ui/Cargo.toml
@@ -13,6 +13,7 @@ maki-providers = { workspace = true }
 maki-lua = { workspace = true }
 maki-storage = { workspace = true }
 ratatui = { workspace = true }
+ratatui-image = { workspace = true }
 crossterm = { workspace = true }
 color-eyre = { workspace = true }
 tracing = { workspace = true }
@@ -30,7 +31,7 @@ arc-swap = { workspace = true }
 getrandom = { workspace = true }
 futures-lite = { workspace = true }
 wait-timeout = { workspace = true }
-image = { workspace = true }
+image = { workspace = true, features = ["jpeg", "gif", "webp"] }
 base64 = { workspace = true }
 nucleo = { workspace = true }
 nucleo-matcher = { workspace = true }

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -137,7 +137,7 @@ impl AgentLoop {
                         if !queued.displayed {
                             let _ = event_tx.send(AgentEvent::QueueItemConsumed {
                                 text: queued.text,
-                                image_count: queued.image_count,
+                                images: queued.input.images.clone(),
                             });
                         }
                         queued.input

--- a/maki-ui/src/agent/shared_queue.rs
+++ b/maki-ui/src/agent/shared_queue.rs
@@ -39,7 +39,6 @@ impl From<Submission> for QueuedMessage {
 
 pub(crate) struct QueuedInput {
     pub(crate) text: String,
-    pub(crate) image_count: usize,
     pub(crate) input: AgentInput,
     pub(crate) run_id: u64,
     /// `true` when the UI already drew the bubble (immediate dispatch).
@@ -334,7 +333,6 @@ mod tests {
     fn queued(text: &str, run_id: u64) -> QueuedInput {
         QueuedInput {
             text: text.into(),
-            image_count: 0,
             input: input(text),
             run_id,
             displayed: false,

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -1044,7 +1044,7 @@ impl App {
             let id = self.shell.reserve_id();
             let sigil = if prefix.visible { "!" } else { "!!" };
             let display = format!("{sigil} {}", prefix.command);
-            self.main_chat().show_user_message(display);
+            self.main_chat().show_user_message(display, Vec::new());
             return vec![Action::ShellCommand {
                 id,
                 command: prefix.command,
@@ -1235,9 +1235,9 @@ impl App {
         };
         let result = self.chats[chat_idx].handle_event(envelope.event, plan_path);
 
-        if let ChatEventResult::QueueItemConsumed { text, image_count } = result {
+        if let ChatEventResult::QueueItemConsumed { text, images } = result {
             if chat_idx == 0 {
-                self.on_queue_item_consumed(&text, image_count);
+                self.on_queue_item_consumed(text, images);
             }
             return vec![];
         }
@@ -1886,12 +1886,4 @@ fn sync_search_highlight(modal: &SearchModal, chat: &mut Chat) {
         chat.scroll_to_segment(i);
     }
     chat.set_highlight_segment(idx);
-}
-
-fn format_with_images(text: &str, image_count: usize) -> String {
-    match image_count {
-        0 => text.to_string(),
-        1 => format!("{text} [1 image]"),
-        n => format!("{text} [{n} images]"),
-    }
 }

--- a/maki-ui/src/app/queue.rs
+++ b/maki-ui/src/app/queue.rs
@@ -1,8 +1,8 @@
 //! Queue for messages typed while the agent is busy.
 
-use maki_agent::AgentInput;
+use maki_agent::{AgentInput, ImageSource};
 
-use super::{Action, App, Status, format_with_images};
+use super::{Action, App, Status};
 
 use crate::agent::shared_queue::{Compaction, QueueItem, QueueSender, QueuedInput};
 use crate::components::queue_panel::QueueEntry;
@@ -158,7 +158,6 @@ impl App {
         let input = self.build_agent_input(&msg);
         shared.push(QueueItem::Message(QueuedInput {
             text: msg.text,
-            image_count: msg.images.len(),
             input,
             run_id: self.run_id,
             displayed: false,
@@ -197,18 +196,16 @@ impl App {
     /// queue items start runs without `start_run`, so this is where the app
     /// learns the agent is busy. Immediate-dispatch items skip this event,
     /// so no dedup needed.
-    pub(super) fn on_queue_item_consumed(&mut self, text: &str, image_count: usize) {
+    pub(super) fn on_queue_item_consumed(&mut self, text: String, images: Vec<ImageSource>) {
         self.status = Status::Streaming;
-        self.main_chat()
-            .show_user_message(format_with_images(text, image_count));
+        self.main_chat().show_user_message(text, images);
     }
 
     /// Immediate path: kick off the agent and draw the bubble in the same
     /// frame, so the user sees their message land where it will stay.
     pub(super) fn start_from_queue(&mut self, msg: &QueuedMessage) -> Vec<Action> {
-        let display = format_with_images(&msg.text, msg.images.len());
         let input = self.build_agent_input(msg);
-        self.start_run(input, display)
+        self.start_run(input, msg.text.clone())
     }
 
     pub(crate) fn start_mailbox_run(
@@ -233,8 +230,9 @@ impl App {
         self.recoverable_queue.clear();
         self.status = Status::Streaming;
         self.fire_session_autocmd("TurnStart", serde_json::json!({}));
-        if !display.is_empty() {
-            self.main_chat().show_user_message(display);
+        if !display.is_empty() || !input.images.is_empty() {
+            self.main_chat()
+                .show_user_message(display, input.images.clone());
         }
         vec![Action::SendMessage(Box::new(input))]
     }

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -560,7 +560,7 @@ fn queue_item_consumed_pushes_deferred_user_message() {
     app.update(agent_msg_with_run_id(
         AgentEvent::QueueItemConsumed {
             text: "queued".into(),
-            image_count: 0,
+            images: Vec::new(),
         },
         app.run_id,
     ));
@@ -584,7 +584,7 @@ fn queue_item_consumed_marks_agent_streaming() {
     app.update(agent_msg_with_run_id(
         AgentEvent::QueueItemConsumed {
             text: "restored".into(),
-            image_count: 0,
+            images: Vec::new(),
         },
         app.run_id,
     ));
@@ -1595,7 +1595,7 @@ fn page_keys_scroll_the_transcript_by_one_page() {
     let backend = ratatui::backend::TestBackend::new(area.width, area.bottom());
     let mut terminal = ratatui::Terminal::new(backend).unwrap();
     terminal
-        .draw(|frame| app.active_chat().view(frame, area, false))
+        .draw(|frame| app.active_chat().view(frame, area, false, true))
         .unwrap();
     let down = app.active_chat().win_view();
     assert_eq!(
@@ -1695,7 +1695,7 @@ fn app_with_transcript(zone: Rect) -> App {
     let backend = ratatui::backend::TestBackend::new(zone.width, zone.bottom());
     let mut terminal = ratatui::Terminal::new(backend).unwrap();
     terminal
-        .draw(|frame| app.active_chat().view(frame, zone, false))
+        .draw(|frame| app.active_chat().view(frame, zone, false, true))
         .unwrap();
     app
 }

--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -149,7 +149,13 @@ impl App {
     fn render_messages(&mut self, frame: &mut Frame, layout: &ViewLayout, render_chat: usize) {
         let accent = self.effective_mode_color();
         self.chats[render_chat].set_accent(accent);
-        self.chats[render_chat].view(frame, layout.msg_area, self.selection_state.is_some());
+        let images_visible = !self.any_overlay_open();
+        self.chats[render_chat].view(
+            frame,
+            layout.msg_area,
+            self.selection_state.is_some(),
+            images_visible,
+        );
     }
 
     fn render_bottom_panel(&mut self, frame: &mut Frame, layout: &ViewLayout) -> Option<Position> {

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -16,7 +16,7 @@ use maki_agent::tools::{MAIN_TASK_ID, ToolInvocation, ToolRegistry, WRITE_TOOL_N
 use maki_agent::{AgentEvent, BufferSnapshot, ToolDoneEvent, ToolOutput, ToolStartEvent};
 use maki_config::{ToolKey, ToolOutputLines, UiConfig};
 use maki_lua::WinView;
-use maki_providers::{ContentBlock, Message, RequestOptions, Role};
+use maki_providers::{ContentBlock, ImageSource, Message, RequestOptions, Role};
 use maki_storage::id::MakiId;
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -36,7 +36,7 @@ pub enum ChatEventResult {
     Done,
     QueueItemConsumed {
         text: String,
-        image_count: usize,
+        images: Vec<ImageSource>,
     },
     Error(String),
     PermissionRequest {
@@ -142,7 +142,18 @@ impl Chat {
                         .push(DisplayMessage::plan(content, pp.display().to_string()));
                 }
             }
-            AgentEvent::TurnComplete(_) => {}
+            AgentEvent::TurnComplete(turn) => {
+                for block in turn.message.content {
+                    if let ContentBlock::Image { source } = block {
+                        self.messages_panel.flush();
+                        self.messages_panel.push(DisplayMessage::with_images(
+                            DisplayRole::Assistant,
+                            String::new(),
+                            vec![source],
+                        ));
+                    }
+                }
+            }
             AgentEvent::ToolResultsSubmitted { .. } => {
                 if let Some(usage) = self.pending_turn_usage.take() {
                     self.messages_panel.set_turn_usage_on_last_tool(usage);
@@ -158,8 +169,8 @@ impl Chat {
             AgentEvent::CompactionDone { .. } => {
                 self.messages_panel.flush();
             }
-            AgentEvent::QueueItemConsumed { text, image_count } => {
-                return ChatEventResult::QueueItemConsumed { text, image_count };
+            AgentEvent::QueueItemConsumed { text, images } => {
+                return ChatEventResult::QueueItemConsumed { text, images };
             }
             AgentEvent::QueueDrained => {}
             AgentEvent::Retry { .. } => unreachable!("handled before handle_event"),
@@ -277,8 +288,15 @@ impl Chat {
         self.messages_panel.cadence()
     }
 
-    pub fn view(&mut self, frame: &mut Frame, area: Rect, has_selection: bool) {
-        self.messages_panel.view(frame, area, has_selection);
+    pub fn view(
+        &mut self,
+        frame: &mut Frame,
+        area: Rect,
+        has_selection: bool,
+        images_visible: bool,
+    ) {
+        self.messages_panel
+            .view(frame, area, has_selection, images_visible);
     }
 
     pub fn scroll_pos(&self) -> ScrollPos {
@@ -396,9 +414,13 @@ impl Chat {
 
     /// Flush, push, and re-pin scroll in one shot to avoid
     /// the one-frame hop where the bubble briefly lands in the wrong row.
-    pub fn show_user_message(&mut self, text: impl Into<String>) {
+    pub fn show_user_message(&mut self, text: impl Into<String>, images: Vec<ImageSource>) {
         self.flush();
-        self.push_user_message(text);
+        self.messages_panel.push(DisplayMessage::with_images(
+            DisplayRole::User,
+            text.into(),
+            images,
+        ));
         self.enable_auto_scroll();
     }
 
@@ -474,8 +496,19 @@ pub fn history_to_display(
         }
         match msg.role {
             Role::User => {
-                if let Some(text) = msg.user_text() {
-                    display.push(DisplayMessage::new(DisplayRole::User, text.to_owned()));
+                // An empty `display_text` marks a message the transcript never
+                // shows, so its attachments must not sneak in either.
+                if msg.display_text.as_deref() == Some("") {
+                    continue;
+                }
+                let images = user_images(msg);
+                let text = msg.user_text();
+                if text.is_some() || !images.is_empty() {
+                    display.push(DisplayMessage::with_images(
+                        DisplayRole::User,
+                        text.unwrap_or_default().to_owned(),
+                        images,
+                    ));
                 }
             }
             Role::Assistant => {
@@ -483,6 +516,13 @@ pub fn history_to_display(
                     match block {
                         ContentBlock::Text { text } if !text.is_empty() => {
                             display.push(DisplayMessage::new(DisplayRole::Assistant, text.clone()));
+                        }
+                        ContentBlock::Image { source } => {
+                            display.push(DisplayMessage::with_images(
+                                DisplayRole::Assistant,
+                                String::new(),
+                                vec![source.clone()],
+                            ));
                         }
                         ContentBlock::Thinking { thinking, .. } if !thinking.is_empty() => {
                             display
@@ -555,6 +595,7 @@ pub fn history_to_display(
                                     name: static_name.into(),
                                 })),
                                 text,
+                                images: Vec::new(),
                                 tool_input: None,
                                 tool_raw_input: Some(Arc::new(input.clone())),
                                 tool_output,
@@ -649,6 +690,25 @@ fn build_loaded_tool(
     }
 }
 
+/// Images the user attached. A tool result also rides in a user message, and
+/// its images already render under the tool itself, so those stay out.
+fn user_images(msg: &Message) -> Vec<ImageSource> {
+    if msg
+        .content
+        .iter()
+        .any(|block| matches!(block, ContentBlock::ToolResult { .. }))
+    {
+        return Vec::new();
+    }
+    msg.content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Image { source } => Some(source.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
 fn build_tool_results_map(messages: &[Message]) -> HashMap<&str, (bool, &str)> {
     let mut map = HashMap::new();
     for msg in messages {
@@ -672,9 +732,123 @@ fn build_tool_results_map(messages: &[Message]) -> HashMap<&str, (bool, &str)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use maki_agent::{AgentEvent, ToolDoneEvent, ToolOutput, ToolStartEvent};
+    use crate::components::IMAGE_PLACEHOLDER;
+    use maki_agent::{AgentEvent, ToolDoneEvent, ToolOutput, ToolStartEvent, TurnCompleteEvent};
     use maki_config::UiConfig;
+    use maki_providers::ImageMediaType;
     use test_case::test_case;
+
+    const IMAGE_DATA: &str = "dGVzdA==";
+    const EXPECTED_QUEUE_DELIVERY: &str = "a consumed queue item must carry its images";
+
+    fn image() -> ImageSource {
+        ImageSource::new(ImageMediaType::Png, Arc::from(IMAGE_DATA))
+    }
+
+    #[test_case(USER_TEXT, USER_TEXT ; "captioned")]
+    #[test_case("", IMAGE_PLACEHOLDER ; "image_only")]
+    fn history_delivers_images_without_synthetic_or_tool_attachments(text: &str, expected: &str) {
+        let mut hidden = Message::synthetic(USER_TEXT.into());
+        hidden.content.push(ContentBlock::Image { source: image() });
+        let mut observation = Message::observation(USER_TEXT.into());
+        observation
+            .content
+            .push(ContentBlock::Image { source: image() });
+        let tool_result = Message {
+            role: Role::User,
+            content: vec![
+                ContentBlock::ToolResult {
+                    tool_use_id: TASK_ID.into(),
+                    content: USER_TEXT.into(),
+                    is_error: false,
+                },
+                ContentBlock::Image { source: image() },
+            ],
+            ..Default::default()
+        };
+        let assistant = Message {
+            role: Role::Assistant,
+            content: vec![ContentBlock::Image { source: image() }],
+            ..Default::default()
+        };
+        let (display, _) = history_to_display(
+            &[
+                Message::user_with_images(text.into(), vec![image()]),
+                hidden,
+                observation,
+                tool_result,
+                assistant,
+            ],
+            &empty_outputs(),
+            &ToolOutputLines::default(),
+        );
+        assert_eq!(display.len(), 2);
+        assert_eq!(display[0].role, DisplayRole::User);
+        assert_eq!(display[0].text, expected);
+        assert_eq!(display[1].role, DisplayRole::Assistant);
+        assert_eq!(display[1].text, IMAGE_PLACEHOLDER);
+        for message in display {
+            assert_eq!(message.images.len(), 1);
+            assert_eq!(&*message.images[0].data, IMAGE_DATA);
+        }
+    }
+
+    #[test]
+    fn queued_user_images_reach_display() {
+        let mut chat = chat();
+        let result = chat.handle_event(
+            AgentEvent::QueueItemConsumed {
+                text: String::new(),
+                images: vec![image()],
+            },
+            None,
+        );
+        let ChatEventResult::QueueItemConsumed { text, images } = result else {
+            panic!("{EXPECTED_QUEUE_DELIVERY}");
+        };
+        chat.show_user_message(text, images);
+        let message = chat.message_at(0).unwrap();
+        assert_eq!(message.role, DisplayRole::User);
+        assert_eq!(message.text, IMAGE_PLACEHOLDER);
+        assert_eq!(message.images.len(), 1);
+        assert_eq!(&*message.images[0].data, IMAGE_DATA);
+    }
+
+    #[test_case("" ; "image_only")]
+    #[test_case(REPLY_TEXT ; "streamed_text")]
+    fn turn_complete_delivers_images_without_replaying_text(text: &str) {
+        let mut chat = chat();
+        text_delta(&mut chat, text);
+        chat.handle_event(
+            AgentEvent::TurnComplete(Box::new(TurnCompleteEvent {
+                message: Message {
+                    role: Role::Assistant,
+                    content: vec![
+                        ContentBlock::Text { text: text.into() },
+                        ContentBlock::Image { source: image() },
+                    ],
+                    ..Default::default()
+                },
+                usage: Default::default(),
+                model: String::new(),
+                cost: None,
+                context_size: None,
+                context_window: 0,
+            })),
+            None,
+        );
+        let image_index = usize::from(!text.is_empty());
+        assert_eq!(chat.message_count(), image_index + 1);
+        if !text.is_empty() {
+            assert_eq!(chat.message_at(0).unwrap().text, text);
+            assert!(chat.message_at(0).unwrap().images.is_empty());
+        }
+        let message = chat.message_at(image_index).unwrap();
+        assert_eq!(message.role, DisplayRole::Assistant);
+        assert_eq!(message.text, IMAGE_PLACEHOLDER);
+        assert_eq!(message.images.len(), 1);
+        assert_eq!(&*message.images[0].data, IMAGE_DATA);
+    }
 
     fn tool_start(id: &str, tool: &str) -> AgentEvent {
         AgentEvent::ToolStart(Box::new(ToolStartEvent {
@@ -1186,7 +1360,7 @@ mod tests {
         end(&mut chat, TaskOutcome::Unknown);
         let ending = chat.message_count() - 1;
 
-        chat.show_user_message(USER_TEXT);
+        chat.show_user_message(USER_TEXT, Vec::new());
         text_delta(&mut chat, REPLY_TEXT);
         chat.flush();
         let before = chat.message_count();
@@ -1261,7 +1435,7 @@ mod tests {
         status: TaskStatus,
     ) {
         let mut chat = chat();
-        chat.show_user_message(USER_TEXT);
+        chat.show_user_message(USER_TEXT, Vec::new());
         end(&mut chat, first);
         let count = chat.message_count();
 

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -17,17 +17,21 @@ use super::tool_display::{
     instructions_search_text, search_text_for, thinking_indicator, thinking_style,
     truncate_to_header, user_style,
 };
-use super::{DisplayMessage, DisplayRole, ToolRole, ToolStatus, code_view::SectionFlags};
+use super::{
+    DisplayMessage, DisplayRole, IMAGE_PLACEHOLDER, ToolRole, ToolStatus, code_view::SectionFlags,
+};
 use crate::animation::spinner_str;
 use crate::components::keybindings::key;
 use crate::markdown::{hr_line, plain_lines, text_to_lines, truncate_output};
 use crate::render_worker::RenderWorker;
 use crate::selection::{DocPos, RowPos, Selection};
 use crate::splash::{ColorTransition, Splash};
+use crate::terminal_image;
 use crate::theme;
 use crate::update;
 use crate::wrap;
 use maki_config::{ClockFormat, ToolOutputLines, UiConfig};
+use ratatui_image::picker::Picker;
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
@@ -36,8 +40,8 @@ use std::time::Instant;
 use super::scrollbar::{self, render_vertical_scrollbar};
 use super::streaming_content::StreamingContent;
 use maki_agent::{
-    BufferSnapshot, EventSender, InstructionBlock, NO_FILES_FOUND, SharedBuf, ToolDoneEvent,
-    ToolOutput, ToolStartEvent,
+    BufferSnapshot, EventSender, ImageSource, InstructionBlock, NO_FILES_FOUND, SharedBuf,
+    ToolDoneEvent, ToolOutput, ToolStartEvent,
 };
 use maki_lua::{EventHandle, WARM_TOOL_CAP, WinView};
 use maki_storage::id::{MakiId, SessionRef};
@@ -51,6 +55,8 @@ use ratatui::text::{Line, Span};
 use tracing::warn;
 
 const REFLOW_MARGIN_VIEWPORTS: u32 = 1;
+/// How far outside the drawn range an image keeps its encoded protocol.
+const IMAGE_KEEP_MARGIN_SEGMENTS: usize = 8;
 
 #[derive(Clone, Copy)]
 pub struct PromptProgress {
@@ -73,6 +79,9 @@ pub struct MessagesPanel {
     /// the row walk and clicks address the tail between frames.
     tail: Vec<(TailPart, u16)>,
     hl_worker: RenderWorker,
+    image_picker: Option<Picker>,
+    inline_images: bool,
+    image_generation: u64,
     theme_generation: u64,
     highlight_segment: Option<usize>,
     idle_splash: Splash,
@@ -129,6 +138,9 @@ impl MessagesPanel {
             cache: SegmentCache::new(),
             tail: Vec::new(),
             hl_worker: RenderWorker::new(),
+            image_picker: terminal_image::picker(ui_config.inline_images),
+            inline_images: ui_config.inline_images,
+            image_generation: terminal_image::generation(),
             theme_generation: theme::generation(),
             highlight_segment: None,
             idle_splash: Splash::new(ui_config.splash_animation),
@@ -678,6 +690,9 @@ impl MessagesPanel {
         let Some(seg) = self.cache.get(pos.seg) else {
             return self.try_toggle_collapsed_thinking(pos);
         };
+        if !seg.images.is_empty() && pos.row >= seg.text_height(width) {
+            return false;
+        }
         let Some(tool_id) = seg.tool_id.as_deref() else {
             let msg_idx = seg.msg_index;
             return self.try_toggle_cached_thinking(msg_idx, width);
@@ -767,11 +782,12 @@ impl MessagesPanel {
         msg.tool_output.as_deref()?.owned_instructions()
     }
 
-    /// Drains the highlight worker and every live tool buffer. These used to
-    /// run inside [`Self::view`], which is why a running tool had to claim it
-    /// was animating: it was the only way to keep them fed.
+    /// Drains the highlight worker, every live tool buffer and the finished
+    /// image decodes. These used to run inside [`Self::view`], which is why a
+    /// running tool had to claim it was animating: it was the only way to keep
+    /// them fed.
     pub fn tick(&mut self) -> Dirty {
-        let mut dirty = self.drain_highlights() | self.poll_live_bufs();
+        let mut dirty = self.drain_highlights() | self.poll_live_bufs() | self.refresh_images();
         if self.show_idle_splash() {
             dirty |= self.idle_splash.poll_update(update::latest_version());
         }
@@ -805,7 +821,47 @@ impl MessagesPanel {
             && self.streaming_text.is_empty()
     }
 
-    pub fn view(&mut self, frame: &mut Frame, area: Rect, has_selection: bool) {
+    /// A resume can come back to a terminal whose font size changed while we
+    /// were suspended, and the picker caches those cell metrics, so rebuild it
+    /// and drop every protocol encoded against the old ones.
+    fn refresh_images(&mut self) -> Dirty {
+        let generation = terminal_image::generation();
+        if generation == self.image_generation {
+            return Dirty::any(
+                self.cache
+                    .segments_mut()
+                    .iter_mut()
+                    .map(Segment::poll_images),
+            );
+        }
+        self.image_generation = generation;
+        self.image_picker = terminal_image::picker(self.inline_images);
+        for seg in self.cache.segments_mut() {
+            seg.release_images();
+        }
+        Dirty::YES
+    }
+
+    /// Rebuilding an encoded protocol costs a decode, a resize and, on kitty, a
+    /// retransmit of megabytes. Releasing exactly at the viewport edge would
+    /// make a one row scroll thrash, so segments just outside keep theirs.
+    fn release_images_outside(&mut self, last_drawn: usize) {
+        let keep = self.scroll.seg.saturating_sub(IMAGE_KEEP_MARGIN_SEGMENTS)
+            ..=last_drawn.saturating_add(IMAGE_KEEP_MARGIN_SEGMENTS);
+        for (i, seg) in self.cache.segments_mut().iter_mut().enumerate() {
+            if !keep.contains(&i) {
+                seg.release_images();
+            }
+        }
+    }
+
+    pub fn view(
+        &mut self,
+        frame: &mut Frame,
+        area: Rect,
+        has_selection: bool,
+        images_visible: bool,
+    ) {
         self.viewport_height = area.height;
         let width = area.width.saturating_sub(1);
         let theme_gen = theme::generation();
@@ -865,21 +921,27 @@ impl MessagesPanel {
         let viewport = Rect::new(area.x, area.y, width, area.height);
         let mut cursor = RenderCursor::new(self.scroll.row, viewport);
 
+        let mut last_drawn = self.scroll.seg;
         for (i, seg) in self
             .cache
-            .segments()
-            .iter()
+            .segments_mut()
+            .iter_mut()
             .enumerate()
             .skip(self.scroll.seg)
         {
             if cursor.past_bottom() {
                 break;
             }
-            let h = seg.height(width);
+            let h = seg.text_height(width);
             let highlight = self.highlight_segment == Some(i);
             let style = seg.tool_id.as_ref().map(|_| theme::current().tool_bg);
             cursor.render(seg.lines(), h, style, highlight, frame);
+            for image in &mut seg.images {
+                cursor.render_image(image, self.image_picker.as_ref(), images_visible, frame);
+            }
+            last_drawn = i;
         }
+        self.release_images_outside(last_drawn);
 
         let spacer_lines: [Line<'static>; 1] = [Line::default()];
         for &(part, h) in self
@@ -1408,6 +1470,7 @@ impl MessagesPanel {
 
         let seg = self.cache.get_mut(seg_idx).unwrap();
         seg.update_with_reuse(tl, &self.hl_worker);
+        seg.set_images(message_images(msg));
 
         if let Some(blocks) = instructions {
             self.upsert_instruction_segment(tool_id, &blocks);
@@ -1429,6 +1492,7 @@ impl MessagesPanel {
                 self.cache.push_spacer_if_needed();
                 let mut seg = Segment::with_tool(id.clone());
                 seg.apply_highlight(tl, &self.hl_worker);
+                seg.set_images(message_images(msg));
                 self.cache.push(seg);
                 self.cache.reserve_instructions(&id);
 
@@ -1449,7 +1513,9 @@ impl MessagesPanel {
                 }
                 let lines = build_message_lines(msg, self.viewport_width);
                 self.cache.push_spacer_if_needed();
-                self.cache.push(Segment::with_lines(lines, Some(i)));
+                let mut seg = Segment::with_lines(lines, Some(i));
+                seg.set_images(message_images(msg));
+                self.cache.push(seg);
             }
         }
         self.cache.mark_built(self.messages.len());
@@ -1568,6 +1634,16 @@ impl MessagesPanel {
     }
 }
 
+fn message_images(msg: &DisplayMessage) -> impl Iterator<Item = ImageSource> + '_ {
+    msg.images
+        .iter()
+        .chain(match msg.tool_output.as_deref() {
+            Some(ToolOutput::Image { source, .. }) => Some(source),
+            _ => None,
+        })
+        .cloned()
+}
+
 fn message_style(role: &DisplayRole) -> RoleStyle {
     match role {
         DisplayRole::User => user_style(),
@@ -1611,9 +1687,14 @@ fn logical_line_count(text: &str) -> usize {
 fn build_message_lines(msg: &DisplayMessage, width: u16) -> Vec<Line<'static>> {
     let style = message_style(&msg.role);
     let prefix = message_prefix(msg, &style);
+    let text = if !msg.images.is_empty() && msg.text == IMAGE_PLACEHOLDER {
+        ""
+    } else {
+        &msg.text
+    };
     let mut lines = if style.use_markdown {
         text_to_lines(
-            &msg.text,
+            text,
             prefix,
             style.text_style,
             style.prefix_style,
@@ -1621,7 +1702,7 @@ fn build_message_lines(msg: &DisplayMessage, width: u16) -> Vec<Line<'static>> {
             style.max_line_bytes,
         )
     } else {
-        plain_lines(&msg.text, prefix, style.text_style, style.prefix_style)
+        plain_lines(text, prefix, style.text_style, style.prefix_style)
     };
     if let Some(pp) = &msg.plan_path {
         if !msg.text.is_empty() {

--- a/maki-ui/src/components/messages/render.rs
+++ b/maki-ui/src/components/messages/render.rs
@@ -3,6 +3,14 @@ use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::Line;
 use ratatui::widgets::{Paragraph, Wrap};
+use ratatui_image::{
+    Image,
+    picker::Picker,
+    sliced::{SignedPosition, SlicedImage, SlicedProtocol},
+};
+
+use crate::components::IMAGE_PLACEHOLDER;
+use crate::terminal_image::InlineImage;
 
 pub(super) struct RenderCursor {
     skip: u16,
@@ -25,6 +33,60 @@ impl RenderCursor {
 
     pub fn past_bottom(&self) -> bool {
         self.y >= self.bottom
+    }
+
+    /// `visible` is false while an overlay covers the transcript. The encoded
+    /// protocol is kept either way: releasing it here would re-decode and
+    /// re-transmit every image each time a permission prompt opens and closes.
+    pub fn render_image(
+        &mut self,
+        image: &mut InlineImage,
+        picker: Option<&Picker>,
+        visible: bool,
+        frame: &mut Frame,
+    ) {
+        let height = image.height();
+        if self.skip >= height || self.past_bottom() {
+            self.skip = self.skip.saturating_sub(height);
+            return;
+        }
+        let protocol = match picker.filter(|_| visible) {
+            Some(picker) => {
+                image.prepare(picker, self.viewport.width);
+                image.protocol(self.viewport.width)
+            }
+            None => None,
+        };
+        let Some(protocol) = protocol else {
+            self.render(&[Line::from(IMAGE_PLACEHOLDER)], height, None, false, frame);
+            return;
+        };
+        let visible_rows = height
+            .saturating_sub(self.skip)
+            .min(self.bottom.saturating_sub(self.y));
+        let area = Rect::new(self.viewport.x, self.y, self.viewport.width, visible_rows);
+        if let SlicedProtocol::Sliced(rows) = protocol {
+            // Not `SlicedImage::new`: upstream renders `.skip(skip).take(len - drop)`
+            // rows into `area`, which is `skip` rows too many when an image is
+            // clipped at the top and the bottom at once, so it draws past `area`
+            // into the segments below. Placing each row ourselves cannot overdraw.
+            for (offset, row) in rows
+                .iter()
+                .skip(self.skip as usize)
+                .take(visible_rows as usize)
+                .enumerate()
+            {
+                frame.render_widget(
+                    Image::new(row),
+                    Rect::new(area.x, area.y + offset as u16, area.width, 1),
+                );
+            }
+        } else {
+            let position = SignedPosition::from((0, -(self.skip as i16)));
+            frame.render_widget(SlicedImage::new(protocol, position), area);
+        }
+        self.skip = 0;
+        self.y += visible_rows;
     }
 
     pub fn render(
@@ -58,5 +120,107 @@ impl RenderCursor {
         }
         frame.render_widget(p, seg_area);
         self.y += visible_h;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use base64::{Engine, engine::general_purpose::STANDARD};
+    use color_eyre::eyre::Result;
+    use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
+    use maki_providers::{ImageMediaType, ImageSource};
+    use ratatui::{Terminal, backend::TestBackend, layout::Rect};
+    use ratatui_image::{
+        FontSize,
+        picker::{Picker, ProtocolType},
+    };
+    use test_case::test_case;
+
+    use super::RenderCursor;
+    use crate::terminal_image::InlineImage;
+
+    const VIEWPORT: Rect = Rect::new(2, 2, 4, 2);
+    const IMAGE_HEIGHT: u16 = 6;
+    const TOP_SKIP: u16 = 2;
+    const KITTY_RESTORE_CURSOR: &str = "\x1b[u";
+    const OVERDRAW: &str = "a clipped image must not paint outside the viewport";
+    const BLANK_ROW: &str = "every viewport row must get some of the image";
+    const WRONG_ROW: &str = "the clipped rows must be the ones the full draw put there";
+
+    #[test_case(ProtocolType::Iterm2; "iterm2")]
+    #[test_case(ProtocolType::Kitty; "kitty")]
+    #[test_case(ProtocolType::Halfblocks; "halfblocks")]
+    fn image_clips_top_and_bottom(protocol: ProtocolType) -> Result<()> {
+        #[allow(deprecated)]
+        let mut picker = Picker::from_fontsize(FontSize::new(2, 2));
+        picker.set_protocol_type(protocol);
+        let pixels = RgbaImage::from_fn(8, 12, |_, y| Rgba([y as u8 * 20, 80, 160, 255]));
+        let mut png = Cursor::new(Vec::new());
+        DynamicImage::ImageRgba8(pixels).write_to(&mut png, ImageFormat::Png)?;
+        let source = ImageSource {
+            media_type: ImageMediaType::Png,
+            data: STANDARD.encode(png.into_inner()).into(),
+        };
+        let mut image = InlineImage::new_prepared(source, &picker, VIEWPORT.width)?;
+        assert_eq!(image.height(), IMAGE_HEIGHT);
+        let mut terminal = Terminal::new(TestBackend::new(8, 8))?;
+        let full_viewport = Rect {
+            height: IMAGE_HEIGHT,
+            ..VIEWPORT
+        };
+        let full = terminal
+            .draw(|frame| {
+                RenderCursor::new(0, full_viewport).render_image(
+                    &mut image,
+                    Some(&picker),
+                    true,
+                    frame,
+                );
+            })?
+            .buffer
+            .clone();
+        let mut cursor = RenderCursor::new(TOP_SKIP, VIEWPORT);
+        terminal.draw(|frame| {
+            let before = frame.buffer_mut().clone();
+            cursor.render_image(&mut image, Some(&picker), true, frame);
+            let after = frame.buffer_mut();
+            for y in before.area.y..before.area.bottom() {
+                for x in before.area.x..before.area.right() {
+                    if !VIEWPORT.contains((x, y).into()) {
+                        assert_eq!(after[(x, y)], before[(x, y)], "{OVERDRAW}");
+                    }
+                }
+            }
+            for y in VIEWPORT.y..VIEWPORT.bottom() {
+                assert!(
+                    (VIEWPORT.x..VIEWPORT.right()).any(|x| after[(x, y)] != before[(x, y)]),
+                    "{BLANK_ROW}"
+                );
+                for x in VIEWPORT.x..VIEWPORT.right() {
+                    // Kitty packs a row into one cell and ends it by restoring
+                    // the cursor to the far corner of the area it drew into, so
+                    // that tail differs between a 6 row draw and a 2 row one.
+                    // Everything before it describes the image.
+                    if protocol == ProtocolType::Kitty && x == VIEWPORT.x {
+                        assert_eq!(
+                            after[(x, y)].symbol().split(KITTY_RESTORE_CURSOR).next(),
+                            full[(x, y + TOP_SKIP)]
+                                .symbol()
+                                .split(KITTY_RESTORE_CURSOR)
+                                .next(),
+                            "{WRONG_ROW}"
+                        );
+                    } else {
+                        assert_eq!(after[(x, y)], full[(x, y + TOP_SKIP)], "{WRONG_ROW}");
+                    }
+                }
+            }
+        })?;
+        assert_eq!(cursor.skip, 0);
+        assert_eq!(cursor.y, VIEWPORT.bottom());
+        assert!(cursor.past_bottom());
+        Ok(())
     }
 }

--- a/maki-ui/src/components/messages/segment.rs
+++ b/maki-ui/src/components/messages/segment.rs
@@ -1,11 +1,16 @@
 use crate::render_worker::RenderWorker;
+use crate::repaint::Dirty;
+use crate::terminal_image::InlineImage;
 use crate::theme;
 use crate::wrap;
+use maki_providers::ImageSource;
+use std::sync::Arc;
 
 use super::super::code_view::SectionFlags;
 use super::super::tool_display::{HighlightRequest, ToolLines};
 use ratatui::text::{Line, Span};
 use std::cell::Cell;
+use std::mem;
 use std::ops::Range;
 
 const INST_SUFFIX: &str = "__inst";
@@ -49,6 +54,7 @@ impl HighlightKey {
 #[derive(Default)]
 pub(super) struct Segment {
     lines: Vec<Line<'static>>,
+    pub images: Vec<InlineImage>,
     pub tool_id: Option<String>,
     /// Backlink to `self.messages`, set only by `with_lines`. A click on a
     /// collapsed thinking indicator has no tool_id to route by, so this is
@@ -113,6 +119,36 @@ impl Segment {
     /// and the copy path all read this one number, so none of them can
     /// disagree on how tall a segment is.
     pub fn height(&self, width: u16) -> u16 {
+        self.images
+            .iter()
+            .fold(self.text_height(width), |height, image| {
+                height.saturating_add(image.height())
+            })
+    }
+
+    pub fn set_images(&mut self, sources: impl Iterator<Item = ImageSource>) {
+        let mut previous = mem::take(&mut self.images).into_iter();
+        self.images = sources
+            .map(|source| {
+                previous
+                    .next()
+                    .filter(|image| Arc::ptr_eq(&image.source().data, &source.data))
+                    .unwrap_or_else(|| InlineImage::new(source))
+            })
+            .collect();
+    }
+
+    pub fn poll_images(&mut self) -> Dirty {
+        Dirty::any(self.images.iter_mut().map(InlineImage::poll))
+    }
+
+    pub fn release_images(&mut self) {
+        for image in &mut self.images {
+            image.release();
+        }
+    }
+
+    pub fn text_height(&self, width: u16) -> u16 {
         if let Some(c) = self.cached_height.get()
             && c.at_width == width
         {

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -8,11 +8,56 @@ use maki_agent::tools::{BASH_TOOL_NAME, GREP_TOOL_NAME, WRITE_TOOL_NAME};
 use maki_agent::{
     GrepFileEntry, GrepMatchGroup, SnapshotLine, SnapshotSpan, SpanStyle, ToolInput, ToolOutput,
 };
+use maki_providers::ImageMediaType;
 use ratatui::backend::TestBackend;
 use std::collections::HashSet;
 use std::ops::Range;
 use std::time::Duration;
 use test_case::test_case;
+
+#[test_case(false ; "live")]
+#[test_case(true ; "loaded")]
+fn tool_images_survive_snapshot_rebuilds(loaded: bool) {
+    const TOOL_ID: &str = "image_tool";
+    const CAPTION: &str = "image caption";
+    const WIDTH: u16 = 80;
+    const SAME_IMAGE: &str = "a rebuild must reuse the image, not decode it again";
+    const FALLBACK_ROW: &str = "an image with no protocol still owns its row";
+
+    let source = ImageSource::new(ImageMediaType::Png, Arc::from("invalid image"));
+    let mut panel = panel_with_tools(&[(TOOL_ID, BASH_TOOL_NAME)]);
+    // No picker, so nothing is ever decoded and the test never touches the
+    // decode thread. What it watches is the segment keeping its image across
+    // rebuilds, and the text fallback in its place.
+    panel.image_picker = None;
+    rebuild(&mut panel);
+    panel.tool_done(ToolDoneEvent {
+        output: Arc::new(ToolOutput::Image {
+            source: source.clone(),
+            text: CAPTION.into(),
+        }),
+        ..done(TOOL_ID)
+    });
+    if loaded {
+        panel.load_messages(panel.messages.clone());
+        rebuild(&mut panel);
+    }
+    panel.tool_snapshot(TOOL_ID, BufferSnapshot::plain_text(CAPTION.into()), None);
+    let terminal = render(&mut panel, WIDTH, 24);
+    let index = panel.cache.find_by_tool_id(TOOL_ID).unwrap();
+    let segment = panel.cache.get(index).unwrap();
+    assert_eq!(segment.images.len(), 1);
+    assert!(
+        Arc::ptr_eq(&segment.images[0].source().data, &source.data),
+        "{SAME_IMAGE}"
+    );
+    assert_eq!(
+        segment.height(WIDTH - 1),
+        segment.text_height(WIDTH - 1) + 1,
+        "{FALLBACK_ROW}"
+    );
+    assert!(buffer_text(&terminal).contains(IMAGE_PLACEHOLDER));
+}
 
 fn snap_line(text: &str) -> SnapshotLine {
     SnapshotLine {
@@ -219,7 +264,7 @@ fn render_sel(
     let mut terminal = ratatui::Terminal::new(backend).unwrap();
     terminal
         .draw(|f| {
-            panel.view(f, f.area(), has_selection);
+            panel.view(f, f.area(), has_selection, true);
         })
         .unwrap();
     terminal

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -35,8 +35,10 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use maki_agent::AgentInput;
 use maki_agent::{BufferSnapshot, ToolInput, ToolOutput};
 use maki_lua::{PackCommand, PackPlan};
-use maki_providers::{Message, ModelTier};
+use maki_providers::{ImageSource, Message, ModelTier};
 use ratatui::text::{Line, Span};
+
+pub(crate) use maki_providers::IMAGE_PLACEHOLDER;
 
 pub(crate) const CHEVRON: &str = "❯ ";
 
@@ -286,6 +288,7 @@ pub enum ToolStatus {
 pub struct DisplayMessage {
     pub role: DisplayRole,
     pub text: String,
+    pub images: Vec<ImageSource>,
     pub tool_input: Option<Arc<ToolInput>>,
     pub tool_raw_input: Option<Arc<serde_json::Value>>,
     pub tool_output: Option<Arc<ToolOutput>>,
@@ -306,6 +309,7 @@ impl DisplayMessage {
         Self {
             role,
             text,
+            images: Vec::new(),
             tool_input: None,
             tool_raw_input: None,
             tool_output: None,
@@ -322,10 +326,23 @@ impl DisplayMessage {
         }
     }
 
+    pub fn with_images(role: DisplayRole, text: String, images: Vec<ImageSource>) -> Self {
+        let text = if text.trim().is_empty() && !images.is_empty() {
+            IMAGE_PLACEHOLDER.into()
+        } else {
+            text
+        };
+        Self {
+            images,
+            ..Self::new(role, text)
+        }
+    }
+
     pub fn plan(text: String, plan_path: String) -> Self {
         Self {
             role: DisplayRole::Assistant,
             text,
+            images: Vec::new(),
             tool_input: None,
             tool_raw_input: None,
             tool_output: None,

--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -883,6 +883,7 @@ mod tests {
             render_header: None,
             snapshot_theme_gen: 0,
             thinking_collapsed: false,
+            images: Vec::new(),
         }
     }
 
@@ -1021,6 +1022,7 @@ mod tests {
             render_header: None,
             snapshot_theme_gen: 0,
             thinking_collapsed: false,
+            images: Vec::new(),
         }
     }
 
@@ -1116,6 +1118,7 @@ mod tests {
             render_header: None,
             snapshot_theme_gen: 0,
             thinking_collapsed: false,
+            images: Vec::new(),
         }
     }
 
@@ -1156,6 +1159,7 @@ mod tests {
             render_header: None,
             snapshot_theme_gen: 0,
             thinking_collapsed: false,
+            images: Vec::new(),
         }
     }
 
@@ -1463,6 +1467,7 @@ mod tests {
             render_header: None,
             snapshot_theme_gen: 0,
             thinking_collapsed: false,
+            images: Vec::new(),
         }
     }
 
@@ -1564,6 +1569,7 @@ mod tests {
             render_header: None,
             snapshot_theme_gen: 0,
             thinking_collapsed: false,
+            images: Vec::new(),
         }
     }
 
@@ -1674,6 +1680,7 @@ mod tests {
             render_header: None,
             snapshot_theme_gen: 0,
             thinking_collapsed: false,
+            images: Vec::new(),
         };
         assert!(
             search_text_for(&msg).contains("llm_output_here"),
@@ -1707,6 +1714,7 @@ mod tests {
             render_header: None,
             snapshot_theme_gen: 0,
             thinking_collapsed: false,
+            images: Vec::new(),
         };
         assert!(
             search_text_for(&msg).contains("body_fallback"),
@@ -1737,6 +1745,7 @@ mod tests {
             render_header: None,
             snapshot_theme_gen: 0,
             thinking_collapsed: false,
+            images: Vec::new(),
         };
         assert!(
             search_text_for(&msg).contains(LIVE_TEXT),

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -1494,7 +1494,6 @@ impl<'t> EventLoop<'t> {
                 let run_id = rt.app.run_id;
                 rt.handles.queue.push(QueueItem::Message(QueuedInput {
                     text: input.message.clone(),
-                    image_count: input.images.len(),
                     input,
                     run_id,
                     displayed: true,

--- a/maki-ui/src/image.rs
+++ b/maki-ui/src/image.rs
@@ -7,8 +7,8 @@ use base64::Engine;
 use image::{ImageBuffer, RgbaImage};
 use maki_agent::{ImageMediaType, ImageSource};
 
-const MAX_IMAGE_PIXELS: usize = 8_000_000;
-const MAX_IMAGE_BYTES: usize = 20 * 1024 * 1024;
+pub(crate) const MAX_IMAGE_PIXELS: usize = 8_000_000;
+pub(crate) const MAX_IMAGE_BYTES: usize = 20 * 1024 * 1024;
 
 const IMAGE_EXTENSIONS: &[(&str, ImageMediaType)] = &[
     ("png", ImageMediaType::Png),

--- a/maki-ui/src/lib.rs
+++ b/maki-ui/src/lib.rs
@@ -32,6 +32,7 @@ mod agent;
 mod event_loop;
 mod input;
 mod terminal;
+mod terminal_image;
 
 use std::time::Instant;
 

--- a/maki-ui/src/terminal.rs
+++ b/maki-ui/src/terminal.rs
@@ -317,6 +317,7 @@ fn pop_terminal_modes() {
 }
 
 fn resume(terminal: &mut ratatui::DefaultTerminal) {
+    crate::terminal_image::invalidate();
     write_mux_sequence(PUSH_WINDOW_TITLE_SEQUENCE);
     stdout().execute(EnterAlternateScreen).ok();
     stdout().execute(EnableBracketedPaste).ok();

--- a/maki-ui/src/terminal_image.rs
+++ b/maki-ui/src/terminal_image.rs
@@ -1,0 +1,369 @@
+use std::env;
+use std::io::{Cursor, IsTerminal, stdout};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+
+use base64::{Engine, engine::general_purpose::STANDARD};
+use color_eyre::eyre::{Result, ensure};
+use image::{DynamicImage, ImageDecoder, ImageReader, Limits};
+use maki_providers::ImageSource;
+use ratatui::layout::Size;
+use ratatui_image::{
+    FontSize,
+    picker::{Picker, ProtocolType},
+    sliced::SlicedProtocol,
+};
+
+use crate::image::{MAX_IMAGE_BYTES, MAX_IMAGE_PIXELS};
+use crate::repaint::Dirty;
+
+const MAX_IMAGE_ROWS: u16 = 20;
+const FALLBACK_FONT_SIZE: FontSize = FontSize::new(10, 20);
+const DECODE_THREAD: &str = "inline-image";
+static GENERATION: AtomicU64 = AtomicU64::new(0);
+static DECODE_JOBS: OnceLock<flume::Sender<DecodeJob>> = OnceLock::new();
+
+type DecodeJob = Box<dyn FnOnce() + Send + 'static>;
+
+/// Decoding gets its own thread rather than `maki_highlight::pool`: that one is
+/// single threaded to bound syntect's regex cache, and a multi-megabyte decode
+/// queued ahead of the transcript's highlight jobs stalls the whole UI.
+fn decode_jobs() -> &'static flume::Sender<DecodeJob> {
+    DECODE_JOBS.get_or_init(|| {
+        let (tx, rx) = flume::unbounded::<DecodeJob>();
+        thread::Builder::new()
+            .name(DECODE_THREAD.into())
+            .spawn(move || {
+                while let Ok(job) = rx.recv() {
+                    if catch_unwind(AssertUnwindSafe(job)).is_err() {
+                        tracing::error!("inline image decode panicked");
+                    }
+                }
+            })
+            .expect("failed to spawn the inline image thread");
+        tx
+    })
+}
+
+pub(crate) fn invalidate() {
+    GENERATION.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn generation() -> u64 {
+    GENERATION.load(Ordering::Relaxed)
+}
+
+pub(crate) fn picker(inline_images: bool) -> Option<Picker> {
+    if !stdout().is_terminal() {
+        return None;
+    }
+    let protocol = protocol_from_env(inline_images, |key| env::var(key).ok())?;
+    let font = crossterm::terminal::window_size()
+        .ok()
+        .filter(|size| size.columns > 0 && size.rows > 0)
+        .map(|size| FontSize::new(size.width / size.columns, size.height / size.rows))
+        .filter(|font| font.width > 0 && font.height > 0)
+        .unwrap_or(FALLBACK_FONT_SIZE);
+    #[allow(deprecated)]
+    let mut picker = Picker::from_fontsize(font);
+    picker.set_protocol_type(protocol);
+    Some(picker)
+}
+
+/// An allowlist rather than trusting what the terminal advertises: one that
+/// claims graphics it does not have paints escape bytes all over the UI. When
+/// the guess is wrong anyway, `ui.inline_images = false` is the way out. An
+/// unrecognized `TERM_PROGRAM` (tmux and some shell configs set it) falls
+/// through to `TERM`, which kitty sets itself and forwards over ssh.
+fn protocol_from_env(
+    inline_images: bool,
+    get: impl Fn(&str) -> Option<String>,
+) -> Option<ProtocolType> {
+    if !inline_images {
+        return None;
+    }
+    if ["TMUX", "STY", "ZELLIJ"]
+        .iter()
+        .any(|key| get(key).is_some())
+    {
+        return None;
+    }
+    match get("TERM_PROGRAM").as_deref() {
+        Some("ghostty" | "kitty") => return Some(ProtocolType::Kitty),
+        Some("iTerm.app" | "WezTerm") => return Some(ProtocolType::Iterm2),
+        _ => {}
+    }
+    match get("TERM").as_deref() {
+        Some("xterm-kitty" | "xterm-ghostty") => Some(ProtocolType::Kitty),
+        _ => None,
+    }
+}
+
+enum ImageState {
+    Idle {
+        height: u16,
+    },
+    Pending {
+        width: u16,
+        height: u16,
+        result: flume::Receiver<Result<SlicedProtocol>>,
+    },
+    Ready {
+        width: u16,
+        protocol: SlicedProtocol,
+    },
+    Failed,
+}
+
+pub(crate) struct InlineImage {
+    source: ImageSource,
+    state: ImageState,
+}
+
+impl InlineImage {
+    pub fn new(source: ImageSource) -> Self {
+        Self {
+            source,
+            state: ImageState::Idle { height: 1 },
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_prepared(source: ImageSource, picker: &Picker, width: u16) -> Result<Self> {
+        let protocol = encode(&source, picker, width)?;
+        Ok(Self {
+            source,
+            state: ImageState::Ready { width, protocol },
+        })
+    }
+
+    pub fn source(&self) -> &ImageSource {
+        &self.source
+    }
+
+    pub fn height(&self) -> u16 {
+        match &self.state {
+            ImageState::Ready { protocol, .. } => protocol.size().height,
+            ImageState::Pending { height, .. } | ImageState::Idle { height } => *height,
+            ImageState::Failed => 1,
+        }
+    }
+
+    pub fn release(&mut self) {
+        if !matches!(self.state, ImageState::Failed) {
+            self.state = ImageState::Idle {
+                height: self.height(),
+            };
+        }
+    }
+
+    pub fn prepare(&mut self, picker: &Picker, width: u16) {
+        if width == 0 {
+            return;
+        }
+        match &self.state {
+            ImageState::Pending { .. } | ImageState::Failed => return,
+            ImageState::Ready {
+                width: encoded_width,
+                ..
+            } if *encoded_width == width => return,
+            _ => {}
+        }
+        let (tx, result) = flume::bounded(1);
+        let source = self.source.clone();
+        let picker = picker.clone();
+        self.state = ImageState::Pending {
+            width,
+            height: self.height(),
+            result,
+        };
+        let _ = decode_jobs().send(Box::new(move || {
+            if !tx.is_disconnected() {
+                let _ = tx.send(encode(&source, &picker, width));
+            }
+        }));
+    }
+
+    pub fn poll(&mut self) -> Dirty {
+        let ImageState::Pending { width, result, .. } = &self.state else {
+            return Dirty::NO;
+        };
+        let result = match result.try_recv() {
+            Ok(result) => result,
+            Err(flume::TryRecvError::Empty) => return Dirty::NO,
+            Err(flume::TryRecvError::Disconnected) => {
+                self.state = ImageState::Failed;
+                return Dirty::YES;
+            }
+        };
+        self.state = match result {
+            Ok(protocol) => ImageState::Ready {
+                width: *width,
+                protocol,
+            },
+            Err(error) => {
+                tracing::warn!(%error, "inline image unavailable");
+                ImageState::Failed
+            }
+        };
+        Dirty::YES
+    }
+
+    pub fn protocol(&self, width: u16) -> Option<&SlicedProtocol> {
+        match &self.state {
+            ImageState::Ready {
+                width: encoded_width,
+                protocol,
+            } if *encoded_width == width => Some(protocol),
+            _ => None,
+        }
+    }
+}
+
+fn encode(source: &ImageSource, picker: &Picker, width: u16) -> Result<SlicedProtocol> {
+    ensure!(
+        source.data.len() <= MAX_IMAGE_BYTES.div_ceil(3) * 4,
+        "Image exceeds 20MB limit"
+    );
+    let bytes = STANDARD.decode(source.data.as_ref())?;
+    let mut reader = ImageReader::new(Cursor::new(bytes)).with_guessed_format()?;
+    let mut limits = Limits::default();
+    limits.max_alloc = Some((MAX_IMAGE_PIXELS * 4) as u64);
+    reader.limits(limits);
+    let decoder = reader.into_decoder()?;
+    let (w, h) = decoder.dimensions();
+    ensure!(
+        u64::from(w) * u64::from(h) <= MAX_IMAGE_PIXELS as u64,
+        "Image exceeds pixel limit"
+    );
+    let image = DynamicImage::from_decoder(decoder)?;
+    let font = picker.font_size();
+    let size = Size::new(
+        width.min(u16::MAX / font.width),
+        MAX_IMAGE_ROWS.min(u16::MAX / font.height),
+    );
+    Ok(SlicedProtocol::new(picker, image, Some(size))?)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use base64::{Engine, engine::general_purpose::STANDARD};
+    use color_eyre::eyre::Result;
+    use image::{DynamicImage, ImageFormat};
+    use maki_providers::{ImageMediaType, ImageSource};
+    use ratatui::layout::Size;
+    use ratatui_image::{
+        FontSize,
+        picker::{Picker, ProtocolType},
+    };
+    use test_case::test_case;
+
+    use super::{ImageState, InlineImage, encode, protocol_from_env};
+    use crate::repaint::Dirty;
+
+    const EXPECTED_IDLE: &str = "nothing to encode with, so the image must stay idle";
+    const EXPECTED_PENDING: &str = "image should be pending after prepare";
+    const HEIGHT_KEPT: &str = "a released image keeps its height so the scroll does not jump";
+    const MALFORMED_IMAGE: &[u8] = b"not an image";
+    const IMAGE_WIDTH: u16 = 4;
+    const IMAGE_HEIGHT: u16 = 6;
+    const TERM_PROGRAM: &str = "TERM_PROGRAM";
+    const TERM: &str = "TERM";
+    const KITTY_PROGRAM: &str = "kitty";
+    const KITTY_TERM: &str = "xterm-kitty";
+    const UNKNOWN_PROGRAM: &str = "unknown";
+
+    fn protocol(inline_images: bool, env: &[(&str, &str)]) -> Option<ProtocolType> {
+        protocol_from_env(inline_images, |key| {
+            env.iter()
+                .find(|(name, _)| *name == key)
+                .map(|(_, value)| (*value).into())
+        })
+    }
+
+    #[test_case(&[(TERM_PROGRAM, "iTerm.app")], Some(ProtocolType::Iterm2); "known_terminal")]
+    #[test_case(&[(TERM, KITTY_TERM)], Some(ProtocolType::Kitty); "known_term")]
+    #[test_case(&[(TERM_PROGRAM, UNKNOWN_PROGRAM), (TERM, KITTY_TERM)], Some(ProtocolType::Kitty); "unsupported_program_falls_back_to_term")]
+    #[test_case(&[(TERM_PROGRAM, UNKNOWN_PROGRAM), (TERM, "xterm-256color")], None; "unsupported_program_and_term")]
+    #[test_case(&[], None; "missing_env")]
+    #[test_case(&[(TERM_PROGRAM, KITTY_PROGRAM), ("TMUX", "mux")], None; "multiplexer")]
+    fn protocol_env_uses_safe_fallback(env: &[(&str, &str)], expected: Option<ProtocolType>) {
+        assert_eq!(protocol(true, env), expected);
+    }
+
+    #[test_case(&[(TERM_PROGRAM, KITTY_PROGRAM)]; "term_program")]
+    #[test_case(&[(TERM, KITTY_TERM)]; "term")]
+    fn disabled_inline_images_yields_no_protocol(env: &[(&str, &str)]) {
+        assert_eq!(protocol(false, env), None);
+    }
+
+    #[test_case(false; "valid_png")]
+    #[test_case(true; "malformed_image")]
+    fn decode_result_drives_the_state_machine(malformed: bool) -> Result<()> {
+        let mut png = Cursor::new(Vec::new());
+        DynamicImage::new_rgb8(IMAGE_WIDTH.into(), IMAGE_HEIGHT.into())
+            .write_to(&mut png, ImageFormat::Png)?;
+        let source = ImageSource {
+            media_type: ImageMediaType::Png,
+            data: STANDARD
+                .encode(if malformed {
+                    MALFORMED_IMAGE
+                } else {
+                    png.get_ref()
+                })
+                .into(),
+        };
+        #[allow(deprecated)]
+        let mut picker = Picker::from_fontsize(FontSize::new(1, 1));
+        picker.set_protocol_type(ProtocolType::Halfblocks);
+        let mut image = InlineImage::new(source.clone());
+        image.prepare(&picker, 0);
+        assert!(
+            matches!(image.state, ImageState::Idle { .. }),
+            "{EXPECTED_IDLE}"
+        );
+        assert_eq!(image.height(), 1);
+        image.prepare(&picker, IMAGE_WIDTH);
+        assert!(
+            matches!(image.state, ImageState::Pending { .. }),
+            "{EXPECTED_PENDING}"
+        );
+
+        // Encode here and hand the answer over instead of waiting on the real
+        // decode thread, which is how this test would start failing at 3am on a
+        // loaded machine.
+        let (tx, result) = flume::bounded(1);
+        tx.send(encode(&source, &picker, IMAGE_WIDTH))?;
+        image.state = ImageState::Pending {
+            width: IMAGE_WIDTH,
+            height: 1,
+            result,
+        };
+        assert_eq!(image.poll(), Dirty::YES);
+        assert_eq!(image.poll(), Dirty::NO);
+        if malformed {
+            assert!(matches!(image.state, ImageState::Failed));
+            assert_eq!(image.height(), 1);
+            assert!(image.protocol(IMAGE_WIDTH).is_none());
+            return Ok(());
+        }
+        assert_eq!(image.height(), IMAGE_HEIGHT);
+        assert_eq!(
+            image.protocol(IMAGE_WIDTH).map(|protocol| protocol.size()),
+            Some(Size::new(IMAGE_WIDTH, IMAGE_HEIGHT))
+        );
+        image.release();
+        assert_eq!(image.height(), IMAGE_HEIGHT, "{HEIGHT_KEPT}");
+        assert!(image.protocol(IMAGE_WIDTH).is_none());
+        image.prepare(&picker, IMAGE_WIDTH);
+        assert!(
+            matches!(image.state, ImageState::Pending { .. }),
+            "{EXPECTED_PENDING}"
+        );
+        Ok(())
+    }
+}

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -71,6 +71,7 @@ All fields are optional. Typos in field names cause an error right away.
 |-------|------|---------|-----|-------------|
 | `splash_animation` | bool | `true` | - | Show splash animation on startup |
 | `scrollbar` | bool | `true` | - | Show vertical scrollbar in scrollable areas |
+| `inline_images` | bool | `true` | - | Render inline images in terminals with graphics support, falling back to an [image] line when off |
 | `notifications` | string | `auto` | - | Terminal notification method: auto, osc9, bell, or off |
 | `flash_duration_ms` | u64 | `1500` | - | Duration of flash messages (ms) |
 | `typewriter_ms_per_char` | u64 | `4` | - | Typewriter effect speed (ms/char) |


### PR DESCRIPTION
## summary
- render pasted, tool-returned, and message images in live chats and restored history
- decode, resize, and encode lazily off the ui thread
- handle scrolling, overlays, and terminal resume with text fallback elsewhere

closes #609. fresh implementation following the feedback on #613, with image extraction wired up and no unrelated ui changes.

currently supports Kitty, Ghostty, iTerm2, and WezTerm.

![inline images in maki-test](https://raw.githubusercontent.com/bzzimmy/maki/d898bc8f4ceb9657a87c7855c2a40d3175d0c4f8/maki_inline_images.png)

## testing
- image delivery, rendering, clipping, and fallback tests passed
- workspace clippy, formatting, python checks, generated docs, and dependency audit passed
- full workspace suite has a known failure in an untouched macOS permissions test
- manually verified inline rendering with `maki-test`