### PR TITLE
feat: add Requesty as an OpenAI-compatible provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ An AI coding agent optimized for minimal use of context tokens, while providing 
 * Z.AI - `ZHIPU_API_KEY`.
 * DeepSeek - `DEEPSEEK_API_KEY`.
 * OpenRouter - `OPENROUTER_API_KEY`.
+* Requesty - `REQUESTY_API_KEY`. Set `REQUESTY_BASE_URL=https://router.eu.requesty.ai/v1` for the EU region.
 * Synthetic - `SYNTHETIC_API_KEY`.
 * Regolo - `REGOLO_API_KEY`. EU-hosted open-weight models.
 * TensorX - `TENSORX_API_KEY`.

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -529,6 +529,16 @@ fn no_catalog_note(kind: ProviderKind) -> &'static str {
              Browse available models at [openrouter.ai/models](https://openrouter.ai/models). \
              Use any model ID directly (e.g. `openrouter/anthropic/claude-sonnet-4`)."
         }
+        ProviderKind::Requesty => {
+            "Requesty routes 700+ models from many providers behind a single API key. \
+             Models are listed live from the API: curated managed policies first \
+             (short ids such as `requesty/claude-sonnet-4-5` or `requesty/gpt-5.4-mini`, \
+             `@eu` variants route only through EU providers), then the full \
+             `<vendor>/<model>` catalog (e.g. `requesty/openai/gpt-4o-mini`). \
+             Get a key at [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys). \
+             Set `REQUESTY_BASE_URL=https://router.eu.requesty.ai/v1` to keep all \
+             traffic in the EU (`router.us.requesty.ai` and `router.ap.requesty.ai` also exist)."
+        }
         _ => "No hardcoded model catalog. Use any model ID supported by this provider.",
     }
 }

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -537,7 +537,7 @@ fn no_catalog_note(kind: ProviderKind) -> &'static str {
              `<vendor>/<model>` catalog (e.g. `requesty/openai/gpt-4o-mini`). \
              Get a key at [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys). \
              Set `REQUESTY_BASE_URL=https://router.eu.requesty.ai/v1` to keep all \
-             traffic in the EU (`router.us.requesty.ai` and `router.ap.requesty.ai` also exist)."
+             traffic in the EU."
         }
         _ => "No hardcoded model catalog. Use any model ID supported by this provider.",
     }

