### PR TITLE
fix(acp): show the file and diff in permission requests

### DIFF
--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -12,8 +12,7 @@ use agent_client_protocol_schema::{
     Notification, PromptRequest, PromptResponse, Request, RequestId, RequestPermissionRequest,
     RequestPermissionResponse, Response, SessionId, SessionModeId, SessionNotification,
     SessionUpdate, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse,
-    SetSessionModeRequest, SetSessionModeResponse, StopReason, TextContent, ToolCallId,
-    ToolCallUpdate, ToolCallUpdateFields,
+    SetSessionModeRequest, SetSessionModeResponse, StopReason, TextContent,
 };
 use color_eyre::eyre::Context;
 use flume::{Sender, WeakSender};
@@ -753,6 +752,11 @@ fn start_event_pump(
     smol::spawn(async move {
         let sid = SessionId::from(session_id.to_string());
         let mut cost_total = initial_cost;
+        // A permission request only carries scopes, which are matching keys and
+        // not always paths, so the file context a client needs has to come from
+        // the tool call that asked for permission. Kept for the turn, like
+        // sdk_mode does: the history holds these inputs anyway.
+        let mut tool_inputs: HashMap<String, Value> = HashMap::new();
 
         while let Some(Envelope {
             event, subagent, ..
@@ -766,10 +770,18 @@ fn start_event_pump(
 
             let update = match event {
                 AgentEvent::PermissionRequest { id, tool, scopes } => {
+                    let tool = tool.to_string();
                     let scope = format!("{tool}: {}", scopes.join(", "));
-                    // A child's own tool call never reached the client, so its
-                    // permission rides on the `task` call the client can see,
-                    // and only the child's channel may take the answer.
+                    // The cache is keyed by the call that asked for permission,
+                    // so look it up before the remap below. A subagent is left
+                    // out on purpose: nothing makes a child's ids unique
+                    // against the parent's, and naming the wrong file in a
+                    // security prompt is worse than naming none.
+                    let raw_input = subagent.is_none().then(|| tool_inputs.get(&id)).flatten();
+                    // A child's own tool call never reached the client, nor
+                    // this cache, so its permission rides on the `task` call
+                    // the client can see, only the child's channel may take the
+                    // answer, and the title is all the dialog gets.
                     let (id, title, answer_tx) = match subagent {
                         Some(info) => {
                             let Some(answer_tx) = info.answer_tx else {
@@ -790,9 +802,13 @@ fn start_event_pump(
                     let request =
                         AgentRequest::RequestPermissionRequest(RequestPermissionRequest::new(
                             sid.clone(),
-                            ToolCallUpdate::new(
-                                ToolCallId::from(id),
-                                ToolCallUpdateFields::new().title(title),
+                            translate::permission_update(
+                                id,
+                                title,
+                                &tool,
+                                raw_input,
+                                &cwd,
+                                home.as_deref(),
                             ),
                             permissions::permission_options(),
                         ));
@@ -804,12 +820,17 @@ fn start_event_pump(
                 AgentEvent::ThinkingDelta { text } => translate::thinking_delta(&text),
                 AgentEvent::ToolPending { id, name } => translate::tool_pending(&id, &name),
                 AgentEvent::ToolStart(event) => {
-                    translate::tool_start(&event, &cwd, home.as_deref())
+                    let update = translate::tool_start(&event, &cwd, home.as_deref());
+                    if let Some(raw_input) = event.raw_input {
+                        tool_inputs.insert(event.id, raw_input);
+                    }
+                    update
                 }
                 AgentEvent::ToolOutput { id, content } => translate::tool_output(&id, &content),
                 AgentEvent::ToolDone(event) => translate::tool_done(&event, &cwd, home.as_deref()),
                 AgentEvent::TurnComplete(event) => translate::usage_update(&event, cost_total),
                 AgentEvent::Done { reason, .. } => {
+                    tool_inputs.clear();
                     if let Some(id) = pending.lock().unwrap().prompt.take() {
                         let resp = PromptResponse::new(translate::map_done_reason(reason));
                         send(
@@ -820,6 +841,10 @@ fn start_event_pump(
                     continue;
                 }
                 AgentEvent::Error { message } => {
+                    // A turn that dies on a provider 500 never reaches `Done`,
+                    // and the pump outlives the session, so without this the
+                    // whole file a `write` was carrying stays pinned forever.
+                    tool_inputs.clear();
                     if let Some(id) = pending.lock().unwrap().prompt.take() {
                         let error = AcpError::internal_error().data(Value::String(message));
                         send(&out_tx, Response::<AgentResponse>::new(id, Err(error)));
@@ -867,7 +892,7 @@ fn json_str(e: &impl std::fmt::Display) -> Value {
 #[cfg(test)]
 mod tests {
     use maki_agent::permissions::PermissionManager;
-    use maki_agent::{DoneReason, EventSender, SubagentInfo, TurnCompleteEvent};
+    use maki_agent::{DoneReason, EventSender, SubagentInfo, ToolStartEvent, TurnCompleteEvent};
     use maki_config::ToolKey;
     use maki_providers::{ContentBlock as MsgBlock, Role, TokenUsage};
     use maki_storage::StateDir;
@@ -967,6 +992,10 @@ mod tests {
     const PERMISSION_TOOL: &str = "write";
     const MAIN_PERMISSION_TITLE: &str = "write: /project";
     const CHILD_PERMISSION_TITLE: &str = "task: write: /project";
+    const TURN_ERROR: &str = "provider returned 500";
+    /// What `openai_compat` substitutes when a provider sends a tool call with
+    /// no id, so two runs of the same session can land on it at once.
+    const COLLIDING_TOOL_USE_ID: &str = "maki_unnamed_0";
 
     /// Feeds a turn and waits for the pump to drain it, so no assertion has to
     /// wait on a clock. `sender` outlives the guard on purpose: that is the ACP
@@ -1010,6 +1039,31 @@ mod tests {
             opts: None,
             answer_tx,
         }
+    }
+
+    fn done_event() -> AgentEvent {
+        AgentEvent::Done {
+            usage: TokenUsage::default(),
+            cost: None,
+            list_cost: None,
+            context_size: 0,
+            context_window: CONTEXT_WINDOW,
+            num_turns: 1,
+            reason: DoneReason::EndTurn,
+        }
+    }
+
+    fn write_tool_start(tool_use_id: &str) -> AgentEvent {
+        AgentEvent::ToolStart(Box::new(ToolStartEvent {
+            id: tool_use_id.to_owned(),
+            tool: Arc::from(PERMISSION_TOOL),
+            summary: String::new(),
+            render_header: None,
+            annotation: None,
+            input: None,
+            raw_input: Some(serde_json::json!({"path": PUMP_CWD, "content": QUEUED_TEXT})),
+            output: None,
+        }))
     }
 
     fn permission_request(tool_use_id: &str) -> AgentEvent {
@@ -1129,17 +1183,7 @@ mod tests {
                     text: QUEUED_TEXT.to_owned(),
                 })
                 .unwrap();
-            sender
-                .send(AgentEvent::Done {
-                    usage: TokenUsage::default(),
-                    cost: None,
-                    list_cost: None,
-                    context_size: 0,
-                    context_window: CONTEXT_WINDOW,
-                    num_turns: 1,
-                    reason: DoneReason::EndTurn,
-                })
-                .unwrap();
+            sender.send(done_event()).unwrap();
         });
 
         let chunk = out_rx.try_recv().expect("the queued text reaches the wire");
@@ -1151,6 +1195,68 @@ mod tests {
         assert_eq!(answer["id"], PROMPT_ID);
         assert_eq!(answer["result"]["stopReason"], "end_turn");
         assert!(pending(&srv).lock().unwrap().prompt.is_none());
+    }
+
+    /// A cached input holds the whole file a `write` is about to lay down, and
+    /// this pump lives as long as the session does, so a turn that died on a
+    /// provider error has to let go of it just like a turn that finished.
+    #[test_case(None, true ; "a_live_turn_shows_the_file_its_tool_call_named")]
+    #[test_case(Some(done_event()), false ; "a_finished_turn_releases_its_tool_inputs")]
+    #[test_case(Some(AgentEvent::Error { message: TURN_ERROR.to_owned() }), false ; "a_failed_turn_releases_its_tool_inputs")]
+    fn a_terminal_event_releases_the_turns_tool_inputs(
+        terminal: Option<AgentEvent>,
+        keeps_input: bool,
+    ) {
+        let (srv, .., out_rx) = test_server();
+        run_pump(&srv, None, |sender| {
+            sender.send(write_tool_start(PARENT_TOOL_USE_ID)).unwrap();
+            if let Some(event) = terminal {
+                sender.send(event).unwrap();
+            }
+            sender.send(permission_request(PARENT_TOOL_USE_ID)).unwrap();
+        });
+
+        let request = out_rx
+            .try_iter()
+            .last()
+            .expect("the permission request reaches the client");
+        let call = &request["params"]["toolCall"];
+        assert_eq!(request["method"], "session/request_permission");
+        assert_eq!(call["title"], MAIN_PERMISSION_TITLE);
+        assert_eq!(!call["rawInput"].is_null(), keeps_input, "{request}");
+    }
+
+    /// Ids are only unique inside one run, so a child can ask about a call whose
+    /// id the parent already cached. The dialog has to stay title only, or it
+    /// would name a file the subagent is not touching.
+    #[test]
+    fn a_subagent_permission_ignores_a_colliding_cached_input() {
+        let (srv, .., out_rx) = test_server();
+        let (answer_tx, _answer_rx) = flume::unbounded();
+        run_pump(&srv, None, |sender| {
+            sender
+                .send(write_tool_start(COLLIDING_TOOL_USE_ID))
+                .unwrap();
+            sender
+                .send_envelope(Envelope {
+                    event: permission_request(COLLIDING_TOOL_USE_ID),
+                    subagent: Some(subagent(Some(answer_tx))),
+                    run_id: 0,
+                })
+                .unwrap();
+        });
+
+        let request = out_rx
+            .try_iter()
+            .last()
+            .expect("the permission request reaches the client");
+        let call = &request["params"]["toolCall"];
+        assert_eq!(request["method"], "session/request_permission");
+        assert_eq!(call["toolCallId"], PARENT_TOOL_USE_ID);
+        assert_eq!(call["title"], CHILD_PERMISSION_TITLE);
+        for field in ["kind", "locations", "rawInput", "content"] {
+            assert!(call[field].is_null(), "{field} must stay unset: {request}");
+        }
     }
 
     /// A resumed session opens with a bill, and subagent turns spend against it

--- a/maki-acp/src/translate.rs
+++ b/maki-acp/src/translate.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use agent_client_protocol_schema::{
@@ -11,6 +12,10 @@ use maki_agent::types::{ToolDoneEvent, ToolOutput, ToolStartEvent, TurnCompleteE
 use maki_providers::{ContentBlock as MsgBlock, ImageMediaType, Message, Role as MsgRole};
 
 const MIN_FENCE_LEN: usize = 3;
+const WRITE_TOOL: &str = "write";
+/// One task pumps every session update, so reading a giant file to render a
+/// diff nobody can read would stall the whole stream.
+const MAX_DIFF_OLD_TEXT_BYTES: u64 = 256 * 1024;
 /// Model pricing is quoted in US dollars, so that is the reported currency.
 const CURRENCY: &str = "USD";
 
@@ -106,6 +111,64 @@ pub fn tool_start(event: &ToolStartEvent, cwd: &Path, home: Option<&Path>) -> Se
         ToolCallId::from(event.id.clone()),
         fields,
     ))
+}
+
+/// Zed merges a permission request into the `tool_call_update` we sent a
+/// moment earlier, so it already shows the file. JetBrains renders the request
+/// on its own, which is why we repeat the context here. Without a raw input
+/// (nothing was cached for this call) the dialog stays what it always was: a
+/// title built from the permission scopes.
+pub fn permission_update(
+    id: String,
+    title: String,
+    tool: &str,
+    raw_input: Option<&serde_json::Value>,
+    cwd: &Path,
+    home: Option<&Path>,
+) -> ToolCallUpdate {
+    let mut fields = ToolCallUpdateFields::new().title(title);
+
+    if let Some(raw_input) = raw_input {
+        fields = fields.kind(tool_kind(tool)).raw_input(raw_input.clone());
+
+        let locations = tool_locations(tool, Some(raw_input), cwd, home);
+        if !locations.is_empty() {
+            fields = fields.locations(locations);
+        }
+
+        if let Some(diff) = write_diff(tool, raw_input, cwd, home) {
+            fields = fields.content(vec![ToolCallContent::Diff(diff)]);
+        }
+    }
+
+    ToolCallUpdate::new(ToolCallId::from(id), fields)
+}
+
+/// `write` replaces the whole file, so its input is the new text and disk still
+/// holds the old one: the write lock is only taken once permission is granted.
+/// `edit` gets no diff on purpose, applying its old_string/new_string here
+/// would be a second copy of the plugin's logic, free to drift.
+fn write_diff(
+    tool: &str,
+    raw_input: &serde_json::Value,
+    cwd: &Path,
+    home: Option<&Path>,
+) -> Option<Diff> {
+    if tool != WRITE_TOOL {
+        return None;
+    }
+    let new_text = raw_input.get("content")?.as_str()?;
+    let path = resolve_path(input_path(raw_input)?, cwd, home)?;
+
+    let old_text = match fs::metadata(&path) {
+        // The model picks this path, and a FIFO reports a length of zero, walks
+        // past the cap and then blocks the read until someone writes to it,
+        // which would freeze every update this session still has to send.
+        Ok(meta) if meta.len() > MAX_DIFF_OLD_TEXT_BYTES || !meta.is_file() => return None,
+        Ok(_) => fs::read_to_string(&path).ok(),
+        Err(_) => None,
+    };
+    Some(Diff::new(path, new_text.to_string()).old_text(old_text))
 }
 
 /// File locations the tool call touches, per ACP "Following the Agent". The
@@ -407,12 +470,20 @@ mod tests {
 
     use maki_providers::ImageSource;
     use serde_json::json;
+    use tempfile::TempDir;
     use test_case::test_case;
 
     use super::*;
 
     const CWD: &str = "/home/user/project";
     const HOME: &str = "/home/user";
+    const EDIT_TOOL: &str = "edit";
+    const PERMISSION_ID: &str = "tu-perm";
+    const PERMISSION_TITLE: &str = "write: src/main.rs";
+    const REL_PATH: &str = "src/main.rs";
+    const ABS_PATH: &str = "/home/user/project/src/main.rs";
+    const OLD_TEXT: &str = "fn main() {}\n";
+    const NEW_TEXT: &str = "fn main() { run() }\n";
 
     #[test_case("1: mod render\n2: mod segment", "```\n1: mod render\n2: mod segment\n```" ; "plain_text_gets_default_fence")]
     #[test_case("has ```rust\ncode\n``` inside", "````\nhas ```rust\ncode\n``` inside\n````" ; "fence_longer_than_inner_backticks")]
@@ -787,5 +858,105 @@ mod tests {
         let event = turn_event(None, 200_000, None);
         let json = serde_json::to_value(usage_update(&event, None)).unwrap();
         assert_eq!(json["used"], 51_200);
+    }
+
+    fn permission_json(
+        tool: &str,
+        raw_input: Option<&serde_json::Value>,
+        cwd: &Path,
+    ) -> serde_json::Value {
+        let update = permission_update(
+            PERMISSION_ID.to_string(),
+            PERMISSION_TITLE.to_string(),
+            tool,
+            raw_input,
+            cwd,
+            Some(Path::new(HOME)),
+        );
+        serde_json::to_value(update).unwrap()
+    }
+
+    fn write_permission_json(dir: &Path) -> serde_json::Value {
+        permission_json(
+            WRITE_TOOL,
+            Some(&json!({"path": REL_PATH, "content": NEW_TEXT})),
+            dir,
+        )
+    }
+
+    #[test_case(WRITE_TOOL, json!({"path": REL_PATH, "content": NEW_TEXT}), true ; "write_input_gets_a_diff")]
+    #[test_case(EDIT_TOOL, json!({"path": REL_PATH, "old_string": "a", "new_string": "b"}), false ; "edit_input_has_no_diff")]
+    fn permission_update_carries_file_context(
+        tool: &str,
+        raw_input: serde_json::Value,
+        has_diff: bool,
+    ) {
+        let json = permission_json(tool, Some(&raw_input), Path::new(CWD));
+        assert_eq!(json["toolCallId"], PERMISSION_ID);
+        assert_eq!(json["title"], PERMISSION_TITLE);
+        assert_eq!(json["rawInput"], raw_input);
+        assert_eq!(json["locations"], json!([{"path": ABS_PATH}]));
+        assert_eq!(!json["content"].is_null(), has_diff, "{json}");
+        // The registry is empty in unit tests, so every kind resolves to
+        // "other" and presence is all there is to check.
+        assert!(!json["kind"].is_null(), "{json}");
+    }
+
+    /// The old text is read at permission time and is still the pre-write
+    /// version, because the write lock is taken after the permission gate.
+    #[test_case(None, None ; "a_new_file_has_no_old_text")]
+    #[test_case(Some(OLD_TEXT.to_string()), Some(OLD_TEXT) ; "an_existing_file_diffs_against_disk")]
+    fn write_permission_diffs_against_the_file_on_disk(
+        on_disk: Option<String>,
+        expected_old: Option<&str>,
+    ) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(REL_PATH);
+        if let Some(contents) = on_disk {
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, contents).unwrap();
+        }
+
+        let json = write_permission_json(dir.path());
+        assert_eq!(json["content"][0]["type"], "diff");
+        assert_eq!(json["content"][0]["path"], path.to_str().unwrap());
+        assert_eq!(json["content"][0]["newText"], NEW_TEXT);
+        assert_eq!(json["content"][0]["oldText"], json!(expected_old));
+    }
+
+    #[test]
+    fn write_permission_skips_the_diff_for_an_oversized_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(REL_PATH);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "x".repeat(MAX_DIFF_OLD_TEXT_BYTES as usize + 1)).unwrap();
+
+        let json = write_permission_json(dir.path());
+        assert!(json["content"].is_null(), "{json}");
+        assert_eq!(json["rawInput"]["content"], NEW_TEXT);
+    }
+
+    /// A FIFO reads as empty metadata and then blocks until someone writes to
+    /// it, and no test can create one on Windows, so a directory stands in for
+    /// everything that is not a regular file.
+    #[test]
+    fn write_permission_skips_the_diff_for_a_path_that_is_not_a_regular_file() {
+        let dir = TempDir::new().unwrap();
+        fs::create_dir_all(dir.path().join(REL_PATH)).unwrap();
+
+        let json = write_permission_json(dir.path());
+        assert!(json["content"].is_null(), "{json}");
+    }
+
+    /// A cache miss must not regress the dialog: it keeps the scope title it
+    /// has always had.
+    #[test]
+    fn permission_update_without_cached_input_is_title_only() {
+        let json = permission_json(WRITE_TOOL, None, Path::new(CWD));
+        assert_eq!(json["toolCallId"], PERMISSION_ID);
+        assert_eq!(json["title"], PERMISSION_TITLE);
+        for field in ["kind", "locations", "rawInput", "content"] {
+            assert!(json[field].is_null(), "{field} must stay unset: {json}");
+        }
     }
 }


### PR DESCRIPTION
`tool_start` already sends the path, the kind and the raw input under the same tool call id, and Zed merges that into the permission request, but JetBrains renders the request on its own, so a write prompt there was a bare Accept/Deny with nothing naming the file.

The pump now keeps each `ToolStart` raw input for the turn, the way `sdk_mode` does, and replays it into the request, and `write` also gets a diff whose `old_text` is read off disk, still the pre-write version because the write lock is taken after the permission gate.

The title stays as the fallback, since scopes are permission matching keys and not paths for tools like `bash` or `webfetch`, so a call with nothing cached, a subagent's for one, keeps the dialog it had before.

Fixes #982