### PR TITLE
fix(providers): price zai glm-5.1 and glm-5.2 at their real rates

### DIFF
--- a/maki-providers/src/providers/zai/mod.rs
+++ b/maki-providers/src/providers/zai/mod.rs
@@ -115,6 +115,9 @@ inventory::submit!(BuiltInProvider {
     needs_url: false,
 });
 
+/// Rates come from the pay as you go table on docs.z.ai. models.dev looks like
+/// a good source but still lists the launch promo for the GLM-5 line, which
+/// expired, so copying from there halves the numbers below.
 pub(crate) const fn models() -> &'static [ModelEntry] {
     &[
         ModelEntry {
@@ -172,17 +175,33 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
             vision: false,
             default: false,
             pricing: ModelPricing {
-                input: 1.00,
-                output: 3.20,
+                input: 1.40,
+                output: 4.40,
                 cache_write: 0.00,
-                cache_read: 0.20,
+                cache_read: 0.26,
                 fast: None,
             },
             max_output_tokens: Some(131072),
             context_window: 1_000_000,
         },
         ModelEntry {
-            prefixes: &["glm-5.1", "glm-5"],
+            prefixes: &["glm-5.1"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Glm,
+            vision: false,
+            default: false,
+            pricing: ModelPricing {
+                input: 1.40,
+                output: 4.40,
+                cache_write: 0.00,
+                cache_read: 0.26,
+                fast: None,
+            },
+            max_output_tokens: Some(131072),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["glm-5"],
             tier: ModelTier::Strong,
             family: ModelFamily::Glm,
             vision: false,
@@ -450,6 +469,19 @@ mod tests {
         let flash = Model::from_spec("zai/glm-5.3-flash").unwrap();
         assert_eq!(flash.tier, ModelTier::Weak);
         assert!(flash.supports_vision());
+    }
+
+    /// These two shared `glm-5`'s row and so billed at its cheaper rate. That
+    /// hurt: `glm-5.1` is the provider default, so a plain session under-
+    /// reported what it spent.
+    #[test_case("zai/glm-5.1" ; "glm_5_1_bills_above_glm_5")]
+    #[test_case("zai/glm-5.2" ; "glm_5_2_bills_above_glm_5")]
+    fn glm_5_x_does_not_ride_the_glm_5_entry(spec: &str) {
+        let glm_5 = Model::from_spec("zai/glm-5").unwrap().pricing;
+        let pricing = Model::from_spec(spec).unwrap().pricing;
+        assert!(pricing.input > glm_5.input);
+        assert!(pricing.output > glm_5.output);
+        assert!(pricing.cache_read > glm_5.cache_read);
     }
 
     #[test]

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -205,8 +205,9 @@ Defaults: mistral-medium-latest (strong), mistral-small-latest (medium), ministr
 | Medium | glm-4.5 | $0.60 / $2.20 | 131K ctx / 98K out |
 | Strong | **glm-5-code** (default) | $1.20 / $5.00 | 200K ctx / 131K out |
 | Strong | glm-5.3 | $1.40 / $4.40 | 1000K ctx / 131K out |
-| Strong | glm-5.2 | $1.00 / $3.20 | 1000K ctx / 131K out |
-| Strong | glm-5.1, glm-5 | $1.00 / $3.20 | 200K ctx / 131K out |
+| Strong | glm-5.2 | $1.40 / $4.40 | 1000K ctx / 131K out |
+| Strong | glm-5.1 | $1.40 / $4.40 | 200K ctx / 131K out |
+| Strong | glm-5 | $1.00 / $3.20 | 200K ctx / 131K out |
 
 Defaults: glm-5-code (strong), glm-4.7-flash (weak), glm-4.7 (medium)
 


### PR DESCRIPTION
`glm-5.1` was sharing a row with `glm-5`, so it billed at $1.00/$3.20 when docs.z.ai lists it at $1.40/$4.40 with $0.26 cache reads, and since `glm-5.1` is the zai default every plain session under-reported its cost by a third.

`glm-5.2` had the same stale numbers and gets the same fix, while bare `glm-5` moves to its own entry and keeps the cheaper rates it really has.

Prices come from the open API pay as you go table on docs.z.ai, not models.dev, which still carries an expired launch promo with halved rates for these models.

The tests pin `glm-5.1` and `glm-5` to different prices so nobody folds the two rows back together, and the strong tier default stays `glm-5-code`.