### PR TITLE
fix(agent): enforce an object root on tool input schemas

### DIFF
--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -630,15 +630,29 @@ pub mod test_support {
     /// Registry and routing tests care about the name and audience only, never
     /// about what the tool returns.
     pub fn mock_tool(name: &str, audience: ToolAudience) -> Arc<dyn registry::Tool> {
+        mock_tool_with_schema(
+            name,
+            audience,
+            serde_json::json!({"type": "object", "properties": {}, "additionalProperties": false}),
+        )
+    }
+
+    pub fn mock_tool_with_schema(
+        name: &str,
+        audience: ToolAudience,
+        schema: Value,
+    ) -> Arc<dyn registry::Tool> {
         Arc::new(MockTool {
             name: name.to_owned(),
             audience,
+            schema,
         })
     }
 
     struct MockTool {
         name: String,
         audience: ToolAudience,
+        schema: Value,
     }
 
     struct MockInvocation;
@@ -660,7 +674,7 @@ pub mod test_support {
             "mock tool".into()
         }
         fn schema(&self) -> Value {
-            serde_json::json!({"type": "object", "properties": {}, "additionalProperties": false})
+            self.schema.clone()
         }
         fn audience(&self) -> ToolAudience {
             self.audience

--- a/maki-agent/src/tools/registry.rs
+++ b/maki-agent/src/tools/registry.rs
@@ -17,6 +17,7 @@ use crate::template::Vars;
 use crate::{BufferSnapshot, ToolOutput};
 
 use super::hook::ToolHook;
+use super::schema::sanitize_tool_input_schema;
 use super::{DescriptionContext, ToolContext};
 
 bitflags! {
@@ -488,7 +489,7 @@ impl ToolRegistry {
             let mut def = json!({
                 "name": entry.name(),
                 "description": description,
-                "input_schema": entry.tool.schema(),
+                "input_schema": sanitize_tool_input_schema(entry.tool.schema()),
             });
             if let Some(examples) = entry.tool.examples() {
                 if supports_examples {
@@ -547,7 +548,11 @@ mod tests {
     use crate::template::Vars;
     use test_case::test_case;
 
-    use crate::tools::test_support::mock_tool;
+    use crate::tools::test_support::{mock_tool, mock_tool_with_schema};
+
+    const ANY_TOOL_NAME: &str = "schemaless";
+    const EMPTY_SCHEMA_REJECTED: &str =
+        "strict providers reject a function whose parameters is empty";
 
     fn mock(name: &str) -> Arc<dyn Tool> {
         mock_tool(name, ToolAudience::all())
@@ -565,6 +570,30 @@ mod tests {
         reg.register(mock("dupe"), lua_source("p")).unwrap();
         let err = reg.register(mock("dupe"), lua_source("p")).unwrap_err();
         assert!(matches!(err, RegistryError::NameConflict { .. }));
+    }
+
+    #[test]
+    fn definitions_never_send_an_empty_schema() {
+        let reg = ToolRegistry::new();
+        reg.register(
+            mock_tool_with_schema(ANY_TOOL_NAME, ToolAudience::all(), json!({})),
+            lua_source("p"),
+        )
+        .unwrap();
+
+        let filter = crate::tools::ToolFilter::All;
+        let ctx = DescriptionContext {
+            filter: &filter,
+            audience: ToolAudience::MAIN,
+            workflow: false,
+            mcp: false,
+        };
+        let defs = reg.definitions(&Vars::new(), &ctx, false);
+        assert_eq!(
+            defs[0]["input_schema"],
+            json!({"type": "object", "properties": {}}),
+            "{EMPTY_SCHEMA_REJECTED}"
+        );
     }
 
     /// Tools added mid-session must show up in the next `definitions()` call.

--- a/maki-agent/src/tools/schema.rs
+++ b/maki-agent/src/tools/schema.rs
@@ -207,57 +207,74 @@ pub fn try_from_json(v: &Value) -> Result<&'static ParamSchema, String> {
             let items: &'static ParamSchema = try_from_json(items_val)?;
             ParamSchema::Array { items, description }
         }
-        Some("object") => {
-            let props_map = v
-                .get("properties")
-                .and_then(|p| p.as_object())
-                .ok_or("object schema missing properties")?;
-            let required: Vec<&str> = v
-                .get("required")
-                .and_then(|r| r.as_array())
-                .map(|arr| arr.iter().filter_map(|x| x.as_str()).collect())
-                .unwrap_or_default();
-            let properties: &'static [Property] = Box::leak(
-                props_map
-                    .iter()
-                    .map(|(name, sub)| -> Result<Property, String> {
-                        let static_name: &'static str = Box::leak(name.clone().into_boxed_str());
-                        let inline_required = sub
-                            .get("required")
-                            .and_then(|r| r.as_bool())
-                            .unwrap_or(false);
-                        let static_schema: &'static ParamSchema = try_from_json(sub)?;
-                        let is_required = inline_required || required.contains(&name.as_str());
-                        let aliases: &'static [&'static str] = match sub.get("alias") {
-                            Some(Value::String(s)) => {
-                                let leaked: &'static str = Box::leak(s.clone().into_boxed_str());
-                                Box::leak(vec![leaked].into_boxed_slice())
-                            }
-                            Some(Value::Array(arr)) => Box::leak(
-                                arr.iter()
-                                    .filter_map(|v| v.as_str())
-                                    .map(|s| -> &'static str {
-                                        Box::leak(s.to_owned().into_boxed_str())
-                                    })
-                                    .collect::<Vec<_>>()
-                                    .into_boxed_slice(),
-                            ),
-                            _ => &[],
-                        };
-                        Ok((static_name, static_schema, is_required, aliases))
-                    })
-                    .collect::<Result<Vec<_>, _>>()?
-                    .into_boxed_slice(),
-            );
-            ParamSchema::Object {
-                properties,
-                description,
-            }
+        Some("object") => parse_object_schema(v, description)?,
+        // A schema that spells out `properties` but forgets `type` is an object
+        // and nothing else. Reading it as "any value" used to throw the whole
+        // parameter list away, so the tool quietly arrived with no arguments.
+        // This is still only a guess though, and the plugins that forget `type`
+        // at the root are the same ones that write a sloppy nested schema, so a
+        // failure here would newly refuse a plugin that used to load and take
+        // all of its tools, commands and hooks with it. We keep the old "any
+        // value" answer in that case, which is never worse than before.
+        None if v.get("properties").is_some_and(Value::is_object) => {
+            parse_object_schema(v, description).unwrap_or_else(|error| {
+                warn!(
+                    error,
+                    "tool schema lists properties but one of them is malformed"
+                );
+                ParamSchema::Any { description }
+            })
         }
         _ => ParamSchema::Any { description },
     };
 
     Ok(Box::leak(Box::new(schema)))
+}
+
+fn parse_object_schema(v: &Value, description: &'static str) -> Result<ParamSchema, String> {
+    let props_map = v
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .ok_or("object schema missing properties")?;
+    let required: Vec<&str> = v
+        .get("required")
+        .and_then(|r| r.as_array())
+        .map(|arr| arr.iter().filter_map(|x| x.as_str()).collect())
+        .unwrap_or_default();
+    let properties: &'static [Property] = Box::leak(
+        props_map
+            .iter()
+            .map(|(name, sub)| -> Result<Property, String> {
+                let static_name: &'static str = Box::leak(name.clone().into_boxed_str());
+                let inline_required = sub
+                    .get("required")
+                    .and_then(|r| r.as_bool())
+                    .unwrap_or(false);
+                let static_schema: &'static ParamSchema = try_from_json(sub)?;
+                let is_required = inline_required || required.contains(&name.as_str());
+                let aliases: &'static [&'static str] = match sub.get("alias") {
+                    Some(Value::String(s)) => {
+                        let leaked: &'static str = Box::leak(s.clone().into_boxed_str());
+                        Box::leak(vec![leaked].into_boxed_slice())
+                    }
+                    Some(Value::Array(arr)) => Box::leak(
+                        arr.iter()
+                            .filter_map(|v| v.as_str())
+                            .map(|s| -> &'static str { Box::leak(s.to_owned().into_boxed_str()) })
+                            .collect::<Vec<_>>()
+                            .into_boxed_slice(),
+                    ),
+                    _ => &[],
+                };
+                Ok((static_name, static_schema, is_required, aliases))
+            })
+            .collect::<Result<Vec<_>, _>>()?
+            .into_boxed_slice(),
+    );
+    Ok(ParamSchema::Object {
+        properties,
+        description,
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -676,15 +693,19 @@ fn log_coercion(
 /// schema with `properties` and `required` as an array. MCP servers and plugins
 /// can return schemas that break these rules, so this function repairs them
 /// before they are sent to a provider.
+///
+/// A root without `type` is always made an object. The root describes the named
+/// arguments of a function, so nothing else fits, and strict providers (MiniMax,
+/// Kimi) reject a function whose `parameters` is `{}`. Nested schemas keep their
+/// own shape, where an empty `{}` still means "any value".
 pub fn sanitize_tool_input_schema(mut schema: Value) -> Value {
     let original = schema.clone();
-    if let Value::Object(map) = &mut schema
-        && is_object_schema(map)
-    {
-        sanitize_object_schema(map);
+    if let Value::Object(map) = &mut schema {
+        map.entry("type").or_insert_with(|| json!("object"));
     } else {
-        sanitize_property_schema(&mut schema);
+        schema = json!({ "type": "object" });
     }
+    sanitize_property_schema(&mut schema);
     if schema != original {
         tracing::debug!(
             from = %original,
@@ -693,12 +714,6 @@ pub fn sanitize_tool_input_schema(mut schema: Value) -> Value {
         );
     }
     schema
-}
-
-fn is_object_schema(map: &serde_json::Map<String, Value>) -> bool {
-    let type_str = map.get("type").and_then(|v| v.as_str());
-    type_str == Some("object")
-        || (type_str.is_none() && map.get("properties").and_then(|v| v.as_object()).is_some())
 }
 
 fn sanitize_object_schema(map: &mut serde_json::Map<String, Value>) {
@@ -821,6 +836,18 @@ mod tests {
     const MSG_EXPECTED_ARRAY: &str = "expected array";
     const MSG_JSON_ENCODED_HINT: &str = "Pass a JSON array";
     const MSG_EXPECTED_ONE_OF: &str = "expected one of";
+
+    const ANY_DESCRIPTION: &str = "Any value";
+    const ANY_PROP: &str = "value";
+    const PATH_PROP: &str = "path";
+    const TYPELESS_KEEPS_PROPERTIES: &str =
+        "a schema that lists properties must keep them, whatever its type says";
+    const ROOT_IS_NEVER_EMPTY: &str =
+        "strict providers reject a function whose parameters is not an object schema";
+    const TYPELESS_ROOT_NEVER_FAILS: &str =
+        "guessing an object root must not fail the parse and take the whole plugin down";
+    const EXPLICIT_OBJECT_STILL_FAILS: &str =
+        "a schema that declares type object must still be rejected when it is malformed";
 
     const STR_PRIM: ParamSchema = ParamSchema::Primitive {
         kind: ParamKind::String,
@@ -1071,6 +1098,43 @@ mod tests {
     }
 
     #[test]
+    fn try_from_json_typeless_with_properties_is_an_object() {
+        let schema_json = json!({
+            "properties": { PATH_PROP: { "type": "string" } },
+            "required": [PATH_PROP],
+        });
+        let schema = try_from_json(&schema_json).unwrap();
+        assert_eq!(
+            to_json_schema(schema)["properties"][PATH_PROP]["type"],
+            json!("string"),
+            "{TYPELESS_KEEPS_PROPERTIES}"
+        );
+        assert!(validate(schema, json!({})).is_err());
+    }
+
+    #[test_case(json!({"type": "object"}) ; "nested_object_without_properties")]
+    #[test_case(json!({"type": "array"}) ; "nested_array_without_items")]
+    fn try_from_json_typeless_root_with_broken_property_degrades_to_any(broken: Value) {
+        let properties = json!({ ANY_PROP: broken });
+        let typeless = try_from_json(&json!({ "properties": properties })).unwrap();
+        assert!(
+            matches!(typeless, ParamSchema::Any { .. }),
+            "{TYPELESS_ROOT_NEVER_FAILS}"
+        );
+
+        let explicit = try_from_json(&json!({ "type": "object", "properties": properties }));
+        assert!(explicit.is_err(), "{EXPLICIT_OBJECT_STILL_FAILS}");
+    }
+
+    #[test_case(json!({}) ; "empty_schema")]
+    #[test_case(json!({"description": ANY_DESCRIPTION}) ; "description_only")]
+    fn try_from_json_without_properties_is_any(schema_json: Value) {
+        let schema = try_from_json(&schema_json).unwrap();
+        assert!(matches!(schema, ParamSchema::Any { .. }));
+        assert!(validate(schema, json!({"anything": 1})).is_ok());
+    }
+
+    #[test]
     fn coerce_stringified_array_with_unescaped_inner_quotes_via_repair() {
         let broken = r#"[{"old_string": "const x = { \"color\": 1 };", "new_string": "fixed"}]"#;
         let input = json!({"path": "/x", "edits": broken});
@@ -1146,21 +1210,32 @@ mod tests {
     #[test_case(json!({"type": "string"}) ; "type_string_root")]
     #[test_case(json!({"type": "integer"}) ; "type_integer_root")]
     #[test_case(json!({"type": "boolean"}) ; "type_boolean_root")]
-    fn sanitize_primitive_root_is_unchanged(input: Value) {
+    #[test_case(json!({"type": "array", "items": {"type": "string"}}) ; "type_array_root")]
+    fn sanitize_typed_root_is_unchanged(input: Value) {
         let result = sanitize_tool_input_schema(input.clone());
         assert_eq!(result, input);
+    }
+
+    #[test_case(json!({}), json!({"type": "object", "properties": {}}) ; "empty_root")]
+    #[test_case(json!(null), json!({"type": "object", "properties": {}}) ; "missing_root")]
+    #[test_case(json!({"description": ANY_DESCRIPTION}), json!({"description": ANY_DESCRIPTION, "type": "object", "properties": {}}) ; "description_only_root")]
+    #[test_case(json!({"required": ["path"]}), json!({"type": "object", "properties": {}, "required": []}) ; "typeless_root")]
+    #[test_case(json!({"enum": [1, 2, 3]}), json!({"enum": [1, 2, 3], "type": "object", "properties": {}}) ; "enum_root")]
+    fn sanitize_forces_object_root(input: Value, expected: Value) {
+        let result = sanitize_tool_input_schema(input);
+        assert_eq!(result, expected, "{ROOT_IS_NEVER_EMPTY}");
+    }
+
+    #[test_case(json!({}) ; "empty_schema_any")]
+    #[test_case(json!({"description": ANY_DESCRIPTION}) ; "description_only_any")]
+    fn sanitize_keeps_nested_any_open(any_schema: Value) {
+        let input = json!({"type": "object", "properties": { ANY_PROP: any_schema }});
+        assert_eq!(sanitize_tool_input_schema(input.clone()), input);
     }
 
     #[test_case(json!({"type": "object", "required": {}}), json!({"type": "object", "properties": {}, "required": []}) ; "required_object")]
     #[test_case(json!({"type": "object", "required": {"foo": true}}), json!({"type": "object", "properties": {}, "required": []}) ; "required_object_with_content")]
     fn sanitize_required_object_to_array(input: Value, expected: Value) {
-        let result = sanitize_tool_input_schema(input);
-        assert_eq!(result, expected);
-    }
-
-    #[test_case(json!({"type": "object"}), json!({"type": "object", "properties": {}}) ; "missing_properties_stays_open")]
-    #[test_case(json!({}), json!({}) ; "empty_schema_any")]
-    fn sanitize_missing_properties(input: Value, expected: Value) {
         let result = sanitize_tool_input_schema(input);
         assert_eq!(result, expected);
     }
@@ -1223,18 +1298,9 @@ mod tests {
         assert_eq!(result, input);
     }
 
-    #[test]
-    fn sanitize_leaves_description_only_as_any() {
-        let input = json!({"description": "Any value"});
-        let result = sanitize_tool_input_schema(input.clone());
-        assert_eq!(result, input);
-    }
-
-    #[test_case(json!({"enum": [1, 2, 3]}) ; "numeric_enum_without_type")]
     #[test_case(json!({"type": ["string", "null"]}) ; "type_union")]
     #[test_case(json!({"type": ["object", "null"], "properties": {}}) ; "nullable_object_union")]
     #[test_case(json!({"type": ["array", "null"], "items": {"type": "string"}}) ; "nullable_array_union")]
-    #[test_case(json!({"items": {"type": "string"}}) ; "items_without_type")]
     fn sanitize_leaves_unrecognized_untouched(input: Value) {
         let result = sanitize_tool_input_schema(input.clone());
         assert_eq!(result, input);
@@ -1246,7 +1312,8 @@ mod tests {
             "type": "object",
             "properties": {
                 "mode": {"enum": [1, 2, 3]},
-                "name": {"type": ["string", "null"]}
+                "name": {"type": ["string", "null"]},
+                "tags": {"items": {"type": "string"}}
             }
         });
         let result = sanitize_tool_input_schema(input.clone());

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -699,6 +699,7 @@ fn parse_hint_content(lua: &Lua, spec: &Table) -> LuaResult<HintContent> {
 ///   description = "Count words in a file.",
 ///   kind = "read",
 ///   schema = {
+///     type = "object",
 ///     properties = { path = { type = "string", description = "File path" } },
 ///     required = { "path" },
 ///   },

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -433,17 +433,28 @@ fn convert_tools(tools: &Value) -> Vec<Value> {
         .filter_map(|t| {
             let name = t.get("name")?.as_str()?;
             let description = t.get("description")?.as_str().unwrap_or("");
-            let parameters = t
-                .get("input_schema")
-                .cloned()
-                .unwrap_or_else(|| json!({"type": "object", "properties": {}}));
-            Some(json!({
+            let mut decl = json!({
                 "name": name,
                 "description": description,
-                "parameters": strip_additional_properties(parameters),
-            }))
+            });
+            if let Some(parameters) = tool_parameters(t) {
+                decl["parameters"] = parameters;
+            }
+            Some(decl)
         })
         .collect()
+}
+
+/// Gemini turns down an object schema that lists no properties, while MiniMax
+/// turns down a bare `{}`, so no single payload pleases both. A tool that takes
+/// no arguments simply travels here without `parameters`.
+fn tool_parameters(tool: &Value) -> Option<Value> {
+    let schema = tool.get("input_schema")?;
+    let has_properties = schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .is_some_and(|props| !props.is_empty());
+    has_properties.then(|| strip_additional_properties(schema.clone()))
 }
 
 fn strip_additional_properties(value: Value) -> Value {
@@ -674,6 +685,11 @@ mod tests {
     use test_case::test_case;
 
     const GEMINI_API_KEY: &str = "test-key";
+    const TOOL_NAME: &str = "word_count";
+    const TOOL_DESCRIPTION: &str = "Count words.";
+    const PATH_PROP: &str = "path";
+    const EMPTY_PROPERTIES_REJECTED: &str =
+        "Gemini rejects a function whose parameters is an object with no properties";
 
     fn test_auth() -> Arc<Mutex<ResolvedAuth>> {
         Arc::new(Mutex::new(ResolvedAuth::for_test(
@@ -705,6 +721,41 @@ mod tests {
             context_window: 1_048_576,
             thinking_fields: None,
         }
+    }
+
+    #[test_case(json!({"type": "object", "properties": {}}) ; "empty_properties")]
+    #[test_case(json!({"type": "object"}) ; "missing_properties")]
+    fn convert_tools_omits_empty_parameters(input_schema: Value) {
+        let tools = json!([{
+            "name": TOOL_NAME,
+            "description": TOOL_DESCRIPTION,
+            "input_schema": input_schema,
+        }]);
+        let decls = convert_tools(&tools);
+        assert_eq!(decls[0]["name"], json!(TOOL_NAME));
+        assert_eq!(
+            decls[0].get("parameters"),
+            None,
+            "{EMPTY_PROPERTIES_REJECTED}"
+        );
+    }
+
+    #[test]
+    fn convert_tools_keeps_populated_parameters() {
+        let tools = json!([{
+            "name": TOOL_NAME,
+            "description": TOOL_DESCRIPTION,
+            "input_schema": {
+                "type": "object",
+                "properties": { PATH_PROP: {"type": "string"} },
+                "additionalProperties": false,
+            },
+        }]);
+        let decls = convert_tools(&tools);
+        assert_eq!(
+            decls[0]["parameters"],
+            json!({"type": "object", "properties": { PATH_PROP: {"type": "string"} }})
+        );
     }
 
     #[test]

--- a/maki-providers/src/providers/openai/responses.rs
+++ b/maki-providers/src/providers/openai/responses.rs
@@ -8,6 +8,7 @@ use serde_json::{Value, json};
 use tracing::{debug, warn};
 
 use crate::model::Model;
+use crate::providers::openai_compat::tool_parameters;
 use crate::providers::{ResolvedAuth, sse_error_status};
 use crate::types::EffortDialect;
 use crate::{
@@ -146,7 +147,7 @@ pub(crate) fn convert_tools(anthropic_tools: &Value) -> Value {
                     "type": "function",
                     "name": t.get("name")?,
                     "description": t.get("description")?,
-                    "parameters": t.get("input_schema")?,
+                    "parameters": tool_parameters(t),
                     "strict": false,
                 }))
             })
@@ -561,6 +562,24 @@ mod tests {
     const OVERLOAD_MESSAGE: &str = "Our servers are currently overloaded. Please try again later.";
     const BAD_REQUEST_MESSAGE: &str = "Invalid value for 'model'";
     const RATE_LIMIT_MESSAGE: &str = "Rate limit hit";
+    const TOOL_NAME: &str = "word_count";
+    const TOOL_DESCRIPTION: &str = "Count words.";
+    const TOOL_MUST_SURVIVE: &str = "a tool without a schema still belongs in the request";
+
+    #[test]
+    fn convert_tools_defaults_missing_parameters() {
+        let tools = json!([{ "name": TOOL_NAME, "description": TOOL_DESCRIPTION }]);
+        let converted = convert_tools(&tools);
+        assert_eq!(
+            converted[0]["name"],
+            json!(TOOL_NAME),
+            "{TOOL_MUST_SURVIVE}"
+        );
+        assert_eq!(
+            converted[0]["parameters"],
+            json!({"type": "object", "properties": {}})
+        );
+    }
 
     async fn run_sse(sse: &str) -> (Result<StreamResponse, AgentError>, Vec<ProviderEvent>) {
         let (tx, rx) = flume::unbounded();

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -373,6 +373,17 @@ pub fn convert_messages(messages: &[Message], system: &str) -> Vec<Value> {
     out
 }
 
+/// A tool can reach us without a usable `input_schema`. Dropping it would take
+/// the tool away from the model behind its back, and `{}` makes strict providers
+/// (MiniMax, Kimi) reject the whole request, so it ships a schema that takes no
+/// arguments.
+pub(crate) fn tool_parameters(tool: &Value) -> Value {
+    match tool.get("input_schema") {
+        Some(schema) if schema.is_object() => schema.clone(),
+        _ => json!({ "type": "object", "properties": {} }),
+    }
+}
+
 pub fn convert_tools(anthropic_tools: &Value) -> Value {
     let Some(tools) = anthropic_tools.as_array() else {
         return json!([]);
@@ -387,7 +398,7 @@ pub fn convert_tools(anthropic_tools: &Value) -> Value {
                     "function": {
                         "name": t.get("name")?,
                         "description": t.get("description")?,
-                        "parameters": t.get("input_schema")?,
+                        "parameters": tool_parameters(t),
                     }
                 }))
             })
@@ -735,6 +746,20 @@ mod tests {
     const TEST_STREAM_TIMEOUT: Duration = Duration::from_secs(300);
     const COUNTS_SURVIVE_A_BAD_COST: &str =
         "a price we cannot read must not take the token counts down with it";
+    const TOOL_NAME: &str = "word_count";
+    const TOOL_DESCRIPTION: &str = "Count words.";
+    const TOOL_MUST_SURVIVE: &str = "a tool without a schema still belongs in the request";
+
+    #[test_case(json!({"name": TOOL_NAME, "description": TOOL_DESCRIPTION}) ; "missing_schema")]
+    #[test_case(json!({"name": TOOL_NAME, "description": TOOL_DESCRIPTION, "input_schema": null}) ; "null_schema")]
+    fn convert_tools_defaults_missing_parameters(tool: Value) {
+        let function = &convert_tools(&json!([tool]))[0]["function"];
+        assert_eq!(function["name"], json!(TOOL_NAME), "{TOOL_MUST_SURVIVE}");
+        assert_eq!(
+            function["parameters"],
+            json!({"type": "object", "properties": {}})
+        );
+    }
 
     #[test]
     fn default_model_parser_reads_context_and_output_length() {

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -443,6 +443,7 @@ maki.api.register_tool({
   description = "Count words in a file.",
   kind = "read",
   schema = {
+    type = "object",
     properties = { path = { type = "string", description = "File path" } },
     required = { "path" },
   },


### PR DESCRIPTION
A Lua tool schema written without `type` became `ParamSchema::Any`, which went out as `parameters: {}`, and MiniMax rejects that outright with `invalid params, function parameters is empty (2013)` while Kimi returns a plain 400 and GLM shrugs, which is why it hid for so long.

`try_from_json` now reads a typeless schema that lists `properties` as an object, so the arguments survive instead of being dropped on the floor, and since that is only a guess it falls back to the old `ParamSchema::Any` when a nested property is malformed, because failing there would refuse a plugin that used to load and take all of its tools, commands and hooks with it.

`sanitize_tool_input_schema` was wired only into the MCP and Lua subagent paths, so the main registry sent every tool definition raw, and it now runs there too and gives any root without a `type` an object shape while nested schemas stay untouched.

Gemini stands on the other side of this fence and refuses an object whose `properties` is empty, so its converter leaves `parameters` out entirely for a tool that takes no arguments, because the two vendors cannot be pleased by one payload.

Both OpenAI converters also dropped a tool that carried no `input_schema` at all, which now becomes an empty object schema.

Fixes #940