--- a/maki-providers/src/manifest.rs
+++ b/maki-providers/src/manifest.rs
@@ -2,7 +2,7 @@ use crate::model::{ModelEntry, ModelFamily, ModelTier};
 use crate::pricing::PricingSchedule;
 use crate::providers::{
     anthropic, aperture, copilot, custom, deepseek, dynamic, google, llama_cpp, mistral, ollama,
-    openai, opencode, openrouter, regolo, synthetic, tensorx, xai, zai,
+    openai, opencode, openrouter, regolo, requesty, synthetic, tensorx, xai, zai,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -140,6 +140,18 @@ const OPENROUTER: ProviderManifest = ProviderManifest {
     pricing_schedule: None,
 };
 
+const REQUESTY: ProviderManifest = ProviderManifest {
+    slug: "requesty",
+    display_name: "Requesty",
+    family: ModelFamily::Generic,
+    supports_thinking: true,
+    accepts_arbitrary_models: true,
+    fallback_max_output: Some(128_000),
+    fallback_context_window: 200_000,
+    models: requesty::models(),
+    pricing_schedule: None,
+};
+
 const REGOLO: ProviderManifest = ProviderManifest {
     slug: "regolo",
     display_name: "Regolo",
@@ -235,6 +247,7 @@ const BUILTINS: &[ProviderManifest] = &[
     ZAI,
     DEEPSEEK,
     OPENROUTER,
+    REQUESTY,
     REGOLO,
     SYNTHETIC,
     TENSORX,

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -29,6 +29,7 @@ use crate::providers::openai::OpenAi;
 use crate::providers::opencode::Opencode;
 use crate::providers::openrouter::OpenRouter;
 use crate::providers::regolo::Regolo;
+use crate::providers::requesty::Requesty;
 use crate::providers::synthetic::Synthetic;
 use crate::providers::tensorx::TensorX;
 use crate::providers::xai::Xai;
@@ -51,6 +52,7 @@ pub enum ProviderKind {
     DeepSeek,
     #[strum(serialize = "openrouter")]
     OpenRouter,
+    Requesty,
     Synthetic,
     Regolo,
     #[strum(serialize = "tensorx")]
@@ -75,6 +77,7 @@ impl ProviderKind {
             Self::Zai => "Z.AI",
             Self::DeepSeek => "DeepSeek",
             Self::OpenRouter => "OpenRouter",
+            Self::Requesty => "Requesty",
             Self::Synthetic => "Synthetic",
             Self::Regolo => "Regolo",
             Self::TensorX => "TensorX",
@@ -96,6 +99,7 @@ impl ProviderKind {
             Self::Zai => "ZHIPU_API_KEY",
             Self::DeepSeek => "DEEPSEEK_API_KEY",
             Self::OpenRouter => "OPENROUTER_API_KEY",
+            Self::Requesty => "REQUESTY_API_KEY",
             Self::Synthetic => "SYNTHETIC_API_KEY",
             Self::Regolo => "REGOLO_API_KEY",
             Self::TensorX => "TENSORX_API_KEY",
@@ -119,6 +123,7 @@ impl ProviderKind {
             Self::Zai => "https://api.z.ai/api/paas/v4",
             Self::DeepSeek => "https://api.deepseek.com",
             Self::OpenRouter => "https://openrouter.ai/api/v1",
+            Self::Requesty => "https://router.requesty.ai/v1",
             Self::Synthetic => "https://api.synthetic.new/openai/v1",
             Self::Regolo => "https://api.regolo.ai/v1",
             Self::TensorX => "https://api.tensorx.ai/v1",
@@ -152,6 +157,9 @@ impl ProviderKind {
             Self::OpenRouter => {
                 Some("300+ models from all providers, prompt caching, provider routing")
             }
+            Self::Requesty => Some(
+                "700+ models behind one key, curated managed routing policies, EU region via `REQUESTY_BASE_URL`",
+            ),
             Self::Opencode => Some(
                 "Dynamically discovered models via [models.dev](https://models.dev/) + all the models provided by Opencode Zen API",
             ),
@@ -177,6 +185,7 @@ impl ProviderKind {
             Self::Zai => ModelFamily::Glm,
             Self::DeepSeek => ModelFamily::Generic,
             Self::OpenRouter => ModelFamily::Generic,
+            Self::Requesty => ModelFamily::Generic,
             Self::Synthetic => ModelFamily::Synthetic,
             Self::Regolo => ModelFamily::Generic,
             Self::TensorX => ModelFamily::Generic,
@@ -203,6 +212,7 @@ impl ProviderKind {
             Self::Zai => Some(16_000),
             Self::DeepSeek => Some(384_000),
             Self::OpenRouter => Some(128_000),
+            Self::Requesty => Some(128_000),
             Self::Synthetic => Some(32_000),
             Self::Regolo => Some(120_000),
             Self::TensorX => None,
@@ -224,6 +234,7 @@ impl ProviderKind {
             Self::Zai => 128_000,
             Self::DeepSeek => 1_000_000,
             Self::OpenRouter => 200_000,
+            Self::Requesty => 200_000,
             Self::Synthetic => 128_000,
             Self::Regolo => 120_000,
             Self::TensorX => 200_000,
@@ -251,6 +262,7 @@ impl ProviderKind {
             Self::Zai => Ok(Box::new(Zai::new(timeouts)?)),
             Self::DeepSeek => Ok(Box::new(DeepSeek::new(timeouts)?)),
             Self::OpenRouter => Ok(Box::new(OpenRouter::new(timeouts)?)),
+            Self::Requesty => Ok(Box::new(Requesty::new(timeouts)?)),
             Self::Synthetic => Ok(Box::new(Synthetic::new(timeouts)?)),
             Self::Regolo => Ok(Box::new(Regolo::new(timeouts)?)),
             Self::TensorX => Ok(Box::new(TensorX::new(timeouts)?)),

--- a/maki-providers/src/providers/aperture.rs
+++ b/maki-providers/src/providers/aperture.rs
@@ -21,6 +21,7 @@ use super::mistral::Mistral;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::openrouter::OpenRouter;
 use super::regolo::Regolo;
+use super::requesty::Requesty;
 use super::synthetic::Synthetic;
 use super::tensorx::TensorX;
 use super::zai::Zai;
@@ -127,6 +128,7 @@ fn compat_kind(kind: ProviderKind) -> Option<ProviderKind> {
         | ProviderKind::Zai
         | ProviderKind::DeepSeek
         | ProviderKind::OpenRouter
+        | ProviderKind::Requesty
         | ProviderKind::Synthetic
         | ProviderKind::Regolo
         | ProviderKind::TensorX => Some(kind),
@@ -179,6 +181,7 @@ fn default_path_prefix(kind: Option<ProviderKind>) -> &'static str {
             | ProviderKind::Mistral
             | ProviderKind::DeepSeek
             | ProviderKind::OpenRouter
+            | ProviderKind::Requesty
             | ProviderKind::Synthetic
             | ProviderKind::Regolo
             | ProviderKind::TensorX
@@ -239,6 +242,9 @@ fn build_routed_provider(
         }
         ProviderKind::OpenRouter => {
             Box::new(OpenRouter::with_auth(auth, timeouts).with_system_prefix(system_prefix))
+        }
+        ProviderKind::Requesty => {
+            Box::new(Requesty::with_auth(auth, timeouts).with_system_prefix(system_prefix))
         }
         ProviderKind::Synthetic => {
             Box::new(Synthetic::with_auth(auth, timeouts).with_system_prefix(system_prefix))

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -33,6 +33,7 @@ use super::openai::OpenAi;
 use super::opencode::Opencode;
 use super::openrouter::OpenRouter;
 use super::regolo::Regolo;
+use super::requesty::Requesty;
 use super::synthetic::Synthetic;
 use super::tensorx::TensorX;
 use super::xai::Xai;
@@ -589,6 +590,10 @@ pub fn create(slug: &str, timeouts: super::Timeouts) -> Result<Box<dyn Provider>
         ),
         ProviderKind::OpenRouter => Box::new(
             OpenRouter::with_auth(auth.clone(), timeouts)
+                .with_system_prefix(meta.system_prefix.clone()),
+        ),
+        ProviderKind::Requesty => Box::new(
+            Requesty::with_auth(auth.clone(), timeouts)
                 .with_system_prefix(meta.system_prefix.clone()),
         ),
         ProviderKind::TensorX => Box::new(

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -8,7 +8,7 @@ use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier, Thin
 use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
-use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
+use super::openai_compat::{MODELS_PATH, OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
 
 static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
@@ -235,7 +235,7 @@ impl Provider for Mistral {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
             self.compat
-                .fetch_and_parse_models(&auth, |m| {
+                .fetch_and_parse_models(&auth, MODELS_PATH, |m| {
                     // Filter: only completion_chat capable models
                     let has_completion_chat = m
                         .get("capabilities")

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -34,6 +34,7 @@ pub(crate) mod openai_compat;
 pub mod opencode;
 pub(crate) mod openrouter;
 pub(crate) mod regolo;
+pub(crate) mod requesty;
 pub(crate) mod synthetic;
 pub(crate) mod tensorx;
 pub(crate) mod xai;

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -18,6 +18,9 @@ const STREAM_DONE: &str = "[DONE]";
 /// not size the accumulator vec.
 const MAX_TOOL_CALLS_PER_MESSAGE: usize = 512;
 const UNNAMED_TOOL_ID_PREFIX: &str = "maki_unnamed_";
+/// The listing every OpenAI compatible API serves, relative to the base URL.
+/// Providers with a second catalog pass their own path instead.
+pub(crate) const MODELS_PATH: &str = "/models";
 static NEXT_UNNAMED_TOOL_ID: AtomicU64 = AtomicU64::new(0);
 
 pub(crate) struct OpenAiCompatConfig {
@@ -206,13 +209,16 @@ impl OpenAiCompatProvider {
         }
     }
 
+    /// Parses the `data` array served at `{base}{path}`, keeping the entries
+    /// `parse_fn` accepts. `path` is [`MODELS_PATH`] for most providers.
     pub async fn fetch_and_parse_models(
         &self,
         auth: &ResolvedAuth,
+        path: &str,
         parse_fn: impl Fn(&Value) -> Option<crate::model::ModelInfo>,
     ) -> Result<Vec<crate::model::ModelInfo>, AgentError> {
         let base = self.base_url(auth);
-        let url = format!("{base}/models");
+        let url = format!("{base}{path}");
         let body_text = self.get_text(auth, &url).await?;
         let body: Value = serde_json::from_str(&body_text)?;
 
@@ -273,7 +279,7 @@ impl OpenAiCompatProvider {
         &self,
         auth: &ResolvedAuth,
     ) -> Result<Vec<crate::model::ModelInfo>, AgentError> {
-        self.fetch_and_parse_models(auth, Self::default_model_parser)
+        self.fetch_and_parse_models(auth, MODELS_PATH, Self::default_model_parser)
             .await
     }
 }

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -11,7 +11,7 @@ use crate::{
     dialect,
 };
 
-use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
+use super::openai_compat::{MODELS_PATH, OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
 
 const REFERER: &str = "https://maki.sh";
@@ -224,7 +224,9 @@ impl Provider for OpenRouter {
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<ModelInfo>, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
-            self.compat.fetch_and_parse_models(&auth, parse_model).await
+            self.compat
+                .fetch_and_parse_models(&auth, MODELS_PATH, parse_model)
+                .await
         })
     }
 

--- a/maki-providers/src/providers/requesty.rs
+++ b/maki-providers/src/providers/requesty.rs
@@ -1,0 +1,370 @@
+use std::sync::{Arc, Mutex};
+
+use flume::Sender;
+use maki_storage::id::SessionRef;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tracing::warn;
+
+use crate::model::{Model, ModelEntry, ModelInfo, ModelPricing};
+use crate::provider::{BoxFuture, Provider};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
+
+use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
+use super::{KeyPool, ResolvedAuth};
+
+const REFERER: &str = "https://maki.sh";
+const APP_TITLE: &str = "maki";
+const PER_MILLION: f64 = 1_000_000.0;
+/// Curated, Requesty-maintained routing policies. Short stable ids
+/// (`claude-sonnet-4-5`, `gpt-5.4-mini`, `gpt-5-mini@eu`) that route across
+/// several upstream providers; listed first so users see them before the
+/// raw `<vendor>/<model>` catalog.
+const MANAGED_MODELS_PATH: &str = "/models/managed";
+/// Full `<vendor>/<model>` catalog.
+const MODELS_PATH: &str = "/models";
+const CHAT_API: &str = "chat";
+
+static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
+    slug: "requesty",
+    api_key_env: "REQUESTY_API_KEY",
+    base_url: "https://router.requesty.ai/v1",
+    max_tokens_field: "max_tokens",
+    include_stream_usage: true,
+    provider_name: "Requesty",
+};
+
+inventory::submit!(maki_config::providers::BuiltInProvider {
+    slug: "requesty",
+    display_name: "Requesty",
+    protocol: maki_config::providers::Protocol::Openai,
+    default_base_url: "https://router.requesty.ai/v1",
+    default_api_key_env: "REQUESTY_API_KEY",
+    default_model: "requesty/openai/gpt-5.5",
+    plans: None,
+    login_url: Some("https://app.requesty.ai/api-keys"),
+    needs_url: false,
+});
+
+pub(crate) const fn models() -> &'static [ModelEntry] {
+    &[]
+}
+
+/// The subset of a Requesty `/models` entry maki cares about. Both the managed
+/// and the full catalog share this shape. Prices are USD per token.
+#[derive(Debug, Deserialize)]
+struct RequestyModel {
+    id: String,
+    #[serde(default)]
+    api: Option<String>,
+    #[serde(default)]
+    context_window: Option<u32>,
+    #[serde(default)]
+    max_output_tokens: Option<u32>,
+    #[serde(default)]
+    input_price: Option<f64>,
+    #[serde(default)]
+    output_price: Option<f64>,
+    #[serde(default)]
+    cached_price: Option<f64>,
+    #[serde(default)]
+    caching_price: Option<f64>,
+    #[serde(default)]
+    supports_reasoning: Option<bool>,
+    #[serde(default)]
+    supports_vision: Option<bool>,
+}
+
+pub struct Requesty {
+    compat: OpenAiCompatProvider,
+    auth: Arc<Mutex<ResolvedAuth>>,
+    key_pool: Option<KeyPool>,
+    system_prefix: Option<String>,
+}
+
+impl Requesty {
+    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
+        let pool = KeyPool::resolve(CONFIG.slug, CONFIG.api_key_env)?;
+        Ok(Self {
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
+            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(
+                CONFIG.slug,
+                pool.current(),
+            )?)),
+            key_pool: Some(pool),
+            system_prefix: None,
+        })
+    }
+
+    pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: super::Timeouts) -> Self {
+        Self {
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
+            auth,
+            key_pool: None,
+            system_prefix: None,
+        }
+    }
+
+    pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
+        self.system_prefix = prefix;
+        self
+    }
+
+    async fn fetch_models(
+        &self,
+        auth: &ResolvedAuth,
+        path: &str,
+    ) -> Result<Vec<ModelInfo>, AgentError> {
+        let base = self.compat.base_url(auth);
+        let body_text = self.compat.get_text(auth, &format!("{base}{path}")).await?;
+        let body: Value = serde_json::from_str(&body_text)?;
+        let mut models: Vec<ModelInfo> = body["data"]
+            .as_array()
+            .map(|arr| arr.iter().filter_map(parse_model).collect())
+            .unwrap_or_default();
+        models.sort_by(|a, b| a.id.cmp(&b.id));
+        Ok(models)
+    }
+}
+
+fn parse_model(m: &Value) -> Option<ModelInfo> {
+    let model: RequestyModel = serde_json::from_value(m.clone()).ok()?;
+
+    // Only chat models: the catalog also lists embedding and other APIs.
+    if model.api.as_deref().is_some_and(|api| api != CHAT_API) {
+        return None;
+    }
+
+    // Requesty reports per-token prices; scale to $/M as `ModelPricing`
+    // expects. A missing price stays `None` so it never reads as free.
+    let per_million = |p: Option<f64>| p.map(|v| v * PER_MILLION);
+    let pricing = match (
+        per_million(model.input_price),
+        per_million(model.output_price),
+    ) {
+        (Some(input), Some(output)) => Some(ModelPricing {
+            input,
+            output,
+            cache_write: per_million(model.caching_price).unwrap_or(0.0),
+            cache_read: per_million(model.cached_price).unwrap_or(0.0),
+            fast: None,
+        }),
+        _ => None,
+    };
+
+    Some(ModelInfo {
+        id: model.id,
+        context_window: model.context_window,
+        max_output_tokens: model.max_output_tokens,
+        pricing,
+        supports_thinking: Some(model.supports_reasoning == Some(true)),
+        supports_vision: Some(model.supports_vision == Some(true)),
+        tier: None,
+        provider_info: None,
+    })
+}
+
+/// Managed policies first, then the full catalog, deduplicated by id. Either
+/// list alone is still a usable answer, so one failing does not fail the other.
+fn merge_models(managed: Vec<ModelInfo>, catalog: Vec<ModelInfo>) -> Vec<ModelInfo> {
+    let mut merged = managed;
+    for model in catalog {
+        if !merged.iter().any(|m| m.id == model.id) {
+            merged.push(model);
+        }
+    }
+    merged
+}
+
+impl Provider for Requesty {
+    fn stream_message<'a>(
+        &'a self,
+        model: &'a Model,
+        messages: &'a [Message],
+        system: &'a str,
+        tools: &'a Value,
+        event_tx: &'a Sender<ProviderEvent>,
+        opts: RequestOptions,
+        _session_id: Option<&'a SessionRef>,
+    ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            let mut buf = String::new();
+            let system = super::with_prefix(&self.system_prefix, system, &mut buf);
+            let mut body = self.compat.build_body(model, messages, system, tools);
+
+            // Requesty only inserts Anthropic cache breakpoints when asked to.
+            // Without this flag Claude pays full input price every turn.
+            body["requesty"] = json!({"auto_cache": true});
+
+            if model.supports_thinking() {
+                opts.thinking
+                    .apply_reasoning_effort(&mut body, &dialect::PREFER_HIGH, model);
+            }
+
+            let extra_headers = [("HTTP-Referer", REFERER), ("X-Title", APP_TITLE)];
+            self.compat
+                .do_stream(model, &extra_headers, &body, event_tx, &auth)
+                .await
+        })
+    }
+
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<ModelInfo>, AgentError>> {
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            let managed = self.fetch_models(&auth, MANAGED_MODELS_PATH).await;
+            let catalog = self.fetch_models(&auth, MODELS_PATH).await;
+            match (managed, catalog) {
+                (Ok(managed), Ok(catalog)) => Ok(merge_models(managed, catalog)),
+                (Ok(managed), Err(e)) => {
+                    warn!(error = %e, "requesty: full catalog unavailable, listing managed models only");
+                    Ok(managed)
+                }
+                (Err(e), Ok(catalog)) => {
+                    warn!(error = %e, "requesty: managed models unavailable, listing full catalog only");
+                    Ok(catalog)
+                }
+                (Err(e), Err(_)) => Err(e),
+            }
+        })
+    }
+
+    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
+        Box::pin(async {
+            Ok(self
+                .key_pool
+                .as_ref()
+                .is_some_and(|p| p.rotate_bearer(&self.auth)))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    use super::*;
+
+    const UNKNOWN_PRICE_STAYS_UNKNOWN: &str = "a price we cannot read must not become a zero price";
+
+    fn sonnet_json() -> Value {
+        json!({
+            "id": "anthropic/claude-sonnet-4-5",
+            "api": "chat",
+            "object": "model",
+            "context_window": 200_000,
+            "max_output_tokens": 64_000,
+            "input_price": 0.000003,
+            "output_price": 0.000015,
+            "cached_price": 0.0000003,
+            "supports_reasoning": true,
+            "supports_vision": true,
+            "supports_tool_calling": true,
+        })
+    }
+
+    #[test]
+    fn parse_model_scales_pricing_to_per_million() {
+        let info = parse_model(&sonnet_json()).expect("model should parse");
+
+        assert_eq!(info.id, "anthropic/claude-sonnet-4-5");
+        assert_eq!(info.context_window, Some(200_000));
+        assert_eq!(info.max_output_tokens, Some(64_000));
+        assert_eq!(info.supports_vision, Some(true));
+        assert_eq!(info.supports_thinking, Some(true));
+        let pricing = info.pricing.expect("pricing should be parsed");
+        assert!((pricing.input - 3.0).abs() < 1e-9);
+        assert!((pricing.output - 15.0).abs() < 1e-9);
+        assert!((pricing.cache_read - 0.3).abs() < 1e-9);
+        assert_eq!(pricing.cache_write, 0.0);
+    }
+
+    #[test]
+    fn parse_model_scales_cache_write() {
+        let mut m = sonnet_json();
+        m["caching_price"] = json!(0.00000375);
+
+        let pricing = parse_model(&m)
+            .expect("model should parse")
+            .pricing
+            .expect("pricing should be parsed");
+        assert!((pricing.cache_write - 3.75).abs() < 1e-9);
+    }
+
+    /// A price we cannot read must not collapse to an all-zero `ModelPricing`,
+    /// which downstream reads as "free". Unknown has to stay unknown.
+    #[test_case(json!(null), json!(null)     ; "no_prices")]
+    #[test_case(json!(0.000003), json!(null) ; "no_output_price")]
+    #[test_case(json!(null), json!(0.000015) ; "no_input_price")]
+    fn parse_model_keeps_unusable_pricing_unknown(input: Value, output: Value) {
+        let mut m = sonnet_json();
+        m["input_price"] = input;
+        m["output_price"] = output;
+
+        let info = parse_model(&m).expect("model should parse");
+        assert!(info.pricing.is_none(), "{UNKNOWN_PRICE_STAYS_UNKNOWN}");
+    }
+
+    #[test]
+    fn parse_model_without_capability_flags_reports_none_supported() {
+        let mut m = sonnet_json();
+        m["supports_reasoning"] = json!(null);
+        m["supports_vision"] = json!(null);
+
+        let info = parse_model(&m).expect("model should parse");
+        assert_eq!(info.supports_thinking, Some(false));
+        assert_eq!(info.supports_vision, Some(false));
+    }
+
+    #[test_case("embedding" ; "embedding")]
+    #[test_case("image"     ; "image")]
+    fn parse_model_skips_non_chat_apis(api: &str) {
+        let mut m = sonnet_json();
+        m["api"] = json!(api);
+
+        assert!(parse_model(&m).is_none());
+    }
+
+    #[test]
+    fn parse_model_without_api_field_is_kept() {
+        let mut m = sonnet_json();
+        m["api"] = json!(null);
+
+        assert!(parse_model(&m).is_some());
+    }
+
+    #[test]
+    fn parse_model_without_id_is_skipped() {
+        let mut m = sonnet_json();
+        m["id"] = json!(null);
+
+        assert!(parse_model(&m).is_none());
+    }
+
+    #[test]
+    fn merge_models_lists_managed_first_and_dedupes() {
+        let managed = vec![
+            ModelInfo::id_only("claude-sonnet-4-5".into()),
+            ModelInfo::id_only("gpt-5.4-mini".into()),
+        ];
+        let catalog = vec![
+            ModelInfo::id_only("anthropic/claude-sonnet-4-5".into()),
+            ModelInfo::id_only("gpt-5.4-mini".into()),
+            ModelInfo::id_only("openai/gpt-4o-mini".into()),
+        ];
+
+        let ids: Vec<String> = merge_models(managed, catalog)
+            .into_iter()
+            .map(|m| m.id)
+            .collect();
+        assert_eq!(
+            ids,
+            [
+                "claude-sonnet-4-5",
+                "gpt-5.4-mini",
+                "anthropic/claude-sonnet-4-5",
+                "openai/gpt-4o-mini",
+            ]
+        );
+    }
+}

--- a/maki-providers/src/providers/requesty.rs
+++ b/maki-providers/src/providers/requesty.rs
@@ -2,7 +2,6 @@ use std::sync::{Arc, Mutex};
 
 use flume::Sender;
 use maki_storage::id::SessionRef;
-use serde::Deserialize;
 use serde_json::{Value, json};
 use tracing::warn;
 
@@ -10,19 +9,16 @@ use crate::model::{Model, ModelEntry, ModelInfo, ModelPricing};
 use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
-use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
+use super::openai_compat::{MODELS_PATH, OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
 
 const REFERER: &str = "https://maki.sh";
 const APP_TITLE: &str = "maki";
 const PER_MILLION: f64 = 1_000_000.0;
-/// Curated, Requesty-maintained routing policies. Short stable ids
-/// (`claude-sonnet-4-5`, `gpt-5.4-mini`, `gpt-5-mini@eu`) that route across
-/// several upstream providers; listed first so users see them before the
-/// raw `<vendor>/<model>` catalog.
+/// Requesty's own curated routing policies, with short stable ids like
+/// `claude-sonnet-4-5` that spread across several upstream providers. Listed
+/// before the raw `<vendor>/<model>` catalog at [`MODELS_PATH`].
 const MANAGED_MODELS_PATH: &str = "/models/managed";
-/// Full `<vendor>/<model>` catalog.
-const MODELS_PATH: &str = "/models";
 const CHAT_API: &str = "chat";
 
 static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
@@ -48,31 +44,6 @@ inventory::submit!(maki_config::providers::BuiltInProvider {
 
 pub(crate) const fn models() -> &'static [ModelEntry] {
     &[]
-}
-
-/// The subset of a Requesty `/models` entry maki cares about. Both the managed
-/// and the full catalog share this shape. Prices are USD per token.
-#[derive(Debug, Deserialize)]
-struct RequestyModel {
-    id: String,
-    #[serde(default)]
-    api: Option<String>,
-    #[serde(default)]
-    context_window: Option<u32>,
-    #[serde(default)]
-    max_output_tokens: Option<u32>,
-    #[serde(default)]
-    input_price: Option<f64>,
-    #[serde(default)]
-    output_price: Option<f64>,
-    #[serde(default)]
-    cached_price: Option<f64>,
-    #[serde(default)]
-    caching_price: Option<f64>,
-    #[serde(default)]
-    supports_reasoning: Option<bool>,
-    #[serde(default)]
-    supports_vision: Option<bool>,
 }
 
 pub struct Requesty {
@@ -109,63 +80,81 @@ impl Requesty {
         self.system_prefix = prefix;
         self
     }
+}
 
-    async fn fetch_models(
-        &self,
-        auth: &ResolvedAuth,
-        path: &str,
-    ) -> Result<Vec<ModelInfo>, AgentError> {
-        let base = self.compat.base_url(auth);
-        let body_text = self.compat.get_text(auth, &format!("{base}{path}")).await?;
-        let body: Value = serde_json::from_str(&body_text)?;
-        let mut models: Vec<ModelInfo> = body["data"]
-            .as_array()
-            .map(|arr| arr.iter().filter_map(parse_model).collect())
-            .unwrap_or_default();
-        models.sort_by(|a, b| a.id.cmp(&b.id));
-        Ok(models)
+/// A catalog entry, read one field at a time. A missing or `null` field is the
+/// normal "Requesty does not say" and stays quiet, while a field that is there
+/// in a shape we cannot read is upstream drift: it gets a log line and costs us
+/// that one value instead of the whole model.
+struct Entry<'a> {
+    id: &'a str,
+    raw: &'a Value,
+}
+
+impl Entry<'_> {
+    fn read<T>(&self, name: &str, parse: impl Fn(&Value) -> Option<T>) -> Option<T> {
+        let value = self.raw.get(name).filter(|v| !v.is_null())?;
+        let parsed = parse(value);
+        if parsed.is_none() {
+            warn!(model = self.id, field = name, value = %value, "requesty: unreadable field, ignoring it");
+        }
+        parsed
+    }
+
+    /// Requesty sends `0` for a limit it does not know. Left as `Some(0)` it
+    /// would beat the manifest fallback and go out as `"max_tokens": 0`.
+    fn limit(&self, name: &str) -> Option<u32> {
+        self.read(name, |v| u32::try_from(v.as_u64()?).ok())
+            .filter(|n| *n > 0)
+    }
+
+    /// Prices arrive per token, `ModelPricing` wants $/M.
+    fn price(&self, name: &str) -> Option<f64> {
+        self.read(name, Value::as_f64).map(|v| v * PER_MILLION)
+    }
+
+    fn flag(&self, name: &str) -> bool {
+        self.read(name, Value::as_bool) == Some(true)
     }
 }
 
+/// Managed policies and the full catalog share this shape, so one parser reads
+/// both.
 fn parse_model(m: &Value) -> Option<ModelInfo> {
-    let model: RequestyModel = serde_json::from_value(m.clone()).ok()?;
+    let id = m["id"].as_str()?;
 
-    // Only chat models: the catalog also lists embedding and other APIs.
-    if model.api.as_deref().is_some_and(|api| api != CHAT_API) {
+    // The catalog also lists embedding and other non chat APIs.
+    if m["api"].as_str().is_some_and(|api| api != CHAT_API) {
         return None;
     }
 
-    // Requesty reports per-token prices; scale to $/M as `ModelPricing`
-    // expects. A missing price stays `None` so it never reads as free.
-    let per_million = |p: Option<f64>| p.map(|v| v * PER_MILLION);
-    let pricing = match (
-        per_million(model.input_price),
-        per_million(model.output_price),
-    ) {
+    let entry = Entry { id, raw: m };
+
+    // Half a price is no price: without both sides it would read as free.
+    let pricing = match (entry.price("input_price"), entry.price("output_price")) {
         (Some(input), Some(output)) => Some(ModelPricing {
             input,
             output,
-            cache_write: per_million(model.caching_price).unwrap_or(0.0),
-            cache_read: per_million(model.cached_price).unwrap_or(0.0),
+            cache_write: entry.price("caching_price").unwrap_or(0.0),
+            cache_read: entry.price("cached_price").unwrap_or(0.0),
             fast: None,
         }),
         _ => None,
     };
 
     Some(ModelInfo {
-        id: model.id,
-        context_window: model.context_window,
-        max_output_tokens: model.max_output_tokens,
+        id: id.to_string(),
+        context_window: entry.limit("context_window"),
+        max_output_tokens: entry.limit("max_output_tokens"),
         pricing,
-        supports_thinking: Some(model.supports_reasoning == Some(true)),
-        supports_vision: Some(model.supports_vision == Some(true)),
+        supports_thinking: Some(entry.flag("supports_reasoning")),
+        supports_vision: Some(entry.flag("supports_vision")),
         tier: None,
         provider_info: None,
     })
 }
 
-/// Managed policies first, then the full catalog, deduplicated by id. Either
-/// list alone is still a usable answer, so one failing does not fail the other.
+/// Managed policies first, then the full catalog, deduplicated by id.
 fn merge_models(managed: Vec<ModelInfo>, catalog: Vec<ModelInfo>) -> Vec<ModelInfo> {
     let mut merged = managed;
     for model in catalog {
@@ -212,8 +201,15 @@ impl Provider for Requesty {
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<ModelInfo>, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
-            let managed = self.fetch_models(&auth, MANAGED_MODELS_PATH).await;
-            let catalog = self.fetch_models(&auth, MODELS_PATH).await;
+            // Both listings at once: the picker only shows up once the slowest
+            // provider answers, so back to back round trips here cost everyone.
+            let (managed, catalog) = futures_lite::future::zip(
+                self.compat
+                    .fetch_and_parse_models(&auth, MANAGED_MODELS_PATH, parse_model),
+                self.compat
+                    .fetch_and_parse_models(&auth, MODELS_PATH, parse_model),
+            )
+            .await;
             match (managed, catalog) {
                 (Ok(managed), Ok(catalog)) => Ok(merge_models(managed, catalog)),
                 (Ok(managed), Err(e)) => {
@@ -245,54 +241,50 @@ mod tests {
 
     use super::*;
 
+    const SONNET_ID: &str = "anthropic/claude-sonnet-4-5";
     const UNKNOWN_PRICE_STAYS_UNKNOWN: &str = "a price we cannot read must not become a zero price";
+    const EPSILON: f64 = 1e-9;
 
     fn sonnet_json() -> Value {
         json!({
-            "id": "anthropic/claude-sonnet-4-5",
+            "id": SONNET_ID,
             "api": "chat",
-            "object": "model",
             "context_window": 200_000,
             "max_output_tokens": 64_000,
             "input_price": 0.000003,
             "output_price": 0.000015,
+            "caching_price": 0.00000375,
             "cached_price": 0.0000003,
             "supports_reasoning": true,
             "supports_vision": true,
-            "supports_tool_calling": true,
         })
     }
 
+    fn assert_price(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() < EPSILON,
+            "expected ${expected}/M, got ${actual}/M"
+        );
+    }
+
     #[test]
-    fn parse_model_scales_pricing_to_per_million() {
+    fn parse_model_reads_an_entry_and_scales_prices_to_per_million() {
         let info = parse_model(&sonnet_json()).expect("model should parse");
 
-        assert_eq!(info.id, "anthropic/claude-sonnet-4-5");
+        assert_eq!(info.id, SONNET_ID);
         assert_eq!(info.context_window, Some(200_000));
         assert_eq!(info.max_output_tokens, Some(64_000));
         assert_eq!(info.supports_vision, Some(true));
         assert_eq!(info.supports_thinking, Some(true));
         let pricing = info.pricing.expect("pricing should be parsed");
-        assert!((pricing.input - 3.0).abs() < 1e-9);
-        assert!((pricing.output - 15.0).abs() < 1e-9);
-        assert!((pricing.cache_read - 0.3).abs() < 1e-9);
-        assert_eq!(pricing.cache_write, 0.0);
+        assert_price(pricing.input, 3.0);
+        assert_price(pricing.output, 15.0);
+        assert_price(pricing.cache_write, 3.75);
+        assert_price(pricing.cache_read, 0.3);
     }
 
-    #[test]
-    fn parse_model_scales_cache_write() {
-        let mut m = sonnet_json();
-        m["caching_price"] = json!(0.00000375);
-
-        let pricing = parse_model(&m)
-            .expect("model should parse")
-            .pricing
-            .expect("pricing should be parsed");
-        assert!((pricing.cache_write - 3.75).abs() < 1e-9);
-    }
-
-    /// A price we cannot read must not collapse to an all-zero `ModelPricing`,
-    /// which downstream reads as "free". Unknown has to stay unknown.
+    /// Half a price is no price: an all-zero `ModelPricing` reads as free
+    /// everywhere downstream.
     #[test_case(json!(null), json!(null)     ; "no_prices")]
     #[test_case(json!(0.000003), json!(null) ; "no_output_price")]
     #[test_case(json!(null), json!(0.000015) ; "no_input_price")]
@@ -303,6 +295,33 @@ mod tests {
 
         let info = parse_model(&m).expect("model should parse");
         assert!(info.pricing.is_none(), "{UNKNOWN_PRICE_STAYS_UNKNOWN}");
+    }
+
+    /// Requesty reports `0` for a limit it does not know. Kept as `Some(0)`
+    /// it would win over the manifest fallback and go out as `"max_tokens": 0`.
+    #[test]
+    fn parse_model_reads_zero_limits_as_unknown() {
+        let mut m = sonnet_json();
+        m["context_window"] = json!(0);
+        m["max_output_tokens"] = json!(0);
+
+        let info = parse_model(&m).expect("model should parse");
+        assert_eq!(info.context_window, None);
+        assert_eq!(info.max_output_tokens, None);
+    }
+
+    /// One field changing shape upstream costs that field, not the model.
+    #[test]
+    fn parse_model_keeps_model_when_one_field_is_unreadable() {
+        let mut m = sonnet_json();
+        m["input_price"] = json!("0.000003");
+        m["max_output_tokens"] = json!("64000");
+
+        let info = parse_model(&m).expect("model should still parse");
+        assert_eq!(info.context_window, Some(200_000));
+        assert_eq!(info.max_output_tokens, None);
+        assert!(info.pricing.is_none(), "{UNKNOWN_PRICE_STAYS_UNKNOWN}");
+        assert_eq!(info.supports_thinking, Some(true));
     }
 
     #[test]
@@ -316,21 +335,14 @@ mod tests {
         assert_eq!(info.supports_vision, Some(false));
     }
 
-    #[test_case("embedding" ; "embedding")]
-    #[test_case("image"     ; "image")]
-    fn parse_model_skips_non_chat_apis(api: &str) {
+    #[test_case(json!("embedding"), false ; "embedding_is_skipped")]
+    #[test_case(json!("image"), false     ; "image_is_skipped")]
+    #[test_case(json!(null), true         ; "unlabelled_is_kept")]
+    fn parse_model_keeps_only_chat_entries(api: Value, kept: bool) {
         let mut m = sonnet_json();
-        m["api"] = json!(api);
+        m["api"] = api;
 
-        assert!(parse_model(&m).is_none());
-    }
-
-    #[test]
-    fn parse_model_without_api_field_is_kept() {
-        let mut m = sonnet_json();
-        m["api"] = json!(null);
-
-        assert!(parse_model(&m).is_some());
+        assert_eq!(parse_model(&m).is_some(), kept);
     }
 
     #[test]
@@ -348,7 +360,7 @@ mod tests {
             ModelInfo::id_only("gpt-5.4-mini".into()),
         ];
         let catalog = vec![
-            ModelInfo::id_only("anthropic/claude-sonnet-4-5".into()),
+            ModelInfo::id_only(SONNET_ID.into()),
             ModelInfo::id_only("gpt-5.4-mini".into()),
             ModelInfo::id_only("openai/gpt-4o-mini".into()),
         ];
@@ -362,7 +374,7 @@ mod tests {
             [
                 "claude-sonnet-4-5",
                 "gpt-5.4-mini",
-                "anthropic/claude-sonnet-4-5",
+                SONNET_ID,
                 "openai/gpt-4o-mini",
             ]
         );

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -233,6 +233,14 @@ Defaults: deepseek-flash (medium), deepseek-v4-pro (strong)
 
 OpenRouter aggregates models from many providers behind a single API key. Browse available models at [openrouter.ai/models](https://openrouter.ai/models). Use any model ID directly (e.g. `openrouter/anthropic/claude-sonnet-4`).
 
+### Requesty
+
+- **Env var**: `REQUESTY_API_KEY`
+- **API**: `https://router.requesty.ai/v1`
+- **Features**: 700+ models behind one key, curated managed routing policies, EU region via `REQUESTY_BASE_URL`
+
+Requesty routes 700+ models from many providers behind a single API key. Models are listed live from the API: curated managed policies first (short ids such as `requesty/claude-sonnet-4-5` or `requesty/gpt-5.4-mini`, `@eu` variants route only through EU providers), then the full `<vendor>/<model>` catalog (e.g. `requesty/openai/gpt-4o-mini`). Get a key at [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys). Set `REQUESTY_BASE_URL=https://router.eu.requesty.ai/v1` to keep all traffic in the EU (`router.us.requesty.ai` and `router.ap.requesty.ai` also exist).
+
 ### Synthetic
 
 - **Env var**: `SYNTHETIC_API_KEY`
@@ -486,7 +494,7 @@ To add a custom provider or proxy, drop an executable script into the config `pr
 
 `resolve` is called each time a new agent spawns, so scripts should read tokens from disk instead of caching them in memory. That way auth changes from other processes get picked up.
 
-The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `copilot`, `ollama`, `llama-cpp`, `mistral`, `zai`, `deepseek`, `openrouter`, `synthetic`, `regolo`, `tensorx`, `opencode`, `xai`, `aperture`.
+The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `copilot`, `ollama`, `llama-cpp`, `mistral`, `zai`, `deepseek`, `openrouter`, `requesty`, `synthetic`, `regolo`, `tensorx`, `opencode`, `xai`, `aperture`.
 
 If your provider serves models not in the base catalog, add a `models` subcommand returning:
 

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -239,7 +239,7 @@ OpenRouter aggregates models from many providers behind a single API key. Browse
 - **API**: `https://router.requesty.ai/v1`
 - **Features**: 700+ models behind one key, curated managed routing policies, EU region via `REQUESTY_BASE_URL`
 
-Requesty routes 700+ models from many providers behind a single API key. Models are listed live from the API: curated managed policies first (short ids such as `requesty/claude-sonnet-4-5` or `requesty/gpt-5.4-mini`, `@eu` variants route only through EU providers), then the full `<vendor>/<model>` catalog (e.g. `requesty/openai/gpt-4o-mini`). Get a key at [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys). Set `REQUESTY_BASE_URL=https://router.eu.requesty.ai/v1` to keep all traffic in the EU (`router.us.requesty.ai` and `router.ap.requesty.ai` also exist).
+Requesty routes 700+ models from many providers behind a single API key. Models are listed live from the API: curated managed policies first (short ids such as `requesty/claude-sonnet-4-5` or `requesty/gpt-5.4-mini`, `@eu` variants route only through EU providers), then the full `<vendor>/<model>` catalog (e.g. `requesty/openai/gpt-4o-mini`). Get a key at [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys). Set `REQUESTY_BASE_URL=https://router.eu.requesty.ai/v1` to keep all traffic in the EU.
 
 ### Synthetic
 

--- a/site/index.html
+++ b/site/index.html
@@ -1344,6 +1344,7 @@ imports = <span class="fn">set</span>()
       <a href="/docs/providers/#z-ai" class="provider-chip">Z.AI</a>
       <a href="/docs/providers/#deepseek" class="provider-chip">DeepSeek</a>
       <a href="/docs/providers/#openrouter" class="provider-chip">OpenRouter</a>
+      <a href="/docs/providers/#requesty" class="provider-chip">Requesty</a>
       <a href="/docs/providers/#synthetic" class="provider-chip">Synthetic</a>
       <a href="/docs/providers/#regolo" class="provider-chip">Regolo</a>
       <a href="/docs/providers/#tensorx" class="provider-chip">TensorX</a>


### PR DESCRIPTION
## Summary

Adds Requesty (router.requesty.ai) as a built in provider, mirroring the OpenRouter integration. One `REQUESTY_API_KEY` reaches 700+ models under `<vendor>/<model>` ids plus Requesty's curated managed routing policies (short ids such as `claude-sonnet-4-5` or `gpt-5.4-mini`), and `REQUESTY_BASE_URL=https://router.eu.requesty.ai/v1` keeps traffic in the EU.

## Changes

- New `maki-providers/src/providers/requesty.rs` on `OpenAiCompatProvider`: slug `requesty`, env `REQUESTY_API_KEY`, base `https://router.requesty.ai/v1`, key pool rotation, system prefix, `HTTP-Referer` / `X-Title` headers, `reasoning_effort` sent only when discovery reports `supports_reasoning`. `list_models` fetches `/v1/models/managed` first, then `/v1/models`, merges them managed first with id dedupe, and still returns whichever list succeeded if the other fails. Each entry maps `context_window`, `max_output_tokens`, per token prices scaled to $/M (input, output, cache read, cache write), vision and reasoning flags, and skips non chat entries. Fields are read one by one, so a single field changing type upstream only loses that value (with a warn log) instead of the whole model, and a zero `context_window` or `max_output_tokens` is treated as unknown. The two fetches run concurrently through `futures_lite::future::zip`. 14 unit tests.
- `ProviderKind::Requesty` wired through `provider.rs` (display name, env, base URL, features, family, fallbacks, `create`), `manifest.rs`, `providers/mod.rs`, `aperture.rs` (as an explicit `base` remap target, same as OpenRouter) and `dynamic.rs`.
- `maki-providers/src/providers/openai_compat.rs`: `fetch_and_parse_models` takes the path as a parameter (`MODELS_PATH` constant), so openrouter, mistral and requesty share one implementation.
- `maki-docgen/src/gen_providers.rs`: catalog note describing managed ids, the `@eu` variants and the EU base URL; `site/docs/content/providers/_index.md` regenerated with `cargo run -p maki-docgen` (diff is the new Requesty section plus `requesty` in the dynamic provider `base` values).
- `README.md` provider bullet and `site/index.html` provider chip.

`REQUESTY_BASE_URL` needed no code since maki already derives `<SLUG>_BASE_URL` for every provider. Requesty is not added to any automatic preference or fallback order.

Behaviour change for anyone already using `requesty/` through the models.dev entry: models.dev lists a `requesty` provider with 154 models, and because Requesty becomes a builtin, `catalog.rs` no longer uses that entry as the model list. The picker shows the live listing instead (about 740 `vendor/model` ids plus the 154 managed ids). The models.dev limits and prices for those 154 managed ids are still read as builtin metadata for anything the live listing does not report, the same way other builtins work since ee6d7a09.

## Validation

- `cargo fmt --all -- --check`, `cargo clippy -p maki-providers -p maki-config -p maki-docgen --tests -- -D warnings` and `cargo run -p maki-docgen -- --check` pass.
- `cargo test` for maki-config (130), maki-docgen (16) and maki-providers, including the 14 requesty tests. The maki-providers suite has a few catalog cache and registry tests that are flaky on clean `main` as well (`free_opencode_model_is_free`, `catalog_marks_model_as_vision`, the `discovered_pricing_decides_free` group); none touch this change.
- Live, through `ProviderKind::from_str("requesty").create(..)` then `list_models()` and `stream_message()`: 156 managed + 776 catalog ids merged to 932; streaming replies from `openai/gpt-4o-mini` (with `usage.cost` parsed), from the managed ids `claude-sonnet-4-5` and `gpt-5.4-mini` with `reasoning_effort: high`, and again with `REQUESTY_BASE_URL` pointed at the EU router. Every model id mentioned in code or docs was confirmed present in the live listings.

Disclosure: I work at Requesty. Happy to adjust anything to match project conventions.

