### PR TITLE
feat(providers): read models.dev for models the tables miss

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Run `maki acp` or configure your ACP supporting editor to use maki, e.g. in [Zed
 "agent_servers": {
   "Maki": {
     "default_config_options": {
-      "model": "deepseek/deepseek-v4-flash"
+      "model": "deepseek/deepseek-flash"
     },
     "type": "custom",
     "command": "maki",

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -99,7 +99,17 @@ If the model name is unique across providers, the prefix can be omitted.
 
 The tables above list the models Maki curates. Any other id a provider accepts works too: type it into `/model` or pass it to `--model`. The picker also lists what the provider's own model endpoint reports, so same-day releases are selectable there.
 
-Rates, context window, vision and thinking support for a model missing from the tables come from [models.dev](https://models.dev/), refreshed daily (`maki models --refresh` forces it). Curated entries win where they exist, because they are checked against each provider's pricing page. A model neither source knows still runs, with the provider's default limits and no cost estimate.
+For an id no table covers, rates, context window, vision and thinking support come from [models.dev](https://models.dev/), refreshed daily (`maki models --refresh` forces it). Maki reads each field on its own, so a row that lists a price but no context window still leaves the window to the sources below.
+
+Sources rank by how sure they are to describe the exact model you asked for:
+
+1. What the provider's own model endpoint reported this session.
+2. A curated row for that id, including its dated snapshots. `claude-sonnet-4-5-20250929` reads the `claude-sonnet-4-5` row.
+3. models.dev.
+4. A curated row for a close relative, reached by shared prefix. `glm-5.4` falls back to `glm-5` here, and takes its family and tier from it either way.
+5. The provider's defaults, with no cost estimate.
+
+A curated row is checked against the provider's own pricing page, so it wins for the id it names. For a relative it loses to models.dev, because a rate nobody checked against the id you typed is only a guess.
 
 New models start at the **medium** tier until you assign one in the picker."#;
 

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -93,7 +93,15 @@ xai/grok-4.6
 zai/glm-4.7
 ```
 
-If the model name is unique across providers, the prefix can be omitted."#;
+If the model name is unique across providers, the prefix can be omitted.
+
+### Models newer than your Maki version
+
+The tables above list the models Maki curates. Any other id a provider accepts works too: type it into `/model` or pass it to `--model`. The picker also lists what the provider's own model endpoint reports, so same-day releases are selectable there.
+
+Rates, context window, vision and thinking support for a model missing from the tables come from [models.dev](https://models.dev/), refreshed daily (`maki models --refresh` forces it). Curated entries win where they exist, because they are checked against each provider's pricing page. A model neither source knows still runs, with the provider's default limits and no cost estimate.
+
+New models start at the **medium** tier until you assign one in the picker."#;
 
 fn providers_toml_section() -> String {
     let mut plan_rows = String::new();

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -19,7 +19,7 @@ pub use providers::Timeouts;
 pub use providers::catalog::ProviderData;
 pub use providers::catalog::{
     catalog_provider, catalog_provider_if_available, catalog_providers,
-    catalog_providers_if_available, model_meta_if_available, refresh_catalog, warm_catalog,
+    catalog_providers_if_available, refresh_catalog, warm_catalog,
 };
 pub use providers::copilot::auth as copilot_auth;
 pub use providers::dynamic;

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -124,18 +124,6 @@ impl ModelPricing {
     }
 }
 
-impl From<&CatalogMeta> for ModelPricing {
-    fn from(meta: &CatalogMeta) -> Self {
-        Self {
-            input: meta.input_price,
-            output: meta.output_price,
-            cache_write: meta.cache_write,
-            cache_read: meta.cache_read,
-            fast: None,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModelFamily {
     Claude,
@@ -218,14 +206,73 @@ pub(crate) fn lookup_entry<'a>(
         .ok_or_else(|| ModelError::UnknownModel(model_id.to_string()))
 }
 
-/// How a release newer than our static tables still gets real rates, limits and
-/// capabilities instead of provider-wide defaults. Curated entries win, and the
-/// catalog is read only when already warm, so this is `None` on a cold start.
-fn catalog_meta_for_unlisted(manifest: &ProviderManifest, model_id: &str) -> Option<CatalogMeta> {
-    if lookup_entry(manifest.models, model_id).is_ok() {
-        return None;
+const SNAPSHOT_DATE_DIGITS: usize = 8;
+
+/// A provider pins a release by stamping a date on an id it already ships,
+/// either `claude-sonnet-4-5-20250929` or `gpt-5.4-2026-03-11`. Both are the
+/// same model as the row they extend, unlike a version bump such as
+/// `claude-opus-5-2`, and the digit count is what tells the two apart.
+fn is_snapshot_suffix(suffix: &str) -> bool {
+    let Some(date) = suffix.strip_prefix('-') else {
+        return false;
+    };
+    date.bytes().all(|b| b.is_ascii_digit() || b == b'-')
+        && date.bytes().filter(u8::is_ascii_digit).count() == SNAPSHOT_DATE_DIGITS
+}
+
+/// Whether a curated row names *this* model rather than merely sharing a prefix
+/// with it. [`lookup_entry`] matches by prefix so dated snapshots resolve to
+/// their base row, which also means `glm-5` answers for `glm-5.4`, a model it
+/// has never been checked against.
+fn names_exactly(entry: &ModelEntry, model_id: &str) -> bool {
+    entry.prefixes.iter().any(|prefix| {
+        model_id
+            .strip_prefix(prefix)
+            .is_some_and(|rest| rest.is_empty() || is_snapshot_suffix(rest))
+    })
+}
+
+/// Everything that can describe one model, ranked by how sure it is to be about
+/// that model and not its neighbour.
+struct ModelSources<'a> {
+    /// The curated row [`lookup_entry`] reached, exact or not.
+    entry: Option<&'a ModelEntry>,
+    /// `entry` names this id. Such a row was checked against the provider's own
+    /// pricing page, so nothing outranks it but live discovery. A row reached
+    /// by prefix is still the right family and a usable guess at the rest, but
+    /// nobody ever checked it against the id we were handed.
+    exact: bool,
+    /// models.dev, which lists releases our tables have not caught up to. Read
+    /// only when already warm, so this is `None` on a cold start.
+    catalog: Option<CatalogMeta>,
+}
+
+impl<'a> ModelSources<'a> {
+    fn resolve(manifest: &'a ProviderManifest, model_id: &str) -> Self {
+        let entry = lookup_entry(manifest.models, model_id).ok();
+        let exact = entry.is_some_and(|entry| names_exactly(entry, model_id));
+        Self {
+            entry,
+            exact,
+            catalog: (!exact)
+                .then(|| catalog::model_meta_if_available(manifest.slug, model_id))
+                .flatten(),
+        }
     }
-    catalog::model_meta_if_available(manifest.slug, model_id)
+
+    /// Exact row, then the catalog, then the same row as a mere relative, so
+    /// the last rung only ever answers when the first was skipped.
+    fn pick<T>(
+        &self,
+        from_entry: impl Fn(&ModelEntry) -> Option<T>,
+        from_catalog: impl Fn(&CatalogMeta) -> Option<T>,
+    ) -> Option<T> {
+        self.entry
+            .filter(|_| self.exact)
+            .and_then(&from_entry)
+            .or_else(|| self.catalog.as_ref().and_then(from_catalog))
+            .or_else(|| self.entry.and_then(&from_entry))
+    }
 }
 
 impl ModelFamily {
@@ -290,35 +337,39 @@ pub struct Model {
 }
 
 impl Model {
-    /// When no static entry matches (a freshly released model the table has not
-    /// caught up to yet), rates and limits come from the models.dev catalog and
-    /// then from the provider defaults, so the spec resolves either way.
+    /// Rates and limits come from the most specific source that names this
+    /// model: live discovery, then [`ModelSources`], then provider defaults.
+    /// Family and tier are about which dialect a model speaks and what role it
+    /// plays, which a relative answers just as well, so they read the curated
+    /// row whether or not it was an exact match.
     fn from_base(manifest: &ProviderManifest, slug: &str, model_id: &str) -> Self {
-        let static_entry = lookup_entry(manifest.models, model_id).ok();
+        let sources = ModelSources::resolve(manifest, model_id);
+        let entry = sources.entry;
         let spec = format!("{slug}/{model_id}");
         // Discovery keys `known_models` by the builtin slug, so a dynamic or
         // custom slug reads positional tiers and metadata through its base.
         let discovered = model_registry::discovered(manifest.slug, model_id);
         let discovered = discovered.as_ref();
-        let catalog = catalog_meta_for_unlisted(manifest, model_id);
-        let tier = model_registry::tier_for(&spec, manifest.slug, static_entry.map(|e| e.tier));
-        let family = static_entry.map_or(manifest.family, |entry| entry.family);
+        let tier = model_registry::tier_for(&spec, manifest.slug, entry.map(|e| e.tier));
+        let family = entry.map_or(manifest.family, |entry| entry.family);
         let discovered_pricing = discovered.and_then(|info| info.pricing.as_ref());
         let pricing = discovered_pricing
-            .or_else(|| static_entry.map(|entry| &entry.pricing))
             .cloned()
-            .or_else(|| catalog.as_ref().map(ModelPricing::from))
+            .or_else(|| {
+                sources.pick(
+                    |entry| Some(entry.pricing.clone()),
+                    |meta| meta.pricing.clone(),
+                )
+            })
             .unwrap_or_default();
         let max_output_tokens = discovered
             .and_then(|info| info.max_output_tokens)
-            .or_else(|| static_entry.and_then(|entry| entry.max_output_tokens))
-            .or_else(|| catalog.as_ref().map(|meta| meta.output))
+            .or_else(|| sources.pick(|entry| entry.max_output_tokens, |meta| meta.output))
             .or(manifest.fallback_max_output);
         let context_window = discovered
             .and_then(|info| info.context_window)
             .or_else(|| anthropic::shared::long_context_window(model_id))
-            .or_else(|| static_entry.map(|entry| entry.context_window))
-            .or_else(|| catalog.as_ref().map(|meta| meta.context))
+            .or_else(|| sources.pick(|entry| Some(entry.context_window), |meta| meta.context))
             .unwrap_or(manifest.fallback_context_window);
         Self {
             id: model_id.to_string(),
@@ -342,18 +393,19 @@ impl Model {
     /// the `Model` so `supports_thinking`/`supports_vision` do not need a live
     /// catalog lookup.
     fn from_catalog(slug: &str, model_id: &str, meta: CatalogMeta) -> Self {
+        let (context_window, max_output_tokens) = (meta.context_window(), meta.max_output());
         Self {
             id: model_id.to_string(),
             provider: Arc::from(slug),
             tier: ModelTier::Medium,
             family: ModelFamily::Generic,
             supports_tool_examples_override: None,
-            thinking_override: ThinkingSupport::from_flags(Some(meta.supports_thinking), false),
-            supports_vision_override: Some(meta.supports_vision),
-            pricing: ModelPricing::from(&meta),
+            thinking_override: ThinkingSupport::from_flags(meta.supports_thinking, false),
+            supports_vision_override: meta.supports_vision,
+            pricing: meta.pricing.unwrap_or_default(),
             discovered_free: false,
-            max_output_tokens: Some(meta.output),
-            context_window: meta.context,
+            max_output_tokens: Some(max_output_tokens),
+            context_window,
             thinking_fields: None,
         }
     }
@@ -370,7 +422,9 @@ impl Model {
         model_registry::discovered(manifest.slug, &self.id)
             .and_then(|d| d.supports_thinking)
             .or_else(|| {
-                catalog_meta_for_unlisted(manifest, &self.id).map(|meta| meta.supports_thinking)
+                ModelSources::resolve(manifest, &self.id)
+                    .catalog?
+                    .supports_thinking
             })
             .unwrap_or(manifest.supports_thinking)
     }
@@ -379,12 +433,8 @@ impl Model {
         self.thinking_override == Some(ThinkingSupport::Required)
     }
 
-    /// Vision support, most specific first:
-    /// 1. per-model override
-    /// 2. discovery
-    /// 3. manifest entry
-    /// 4. warm models.dev metadata for a model no manifest entry claims
-    /// 5. the family default
+    /// Vision support, most specific first: per-model override, discovery,
+    /// [`ModelSources`], the family default.
     pub fn supports_vision(&self) -> bool {
         if let Some(vision) = self.supports_vision_override {
             return vision;
@@ -395,11 +445,9 @@ impl Model {
         model_registry::discovered(manifest.slug, &self.id)
             .and_then(|d| d.supports_vision)
             .or_else(|| {
-                lookup_entry(manifest.models, &self.id)
-                    .ok()
-                    .map(|e| e.vision)
+                ModelSources::resolve(manifest, &self.id)
+                    .pick(|entry| Some(entry.vision), |meta| meta.supports_vision)
             })
-            .or_else(|| catalog_meta_for_unlisted(manifest, &self.id).map(|m| m.supports_vision))
             .unwrap_or_else(|| self.family.supports_vision())
     }
 
@@ -729,6 +777,7 @@ mod tests {
     ];
 
     const EPSILON: f64 = 1e-10;
+
     /// The only builtin whose rates move with the wall clock.
     const SCHEDULED_PROVIDERS: [&str; 1] = ["deepseek"];
     const DEEPSEEK_SPEC: &str = "deepseek/deepseek-v4-pro";
@@ -760,6 +809,48 @@ mod tests {
         cache_read: 0.0,
         fast: None,
     };
+
+    #[test_case(&["claude-sonnet-4-5"], "claude-sonnet-4-5"; "the id itself")]
+    #[test_case(&["claude-sonnet-4-5"], "claude-sonnet-4-5-20250929"; "anthropic snapshot")]
+    #[test_case(&["gpt-5.4"], "gpt-5.4-2026-03-11"; "openai snapshot")]
+    fn a_curated_row_names_its_own_dated_snapshots(
+        prefixes: &'static [&'static str],
+        model_id: &str,
+    ) {
+        assert!(names_exactly(&entry_named(prefixes), model_id));
+    }
+
+    /// Each of these is a different model that merely starts with the row's id.
+    /// Letting the row answer for them is how `glm-5.4` would bill at `glm-5`
+    /// rates forever, silently, rather than reading models.dev.
+    #[test_case(&["glm-5"], "glm-5.4"; "version bump")]
+    #[test_case(&["glm-5"], "glm-5-code"; "named variant")]
+    #[test_case(&["claude-opus-5"], "claude-opus-5-2"; "version bump behind a dash")]
+    #[test_case(&["deepseek-flash"], "deepseek-flash-preview"; "preview of a relative")]
+    fn a_curated_row_does_not_name_its_relatives(
+        prefixes: &'static [&'static str],
+        model_id: &str,
+    ) {
+        let entry = entry_named(prefixes);
+        assert!(!names_exactly(&entry, model_id));
+        assert!(
+            lookup_entry(std::slice::from_ref(&entry), model_id).is_ok(),
+            "still the right row for family and tier, just not for rates"
+        );
+    }
+
+    fn entry_named(prefixes: &'static [&'static str]) -> ModelEntry {
+        ModelEntry {
+            prefixes,
+            tier: ModelTier::Medium,
+            family: ModelFamily::Generic,
+            vision: false,
+            default: false,
+            pricing: ModelPricing::default(),
+            max_output_tokens: None,
+            context_window: 0,
+        }
+    }
 
     #[test_case(999, "999"         ; "under_thousand")]
     #[test_case(1_000, "1.0k"      ; "thousand")]

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::manifest::{ManifestRegistry, ProviderManifest};
 use crate::model_registry;
+use crate::providers::catalog::{self, CatalogMeta};
 use crate::providers::{anthropic, custom, dynamic};
 use crate::types::ThinkingFields;
 
@@ -123,6 +124,18 @@ impl ModelPricing {
     }
 }
 
+impl From<&CatalogMeta> for ModelPricing {
+    fn from(meta: &CatalogMeta) -> Self {
+        Self {
+            input: meta.input_price,
+            output: meta.output_price,
+            cache_write: meta.cache_write,
+            cache_read: meta.cache_read,
+            fast: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModelFamily {
     Claude,
@@ -205,6 +218,16 @@ pub(crate) fn lookup_entry<'a>(
         .ok_or_else(|| ModelError::UnknownModel(model_id.to_string()))
 }
 
+/// How a release newer than our static tables still gets real rates, limits and
+/// capabilities instead of provider-wide defaults. Curated entries win, and the
+/// catalog is read only when already warm, so this is `None` on a cold start.
+fn catalog_meta_for_unlisted(manifest: &ProviderManifest, model_id: &str) -> Option<CatalogMeta> {
+    if lookup_entry(manifest.models, model_id).is_ok() {
+        return None;
+    }
+    catalog::model_meta_if_available(manifest.slug, model_id)
+}
+
 impl ModelFamily {
     pub fn supports_tool_examples(self) -> bool {
         match self {
@@ -268,7 +291,8 @@ pub struct Model {
 
 impl Model {
     /// When no static entry matches (a freshly released model the table has not
-    /// caught up to yet), fall back to the provider defaults so it still resolves.
+    /// caught up to yet), rates and limits come from the models.dev catalog and
+    /// then from the provider defaults, so the spec resolves either way.
     fn from_base(manifest: &ProviderManifest, slug: &str, model_id: &str) -> Self {
         let static_entry = lookup_entry(manifest.models, model_id).ok();
         let spec = format!("{slug}/{model_id}");
@@ -276,21 +300,25 @@ impl Model {
         // custom slug reads positional tiers and metadata through its base.
         let discovered = model_registry::discovered(manifest.slug, model_id);
         let discovered = discovered.as_ref();
+        let catalog = catalog_meta_for_unlisted(manifest, model_id);
         let tier = model_registry::tier_for(&spec, manifest.slug, static_entry.map(|e| e.tier));
         let family = static_entry.map_or(manifest.family, |entry| entry.family);
         let discovered_pricing = discovered.and_then(|info| info.pricing.as_ref());
         let pricing = discovered_pricing
             .or_else(|| static_entry.map(|entry| &entry.pricing))
             .cloned()
+            .or_else(|| catalog.as_ref().map(ModelPricing::from))
             .unwrap_or_default();
         let max_output_tokens = discovered
             .and_then(|info| info.max_output_tokens)
             .or_else(|| static_entry.and_then(|entry| entry.max_output_tokens))
+            .or_else(|| catalog.as_ref().map(|meta| meta.output))
             .or(manifest.fallback_max_output);
         let context_window = discovered
             .and_then(|info| info.context_window)
             .or_else(|| anthropic::shared::long_context_window(model_id))
             .or_else(|| static_entry.map(|entry| entry.context_window))
+            .or_else(|| catalog.as_ref().map(|meta| meta.context))
             .unwrap_or(manifest.fallback_context_window);
         Self {
             id: model_id.to_string(),
@@ -313,11 +341,7 @@ impl Model {
     /// builtin; metadata is read once from the models.dev catalog and cached on
     /// the `Model` so `supports_thinking`/`supports_vision` do not need a live
     /// catalog lookup.
-    fn from_catalog(
-        slug: &str,
-        model_id: &str,
-        meta: crate::providers::catalog::CatalogMetaView,
-    ) -> Self {
+    fn from_catalog(slug: &str, model_id: &str, meta: CatalogMeta) -> Self {
         Self {
             id: model_id.to_string(),
             provider: Arc::from(slug),
@@ -326,13 +350,7 @@ impl Model {
             supports_tool_examples_override: None,
             thinking_override: ThinkingSupport::from_flags(Some(meta.supports_thinking), false),
             supports_vision_override: Some(meta.supports_vision),
-            pricing: ModelPricing {
-                input: meta.input_price,
-                output: meta.output_price,
-                cache_write: meta.cache_write,
-                cache_read: meta.cache_read,
-                fast: None,
-            },
+            pricing: ModelPricing::from(&meta),
             discovered_free: false,
             max_output_tokens: Some(meta.output),
             context_window: meta.context,
@@ -351,6 +369,9 @@ impl Model {
         };
         model_registry::discovered(manifest.slug, &self.id)
             .and_then(|d| d.supports_thinking)
+            .or_else(|| {
+                catalog_meta_for_unlisted(manifest, &self.id).map(|meta| meta.supports_thinking)
+            })
             .unwrap_or(manifest.supports_thinking)
     }
 
@@ -362,26 +383,23 @@ impl Model {
     /// 1. per-model override
     /// 2. discovery
     /// 3. manifest entry
-    /// 4. warm models.dev metadata (builtins skip the catalog in from_spec)
+    /// 4. warm models.dev metadata for a model no manifest entry claims
     /// 5. the family default
     pub fn supports_vision(&self) -> bool {
         if let Some(vision) = self.supports_vision_override {
             return vision;
         }
-        let manifest = ManifestRegistry::for_slug(&self.provider);
-        manifest
-            .and_then(|m| {
-                model_registry::discovered(m.slug, &self.id).and_then(|d| d.supports_vision)
-            })
+        let Some(manifest) = ManifestRegistry::for_slug(&self.provider) else {
+            return self.family.supports_vision();
+        };
+        model_registry::discovered(manifest.slug, &self.id)
+            .and_then(|d| d.supports_vision)
             .or_else(|| {
-                manifest
-                    .and_then(|m| lookup_entry(m.models, &self.id).ok())
+                lookup_entry(manifest.models, &self.id)
+                    .ok()
                     .map(|e| e.vision)
             })
-            .or_else(|| {
-                crate::providers::catalog::model_meta_if_available(&self.provider, &self.id)
-                    .map(|meta| meta.supports_vision)
-            })
+            .or_else(|| catalog_meta_for_unlisted(manifest, &self.id).map(|m| m.supports_vision))
             .unwrap_or_else(|| self.family.supports_vision())
     }
 
@@ -551,7 +569,7 @@ impl Model {
             return Ok(model);
         }
 
-        if let Some(meta) = crate::providers::catalog::model_meta_if_available(slug, model_id) {
+        if let Some(meta) = catalog::model_meta_if_available(slug, model_id) {
             return Ok(Self::from_catalog(slug, model_id, meta));
         }
 
@@ -567,8 +585,7 @@ impl Model {
     /// reflect catalog prices when discovery hasn't seeded the registry, and
     /// which reads zero for "price unknown" too.
     pub fn is_free(&self) -> bool {
-        self.discovered_free
-            || crate::providers::catalog::free_model_if_available(&self.provider, &self.id)
+        self.discovered_free || catalog::free_model_if_available(&self.provider, &self.id)
     }
 }
 

--- a/maki-providers/src/providers/catalog.rs
+++ b/maki-providers/src/providers/catalog.rs
@@ -35,7 +35,14 @@ use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, 
 const MESSAGES_PATH: &str = "/messages";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
 
-const BLOCKED_PROVIDER_IN_CATALOG: &[&str] = &["zai", "zai-coding-plan", "github-copilot"];
+/// Priced per subscription, so every model in it reads as free. The `zai` entry
+/// carries the pay as you go rates for the same models.
+const BLOCKED_PROVIDER_IN_CATALOG: &[&str] = &["zai-coding-plan"];
+
+/// models.dev ids for providers we ship a client for under another name, so
+/// their metadata lands under the slug a model spec is written with.
+const BUILTIN_CATALOG_IDS: &[(&str, &str)] =
+    &[("github-copilot", "copilot"), ("regolo-ai", "regolo")];
 
 /// Builtins with no native client of their own, so [`builtin_provider`]
 /// knowing them must not drop them from the catalog.
@@ -49,6 +56,13 @@ const CATALOG_CACHE_FILE: &str = "models-dev-catalog.json";
 const CATALOG_CACHE_TTL: Duration = Duration::from_secs(86400);
 
 const ALLOWED_NPM: &[&str] = &["@ai-sdk/openai-compatible", "@ai-sdk/anthropic"];
+
+const IMAGE_MODALITY: &str = "image";
+
+/// Used only where the catalog is the whole story. A builtin has its manifest
+/// fallbacks to reach for instead, which are per provider and so beat a guess.
+const DEFAULT_CONTEXT: u32 = 128_000;
+const DEFAULT_OUTPUT: u32 = 64_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EndpointType {
@@ -109,8 +123,13 @@ pub struct ProviderData {
     pub quirks: ProviderQuirks,
 }
 
+/// An unpriced entry counts as free, the same reading `enable_free_models` has
+/// always had. Only catalog providers reach this, and a free tier is the one
+/// place models.dev is reliably explicit about a zero.
 fn is_free_model(meta: &CatalogMeta) -> bool {
-    meta.input_price == 0.0 && meta.output_price == 0.0
+    meta.pricing
+        .as_ref()
+        .is_none_or(|pricing| pricing.input == 0.0 && pricing.output == 0.0)
 }
 
 impl ProviderData {
@@ -258,33 +277,37 @@ impl ProviderData {
     }
 }
 
-#[derive(Clone, Debug)]
+/// What models.dev publishes about one model. Every field is `Option` because
+/// "the catalog says no" and "the catalog does not say" have to stay apart: a
+/// builtin has a manifest and a curated table to fall through to, and collapsing
+/// the two here would let a thin upstream row shrink a 1M window to 128k, or
+/// turn thinking off for a model we know reasons.
+#[derive(Clone, Debug, Default)]
 pub struct CatalogMeta {
-    pub context: u32,
-    pub output: u32,
-    pub input_price: f64,
-    pub output_price: f64,
-    pub cache_read: f64,
-    pub cache_write: f64,
-    pub supports_thinking: bool,
-    pub supports_vision: bool,
+    pub context: Option<u32>,
+    pub output: Option<u32>,
+    pub pricing: Option<ModelPricing>,
+    pub supports_thinking: Option<bool>,
+    pub supports_vision: Option<bool>,
 }
 
 impl CatalogMeta {
+    pub(crate) fn context_window(&self) -> u32 {
+        self.context.unwrap_or(DEFAULT_CONTEXT)
+    }
+
+    pub(crate) fn max_output(&self) -> u32 {
+        self.output.unwrap_or(DEFAULT_OUTPUT)
+    }
+
     fn model_info(&self, model_id: &str) -> ModelInfo {
         ModelInfo {
             id: model_id.to_string(),
-            context_window: Some(self.context),
-            max_output_tokens: Some(self.output),
-            pricing: Some(ModelPricing {
-                input: self.input_price,
-                output: self.output_price,
-                cache_read: self.cache_read,
-                cache_write: self.cache_write,
-                fast: None,
-            }),
-            supports_thinking: Some(self.supports_thinking),
-            supports_vision: Some(self.supports_vision),
+            context_window: Some(self.context_window()),
+            max_output_tokens: Some(self.max_output()),
+            pricing: Some(self.pricing.clone().unwrap_or_default()),
+            supports_thinking: self.supports_thinking,
+            supports_vision: self.supports_vision,
             tier: None,
             provider_info: None,
         }
@@ -325,96 +348,26 @@ impl CatalogData {
         let mut builtin_models = HashMap::new();
 
         for (provider_id, provider) in index {
-            if !ALLOWED_NPM.contains(&provider.npm.as_str()) {
-                debug!(npm = %provider.npm, "skipping provider: unsupported npm package");
-                continue;
-            }
-            if BLOCKED_PROVIDER_IN_CATALOG.contains(&provider_id.as_str()) {
-                debug!(
-                    provider = &provider_id,
-                    "skipping providers from the catalog"
-                );
-                continue;
-            }
-
-            let Some(_base_url) = &provider.api else {
-                debug!(provider = %provider_id, "skipping: no API URL in catalog");
-                continue;
-            };
-
-            let api_format = determine_catalog_format(&provider.npm);
-
-            let mut models = HashMap::new();
-            for (model_id, model_data) in &provider.models {
-                let input_price = model_data
-                    .cost
-                    .as_ref()
-                    .and_then(|c| c.input)
-                    .unwrap_or(0.0);
-                let output_price = model_data
-                    .cost
-                    .as_ref()
-                    .and_then(|c| c.output)
-                    .unwrap_or(0.0);
-
-                let context = model_data
-                    .limit
-                    .as_ref()
-                    .and_then(|l| l.context)
-                    .unwrap_or(128_000);
-                let output = model_data
-                    .limit
-                    .as_ref()
-                    .and_then(|l| l.output)
-                    .unwrap_or(64_000);
-
-                let cache_read = model_data
-                    .cost
-                    .as_ref()
-                    .and_then(|c| c.cache_read)
-                    .unwrap_or(0.0);
-                let cache_write = model_data
-                    .cost
-                    .as_ref()
-                    .and_then(|c| c.cache_write)
-                    .unwrap_or(0.0);
-
-                let supports_vision = model_data.attachment
-                    || model_data
-                        .modalities
-                        .as_ref()
-                        .is_some_and(|m| m.input.iter().any(|s| s == "image"));
-                let supports_thinking = model_data.reasoning;
-
-                models.insert(
-                    model_id.clone(),
-                    CatalogMeta {
-                        context,
-                        output,
-                        input_price,
-                        output_price,
-                        cache_read,
-                        cache_write,
-                        supports_thinking,
-                        supports_vision,
-                    },
-                );
-            }
-
-            let model_count = models.len();
-
-            if builtin_provider(&provider_id).is_some()
-                && !CATALOG_BACKED_BUILTINS.contains(&provider_id.as_str())
-            {
+            let slug = builtin_slug(&provider_id);
+            if builtin_provider(slug).is_some() && !CATALOG_BACKED_BUILTINS.contains(&slug) {
+                let models = parse_models(&provider.models);
                 debug!(
                     provider = %provider_id,
-                    models = model_count,
+                    slug,
+                    models = models.len(),
                     "built-in provider: keeping catalog metadata only"
                 );
-                builtin_models.insert(provider_id, models);
+                builtin_models.insert(slug.to_string(), models);
                 continue;
             }
 
+            if !is_servable(&provider_id, &provider) {
+                continue;
+            }
+
+            let models = parse_models(&provider.models);
+            let model_count = models.len();
+            let api_format = determine_catalog_format(&provider.npm);
             let provider_data =
                 ProviderData::new(provider_id.clone(), &provider, api_format, models);
             providers.insert(provider_id.clone(), provider_data);
@@ -650,6 +603,63 @@ fn determine_catalog_format(npm: &str) -> EndpointType {
     }
 }
 
+fn builtin_slug(catalog_id: &str) -> &str {
+    BUILTIN_CATALOG_IDS
+        .iter()
+        .find(|(id, _)| *id == catalog_id)
+        .map_or(catalog_id, |(_, slug)| slug)
+}
+
+/// Whether we could stream from this provider ourselves: one of the two
+/// protocols we speak, at a base URL the catalog publishes. Built-ins are
+/// checked first and never come through here, since they bring their own
+/// client and only need the metadata.
+fn is_servable(provider_id: &str, provider: &schema::CatalogProvider) -> bool {
+    if !ALLOWED_NPM.contains(&provider.npm.as_str()) {
+        debug!(provider = %provider_id, npm = %provider.npm, "skipping provider: unsupported npm package");
+        return false;
+    }
+    if BLOCKED_PROVIDER_IN_CATALOG.contains(&provider_id) {
+        debug!(provider = %provider_id, "skipping provider: blocked");
+        return false;
+    }
+    if provider.api.is_none() {
+        debug!(provider = %provider_id, "skipping provider: no API URL in catalog");
+        return false;
+    }
+    true
+}
+
+fn parse_models(models: &HashMap<String, schema::CatalogModel>) -> HashMap<String, CatalogMeta> {
+    models
+        .iter()
+        .map(|(model_id, model)| (model_id.clone(), parse_model(model)))
+        .collect()
+}
+
+fn parse_model(model: &schema::CatalogModel) -> CatalogMeta {
+    let limit = model.limit.as_ref();
+    // A published `modalities` answers the vision question on its own; only a
+    // row that lists none falls back to the coarser `attachment` flag.
+    let supports_vision = match model.modalities.as_ref() {
+        Some(modalities) => Some(modalities.input.iter().any(|input| input == IMAGE_MODALITY)),
+        None => model.attachment,
+    };
+    CatalogMeta {
+        context: limit.and_then(|l| l.context),
+        output: limit.and_then(|l| l.output),
+        pricing: model.cost.as_ref().map(|cost| ModelPricing {
+            input: cost.input.unwrap_or(0.0),
+            output: cost.output.unwrap_or(0.0),
+            cache_write: cost.cache_write.unwrap_or(0.0),
+            cache_read: cost.cache_read.unwrap_or(0.0),
+            fast: None,
+        }),
+        supports_thinking: model.reasoning,
+        supports_vision,
+    }
+}
+
 fn catalog_client() -> HttpClient {
     isahc::HttpClient::builder()
         .connect_timeout(Duration::from_secs(10))
@@ -842,8 +852,8 @@ impl Provider for CatalogProvider {
                 })?;
             let stream_model = Model {
                 id: model.id.clone(),
-                max_output_tokens: Some(meta.output),
-                context_window: meta.context,
+                max_output_tokens: Some(meta.max_output()),
+                context_window: meta.context_window(),
                 ..model.clone()
             };
             self.transport
@@ -1001,6 +1011,7 @@ mod tests {
         Authentication, CatalogData, CatalogMeta, EndpointType, ProviderData, ProviderQuirks,
         SessionRef, StateDir, available_if_warm, determine_catalog_format, quirks_for,
     };
+    use crate::manifest::ManifestRegistry;
     use crate::model::{Model, ModelInfo, ModelPricing};
     use crate::provider::Provider;
     use crate::providers::{ResolvedAuth, Timeouts, deepseek, opencode};
@@ -1011,8 +1022,16 @@ mod tests {
     const OPT_IN_HINT: &str = "providers.opencode.enable_free_models = true";
     /// A builtin with a static model table, so it is never a catalog provider.
     const BUILTIN_SLUG: &str = "deepseek";
-    /// Stands in for a model released after our tables were written.
-    const UNLISTED_MODEL: &str = "deepseek-v9-turbo";
+    /// Stands in for a model released after our tables were written, so no
+    /// curated row of any provider starts with it.
+    const UNLISTED_MODEL: &str = "v9-turbo";
+    /// A release that starts with a curated id without being it, the shape
+    /// `lookup_entry` cannot tell apart from the row it belongs to.
+    const SIBLING_SUFFIX: &str = "-preview";
+    /// Same shape, but the catalog row publishes nothing beyond a price.
+    const QUIET_SIBLING_SUFFIX: &str = "-quiet";
+    /// A release the curated row does cover, only date-stamped.
+    const SNAPSHOT_SUFFIX: &str = "-20260401";
     const UNLISTED_INPUT_PRICE: f64 = 1.5;
     const UNLISTED_OUTPUT_PRICE: f64 = 4.5;
     const UNLISTED_CACHE_READ: f64 = 0.15;
@@ -1020,6 +1039,10 @@ mod tests {
     const UNLISTED_OUTPUT: u32 = 96_000;
     /// Nothing like any real rate, so whichever source a model read is obvious.
     const STALE_CATALOG_PRICE: f64 = 99.0;
+    const ZAI_PLAN_ID: &str = "zai-coding-plan";
+    const PAID_INPUT_PRICE: f64 = 1.0;
+    const PAID_CONTEXT: u32 = 128_000;
+    const PAID_OUTPUT: u32 = 64_000;
 
     #[test]
     fn new_rejects_no_auth() {
@@ -1061,6 +1084,22 @@ mod tests {
         assert_eq!(header, expected.then(|| session.to_string()).as_deref());
     }
 
+    /// Limits are published so nothing under test reads a default; only the
+    /// price separates the two rows.
+    fn priced(input: f64) -> CatalogMeta {
+        CatalogMeta {
+            context: Some(PAID_CONTEXT),
+            output: Some(PAID_OUTPUT),
+            pricing: Some(ModelPricing {
+                input,
+                output: input * 2.0,
+                ..ModelPricing::default()
+            }),
+            supports_thinking: Some(false),
+            supports_vision: Some(false),
+        }
+    }
+
     fn opencode_go_provider_data(env_key: &str) -> ProviderData {
         ProviderData {
             quirks: opencode::QUIRKS,
@@ -1071,32 +1110,8 @@ mod tests {
             npm: "@ai-sdk/openai-compatible".into(),
             api_format: EndpointType::ChatCompletions,
             models: HashMap::from([
-                (
-                    "paid-model".into(),
-                    CatalogMeta {
-                        context: 128_000,
-                        output: 64_000,
-                        input_price: 1.0,
-                        output_price: 2.0,
-                        cache_read: 0.0,
-                        cache_write: 0.0,
-                        supports_thinking: false,
-                        supports_vision: false,
-                    },
-                ),
-                (
-                    "free-model".into(),
-                    CatalogMeta {
-                        context: 128_000,
-                        output: 64_000,
-                        input_price: 0.0,
-                        output_price: 0.0,
-                        cache_read: 0.0,
-                        cache_write: 0.0,
-                        supports_thinking: false,
-                        supports_vision: false,
-                    },
-                ),
+                ("paid-model".into(), priced(PAID_INPUT_PRICE)),
+                ("free-model".into(), priced(0.0)),
             ]),
         }
     }
@@ -1609,7 +1624,7 @@ mod tests {
             (
                 "vision-model".into(),
                 CatalogModel {
-                    attachment: true,
+                    attachment: Some(true),
                     ..Default::default()
                 },
             ),
@@ -1632,10 +1647,9 @@ mod tests {
     }
 
     /// models.dev lists every model a provider ships, so it can answer for the
-    /// ones our table has never seen. Builtins are kept out of the catalog's
-    /// provider map (they have a client of their own), and that must not cost
-    /// them the metadata. Curated entries are checked against the provider's
-    /// pricing page, so they still beat a catalog that may be stale.
+    /// ones our table has never seen. Curated rows are checked against the
+    /// provider's own pricing page, so they still beat a catalog that may be
+    /// carrying a stale rate.
     #[test]
     fn catalog_answers_only_for_models_the_static_table_misses() {
         let (_tmp, state_dir) = temp_state_dir();
@@ -1654,65 +1668,243 @@ mod tests {
         );
 
         let curated = &deepseek::models()[0];
-        let listed = Model::from_spec(&format!("{BUILTIN_SLUG}/{}", curated.prefixes[0])).unwrap();
+        let listed = Model::from_spec(&format!("{BUILTIN_SLUG}/{}", curated_flash())).unwrap();
         assert_eq!(listed.pricing.input, curated.pricing.input);
         assert_eq!(listed.context_window, curated.context_window);
     }
 
+    /// Curated rows match by prefix, so `deepseek-flash` answers for every id
+    /// starting with it. That guess loses to models.dev naming the exact model,
+    /// or the next release in an existing family bills at its predecessor's
+    /// rates forever without ever looking stale. A date stamp is the exception:
+    /// it names the same model, so the curated row keeps it.
     #[test]
-    fn builtin_keeps_its_metadata_without_becoming_a_catalog_provider() {
+    fn a_relative_matched_by_prefix_loses_to_the_catalog_naming_the_model() {
         let (_tmp, state_dir) = temp_state_dir();
-        let data = CatalogData::from_index(builtin_catalog(), &state_dir);
+        super::seed_catalog_for_tests(builtin_catalog(), state_dir);
+        let curated = &deepseek::models()[0];
 
-        assert!(data.provider(BUILTIN_SLUG).is_none());
-        assert!(data.model_meta(BUILTIN_SLUG, UNLISTED_MODEL).is_some());
+        let sibling = Model::from_spec(&format!("{BUILTIN_SLUG}/{}", sibling_model())).unwrap();
+        assert_eq!(sibling.pricing.input, UNLISTED_INPUT_PRICE);
+        assert_eq!(sibling.context_window, UNLISTED_CONTEXT);
+        assert_eq!(sibling.max_output_tokens, Some(UNLISTED_OUTPUT));
+        assert!(
+            !sibling.supports_vision(),
+            "the curated relative has vision"
+        );
+        assert_eq!(
+            sibling.family, curated.family,
+            "which dialect a model speaks is still the relative's answer to give"
+        );
+
+        let snapshot = Model::from_spec(&format!(
+            "{BUILTIN_SLUG}/{}{SNAPSHOT_SUFFIX}",
+            curated_flash()
+        ))
+        .unwrap();
+        assert_eq!(snapshot.pricing.input, curated.pricing.input);
     }
 
-    fn builtin_catalog() -> CatalogIndex {
-        let stale_cost = Some(CatalogCost {
-            input: Some(STALE_CATALOG_PRICE),
-            output: Some(STALE_CATALOG_PRICE),
-            cache_read: None,
-            cache_write: None,
-        });
-        let models = HashMap::from([
-            (
-                UNLISTED_MODEL.into(),
-                CatalogModel {
-                    limit: Some(CatalogLimits {
-                        context: Some(UNLISTED_CONTEXT),
-                        input: None,
-                        output: Some(UNLISTED_OUTPUT),
-                    }),
-                    cost: Some(CatalogCost {
-                        input: Some(UNLISTED_INPUT_PRICE),
-                        output: Some(UNLISTED_OUTPUT_PRICE),
-                        cache_read: Some(UNLISTED_CACHE_READ),
-                        cache_write: None,
-                    }),
-                    attachment: true,
-                    reasoning: false,
-                    ..Default::default()
-                },
-            ),
-            (
-                deepseek::models()[0].prefixes[0].into(),
-                CatalogModel {
-                    cost: stale_cost,
-                    ..Default::default()
-                },
-            ),
-        ]);
+    /// The catalog only outranks a relative where it has something to say.
+    /// Every field it leaves out keeps falling through, first to the relative
+    /// and then to the manifest, or reading models.dev would cost a model the
+    /// metadata it already had.
+    #[test]
+    fn fields_the_catalog_omits_fall_through() {
+        let (_tmp, state_dir) = temp_state_dir();
+        super::seed_catalog_for_tests(builtin_catalog(), state_dir);
+        let curated = &deepseek::models()[0];
+        let manifest = ManifestRegistry::for_slug(BUILTIN_SLUG).unwrap();
+
+        let quiet = Model::from_spec(&format!("{BUILTIN_SLUG}/{}", quiet_sibling_model())).unwrap();
+        assert_eq!(
+            quiet.pricing.input, UNLISTED_INPUT_PRICE,
+            "the catalog priced it, so it has to be the one answering below"
+        );
+        assert_eq!(quiet.context_window, curated.context_window);
+        assert_eq!(quiet.max_output_tokens, curated.max_output_tokens);
+        assert_eq!(quiet.supports_vision(), curated.vision);
+        assert_eq!(quiet.supports_thinking(), manifest.supports_thinking);
+    }
+
+    /// models.dev leaves `limit` off plenty of entries, and a builtin manifest
+    /// carries a real number for its provider (DeepSeek serves 1M context)
+    /// against the 128k/64k the catalog guesses for everyone else. An
+    /// unpublished limit must not read as a published one, or every gap in the
+    /// catalog silently shrinks the window we paid for.
+    #[test]
+    fn a_limit_the_catalog_omits_falls_through_to_the_manifest() {
+        let (_tmp, state_dir) = temp_state_dir();
+        let index = single_provider_catalog(
+            BUILTIN_SLUG,
+            "@ai-sdk/openai-compatible",
+            Some("https://api.deepseek.com"),
+        );
+        super::seed_catalog_for_tests(index, state_dir);
+
+        let manifest = ManifestRegistry::for_slug(BUILTIN_SLUG).unwrap();
+        let model = Model::from_spec(&format!("{BUILTIN_SLUG}/{UNLISTED_MODEL}")).unwrap();
+
+        assert_eq!(
+            model.pricing.input, UNLISTED_INPUT_PRICE,
+            "the catalog entry has to be the one answering, or the limits below prove nothing"
+        );
+        assert_eq!(model.context_window, manifest.fallback_context_window);
+        assert_eq!(model.max_output_tokens, manifest.fallback_max_output);
+    }
+
+    /// Every builtin the catalog covers reaches its metadata, whichever SDK it
+    /// publishes, whether it lists a base URL at all, and whatever id it goes by
+    /// there. None of them may reach the provider map: they have a client of
+    /// their own, so a second entry would show up twice in the login pickers.
+    #[test_case("anthropic", "anthropic", "@ai-sdk/anthropic", None; "sdk we speak but no base url")]
+    #[test_case("deepseek", "deepseek", "@ai-sdk/openai-compatible", Some("https://api.deepseek.com"); "everything it takes to be servable")]
+    #[test_case("openai", "openai", "@ai-sdk/openai", Some("https://api.openai.com/v1"); "sdk we do not speak")]
+    #[test_case("google", "google", "@ai-sdk/google", None; "sdk we do not speak and no base url")]
+    #[test_case("openrouter", "openrouter", "@openrouter/ai-sdk-provider", Some("https://openrouter.ai/api/v1"); "vendor sdk")]
+    #[test_case("zai", "zai", "@ai-sdk/openai-compatible", Some("https://api.z.ai/api/paas/v4"); "pay as you go rates")]
+    #[test_case("github-copilot", "copilot", "@ai-sdk/openai-compatible", Some("https://api.githubcopilot.com"); "renamed")]
+    #[test_case("regolo-ai", "regolo", "@ai-sdk/openai-compatible", Some("https://api.regolo.ai/v1"); "renamed too")]
+    fn builtins_keep_their_catalog_metadata(
+        catalog_id: &str,
+        slug: &str,
+        npm: &str,
+        api: Option<&str>,
+    ) {
+        let (_tmp, state_dir) = temp_state_dir();
+        let data =
+            CatalogData::from_index(single_provider_catalog(catalog_id, npm, api), &state_dir);
+
+        assert!(data.model_meta(slug, UNLISTED_MODEL).is_some());
+        assert!(data.provider(slug).is_none());
+        assert!(data.provider(catalog_id).is_none());
+    }
+
+    /// Its models are covered by the pay as you go `zai` entry, and are priced
+    /// at zero here because the plan already paid for them.
+    #[test]
+    fn plan_priced_provider_is_dropped_entirely() {
+        let (_tmp, state_dir) = temp_state_dir();
+        let index = single_provider_catalog(
+            ZAI_PLAN_ID,
+            "@ai-sdk/openai-compatible",
+            Some("https://api.z.ai/api/coding/paas/v4"),
+        );
+        let data = CatalogData::from_index(index, &state_dir);
+
+        assert!(data.provider(ZAI_PLAN_ID).is_none());
+        assert!(data.model_meta(ZAI_PLAN_ID, UNLISTED_MODEL).is_none());
+        assert!(data.model_meta("zai", UNLISTED_MODEL).is_none());
+    }
+
+    /// A renamed builtin only reaches its metadata while both halves hold: the
+    /// slug is one we ship, and the catalog id is not (or the alias is dead
+    /// weight, since the plain path would already have matched).
+    #[test]
+    fn renamed_builtins_map_a_foreign_id_onto_a_slug_we_ship() {
+        for (catalog_id, slug) in super::BUILTIN_CATALOG_IDS {
+            assert!(super::builtin_provider(slug).is_some(), "{slug}");
+            assert!(
+                super::builtin_provider(catalog_id).is_none(),
+                "{catalog_id}"
+            );
+        }
+    }
+
+    /// Rates, limits and both capability flags, the shape of a fully
+    /// documented models.dev row.
+    fn documented_row(vision: bool) -> CatalogModel {
+        CatalogModel {
+            limit: Some(CatalogLimits {
+                context: Some(UNLISTED_CONTEXT),
+                input: None,
+                output: Some(UNLISTED_OUTPUT),
+            }),
+            cost: Some(CatalogCost {
+                input: Some(UNLISTED_INPUT_PRICE),
+                output: Some(UNLISTED_OUTPUT_PRICE),
+                cache_read: Some(UNLISTED_CACHE_READ),
+                cache_write: None,
+            }),
+            attachment: Some(vision),
+            reasoning: Some(false),
+            ..Default::default()
+        }
+    }
+
+    /// A price and nothing else, the shape models.dev really ships for a chunk
+    /// of its catalog, so a test can tell "the catalog answered" apart from
+    /// "the catalog had nothing to say about this field".
+    fn priced_row(input: f64, output: f64) -> CatalogModel {
+        CatalogModel {
+            cost: Some(CatalogCost {
+                input: Some(input),
+                output: Some(output),
+                cache_read: None,
+                cache_write: None,
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn catalog_index(
+        catalog_id: &str,
+        npm: &str,
+        api: Option<&str>,
+        models: HashMap<String, CatalogModel>,
+    ) -> CatalogIndex {
         HashMap::from([(
-            BUILTIN_SLUG.into(),
+            catalog_id.into(),
             CatalogProvider {
-                name: "DeepSeek".into(),
-                env: vec!["DEEPSEEK_API_KEY".into()],
-                npm: "@ai-sdk/openai-compatible".into(),
-                api: Some("https://api.deepseek.com".into()),
+                name: catalog_id.into(),
+                env: Vec::new(),
+                npm: npm.into(),
+                api: api.map(Into::into),
                 models,
             },
         )])
+    }
+
+    fn single_provider_catalog(catalog_id: &str, npm: &str, api: Option<&str>) -> CatalogIndex {
+        let models = HashMap::from([(
+            UNLISTED_MODEL.into(),
+            priced_row(UNLISTED_INPUT_PRICE, UNLISTED_OUTPUT_PRICE),
+        )]);
+        catalog_index(catalog_id, npm, api, models)
+    }
+
+    fn curated_flash() -> &'static str {
+        deepseek::models()[0].prefixes[0]
+    }
+
+    fn sibling_model() -> String {
+        format!("{}{SIBLING_SUFFIX}", curated_flash())
+    }
+
+    fn quiet_sibling_model() -> String {
+        format!("{}{QUIET_SIBLING_SUFFIX}", curated_flash())
+    }
+
+    /// One row per rung of the order: a model the table misses, the curated id,
+    /// its dated snapshot, a relative, and a relative the catalog only prices.
+    fn builtin_catalog() -> CatalogIndex {
+        let stale = || priced_row(STALE_CATALOG_PRICE, STALE_CATALOG_PRICE);
+        let models = HashMap::from([
+            (UNLISTED_MODEL.into(), documented_row(true)),
+            (curated_flash().into(), stale()),
+            (format!("{}{SNAPSHOT_SUFFIX}", curated_flash()), stale()),
+            (sibling_model(), documented_row(false)),
+            (
+                quiet_sibling_model(),
+                priced_row(UNLISTED_INPUT_PRICE, UNLISTED_OUTPUT_PRICE),
+            ),
+        ]);
+        catalog_index(
+            BUILTIN_SLUG,
+            "@ai-sdk/openai-compatible",
+            Some("https://api.deepseek.com"),
+            models,
+        )
     }
 
     #[test]
@@ -1733,7 +1925,7 @@ mod tests {
         let models = HashMap::from([(
             "omen-alpha".into(),
             CatalogModel {
-                attachment: true,
+                attachment: Some(true),
                 ..Default::default()
             },
         )]);
@@ -2376,8 +2568,8 @@ mod tests {
 
         let (meta, provider_data) = data.lookup("opencode", "gpt-5.1-codex-mini").unwrap();
         assert_eq!(provider_data.slug, "opencode");
-        assert_eq!(meta.context, 128_000);
-        assert_eq!(meta.output, 16_384);
+        assert_eq!(meta.context_window(), 128_000);
+        assert_eq!(meta.max_output(), 16_384);
     }
 
     #[test]
@@ -2465,10 +2657,10 @@ pub(crate) mod schema {
         pub cost: Option<CatalogCost>,
         #[serde(default)]
         pub provider: Option<CatalogShape>,
-        #[serde(default)]
-        pub attachment: bool,
-        #[serde(default)]
-        pub reasoning: bool,
+        /// `None` where the row omits the flag, so a builtin keeps its manifest
+        /// default instead of reading an absent field as a published "no".
+        pub attachment: Option<bool>,
+        pub reasoning: Option<bool>,
         #[serde(default)]
         pub modalities: Option<CatalogModalities>,
     }

--- a/maki-providers/src/providers/catalog.rs
+++ b/maki-providers/src/providers/catalog.rs
@@ -303,6 +303,11 @@ pub enum Authentication {
 
 pub(crate) struct CatalogData {
     providers: HashMap<String, ProviderData>,
+    /// Kept aside for providers that ship a built-in client, since listing them
+    /// in `providers` would show them twice in the login pickers. The catalog is
+    /// still the only source that keeps up with what they release, so a model
+    /// missing from our static tables can read its rates and limits here.
+    builtin_models: HashMap<String, HashMap<String, CatalogMeta>>,
     pub(crate) state_dir: StateDir,
 }
 
@@ -310,12 +315,14 @@ impl CatalogData {
     fn empty(state_dir: StateDir) -> Self {
         Self {
             providers: HashMap::new(),
+            builtin_models: HashMap::new(),
             state_dir,
         }
     }
 
     fn from_index(index: schema::CatalogIndex, state_dir: &StateDir) -> Self {
         let mut providers = HashMap::new();
+        let mut builtin_models = HashMap::new();
 
         for (provider_id, provider) in index {
             if !ALLOWED_NPM.contains(&provider.npm.as_str()) {
@@ -334,16 +341,6 @@ impl CatalogData {
                 debug!(provider = %provider_id, "skipping: no API URL in catalog");
                 continue;
             };
-
-            if builtin_provider(&provider_id).is_some()
-                && !CATALOG_BACKED_BUILTINS.contains(&provider_id.as_str())
-            {
-                debug!(
-                    provider = &provider_id,
-                    "skipping providers supported by built-in providers"
-                );
-                continue;
-            }
 
             let api_format = determine_catalog_format(&provider.npm);
 
@@ -405,6 +402,19 @@ impl CatalogData {
             }
 
             let model_count = models.len();
+
+            if builtin_provider(&provider_id).is_some()
+                && !CATALOG_BACKED_BUILTINS.contains(&provider_id.as_str())
+            {
+                debug!(
+                    provider = %provider_id,
+                    models = model_count,
+                    "built-in provider: keeping catalog metadata only"
+                );
+                builtin_models.insert(provider_id, models);
+                continue;
+            }
+
             let provider_data =
                 ProviderData::new(provider_id.clone(), &provider, api_format, models);
             providers.insert(provider_id.clone(), provider_data);
@@ -419,12 +429,20 @@ impl CatalogData {
 
         Self {
             providers,
+            builtin_models,
             state_dir: state_dir.clone(),
         }
     }
 
     pub(crate) fn provider(&self, slug: &str) -> Option<&ProviderData> {
         self.providers.get(slug)
+    }
+
+    fn model_meta(&self, slug: &str, model_id: &str) -> Option<&CatalogMeta> {
+        self.providers
+            .get(slug)
+            .and_then(|data| data.models.get(model_id))
+            .or_else(|| self.builtin_models.get(slug)?.get(model_id))
     }
 
     pub(crate) fn lookup(
@@ -954,23 +972,12 @@ pub fn try_create(slug: &str, timeouts: Timeouts) -> Option<Result<Box<dyn Provi
 }
 
 /// Look up a single model's metadata in the models.dev catalog, only if the
-/// catalog has already been downloaded. Never triggers a fetch — callers
+/// catalog has already been downloaded. Never triggers a fetch, so callers
 /// (e.g. `Model::from_spec`) must tolerate `None` and fall through, since
 /// the catalog may still be warming in the background.
-pub fn model_meta_if_available(slug: &str, model_id: &str) -> Option<CatalogMetaView> {
-    with_provider_if_available(slug, |data| {
-        data.models.get(model_id).map(|meta| CatalogMetaView {
-            context: meta.context,
-            output: meta.output,
-            input_price: meta.input_price,
-            output_price: meta.output_price,
-            cache_read: meta.cache_read,
-            cache_write: meta.cache_write,
-            supports_thinking: meta.supports_thinking,
-            supports_vision: meta.supports_vision,
-        })
-    })
-    .flatten()
+pub(crate) fn model_meta_if_available(slug: &str, model_id: &str) -> Option<CatalogMeta> {
+    let guard = SHARED_CATALOG.get()?.lock().ok()?;
+    guard.model_meta(slug, model_id).cloned()
 }
 
 /// True when the model belongs to a provider with a [`FreeTier`] and is free
@@ -981,21 +988,6 @@ pub(crate) fn free_model_if_available(slug: &str, model_id: &str) -> bool {
         data.quirks.free_tier.is_some() && data.models.get(model_id).is_some_and(is_free_model)
     })
     .unwrap_or(false)
-}
-
-/// Metadata shape `Model::from_spec` consumes when a spec resolves to a catalog
-/// sub-provider. Public so `maki-providers/src/model.rs` can name it without
-/// depending on the catalog-internal `CatalogMeta` struct.
-#[derive(Debug, Clone, Copy)]
-pub struct CatalogMetaView {
-    pub context: u32,
-    pub output: u32,
-    pub input_price: f64,
-    pub output_price: f64,
-    pub cache_read: f64,
-    pub cache_write: f64,
-    pub supports_thinking: bool,
-    pub supports_vision: bool,
 }
 
 #[cfg(test)]
@@ -1011,12 +1003,23 @@ mod tests {
     };
     use crate::model::{Model, ModelInfo, ModelPricing};
     use crate::provider::Provider;
-    use crate::providers::{ResolvedAuth, Timeouts, opencode};
+    use crate::providers::{ResolvedAuth, Timeouts, deepseek, opencode};
     use crate::{AgentError, ModelFamily, ModelTier, RequestOptions};
     use test_case::test_case;
 
     const SESSION_HEADER: &str = "x-opencode-session";
     const OPT_IN_HINT: &str = "providers.opencode.enable_free_models = true";
+    /// A builtin with a static model table, so it is never a catalog provider.
+    const BUILTIN_SLUG: &str = "deepseek";
+    /// Stands in for a model released after our tables were written.
+    const UNLISTED_MODEL: &str = "deepseek-v9-turbo";
+    const UNLISTED_INPUT_PRICE: f64 = 1.5;
+    const UNLISTED_OUTPUT_PRICE: f64 = 4.5;
+    const UNLISTED_CACHE_READ: f64 = 0.15;
+    const UNLISTED_CONTEXT: u32 = 512_000;
+    const UNLISTED_OUTPUT: u32 = 96_000;
+    /// Nothing like any real rate, so whichever source a model read is obvious.
+    const STALE_CATALOG_PRICE: f64 = 99.0;
 
     #[test]
     fn new_rejects_no_auth() {
@@ -1626,6 +1629,90 @@ mod tests {
 
         let model = super::Model::from_spec(&format!("opencode-go/{model_id}")).unwrap();
         assert_eq!(model.supports_vision(), expected);
+    }
+
+    /// models.dev lists every model a provider ships, so it can answer for the
+    /// ones our table has never seen. Builtins are kept out of the catalog's
+    /// provider map (they have a client of their own), and that must not cost
+    /// them the metadata. Curated entries are checked against the provider's
+    /// pricing page, so they still beat a catalog that may be stale.
+    #[test]
+    fn catalog_answers_only_for_models_the_static_table_misses() {
+        let (_tmp, state_dir) = temp_state_dir();
+        super::seed_catalog_for_tests(builtin_catalog(), state_dir);
+
+        let unlisted = Model::from_spec(&format!("{BUILTIN_SLUG}/{UNLISTED_MODEL}")).unwrap();
+        assert_eq!(unlisted.pricing.input, UNLISTED_INPUT_PRICE);
+        assert_eq!(unlisted.pricing.output, UNLISTED_OUTPUT_PRICE);
+        assert_eq!(unlisted.pricing.cache_read, UNLISTED_CACHE_READ);
+        assert_eq!(unlisted.context_window, UNLISTED_CONTEXT);
+        assert_eq!(unlisted.max_output_tokens, Some(UNLISTED_OUTPUT));
+        assert!(unlisted.supports_vision());
+        assert!(
+            !unlisted.supports_thinking(),
+            "the manifest default is true, so only the catalog can say no"
+        );
+
+        let curated = &deepseek::models()[0];
+        let listed = Model::from_spec(&format!("{BUILTIN_SLUG}/{}", curated.prefixes[0])).unwrap();
+        assert_eq!(listed.pricing.input, curated.pricing.input);
+        assert_eq!(listed.context_window, curated.context_window);
+    }
+
+    #[test]
+    fn builtin_keeps_its_metadata_without_becoming_a_catalog_provider() {
+        let (_tmp, state_dir) = temp_state_dir();
+        let data = CatalogData::from_index(builtin_catalog(), &state_dir);
+
+        assert!(data.provider(BUILTIN_SLUG).is_none());
+        assert!(data.model_meta(BUILTIN_SLUG, UNLISTED_MODEL).is_some());
+    }
+
+    fn builtin_catalog() -> CatalogIndex {
+        let stale_cost = Some(CatalogCost {
+            input: Some(STALE_CATALOG_PRICE),
+            output: Some(STALE_CATALOG_PRICE),
+            cache_read: None,
+            cache_write: None,
+        });
+        let models = HashMap::from([
+            (
+                UNLISTED_MODEL.into(),
+                CatalogModel {
+                    limit: Some(CatalogLimits {
+                        context: Some(UNLISTED_CONTEXT),
+                        input: None,
+                        output: Some(UNLISTED_OUTPUT),
+                    }),
+                    cost: Some(CatalogCost {
+                        input: Some(UNLISTED_INPUT_PRICE),
+                        output: Some(UNLISTED_OUTPUT_PRICE),
+                        cache_read: Some(UNLISTED_CACHE_READ),
+                        cache_write: None,
+                    }),
+                    attachment: true,
+                    reasoning: false,
+                    ..Default::default()
+                },
+            ),
+            (
+                deepseek::models()[0].prefixes[0].into(),
+                CatalogModel {
+                    cost: stale_cost,
+                    ..Default::default()
+                },
+            ),
+        ]);
+        HashMap::from([(
+            BUILTIN_SLUG.into(),
+            CatalogProvider {
+                name: "DeepSeek".into(),
+                env: vec!["DEEPSEEK_API_KEY".into()],
+                npm: "@ai-sdk/openai-compatible".into(),
+                api: Some("https://api.deepseek.com".into()),
+                models,
+            },
+        )])
     }
 
     #[test]

--- a/maki-providers/src/providers/deepseek.rs
+++ b/maki-providers/src/providers/deepseek.rs
@@ -18,7 +18,7 @@ use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
 
 const PAD: &str = "";
-const V4_MARKER: &str = "deepseek-v4";
+const REASONER_ID: &str = "deepseek-reasoner";
 const BALANCE_URL: &str = "https://api.deepseek.com/user/balance";
 
 static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
@@ -36,7 +36,7 @@ inventory::submit!(maki_config::providers::BuiltInProvider {
     protocol: maki_config::providers::Protocol::Openai,
     default_base_url: "https://api.deepseek.com",
     default_api_key_env: "DEEPSEEK_API_KEY",
-    default_model: "deepseek/deepseek-v4-flash",
+    default_model: "deepseek/deepseek-flash",
     plans: None,
     login_url: Some("https://platform.deepseek.com/api_keys"),
     needs_url: false,
@@ -53,17 +53,19 @@ const PEAK_MULTIPLIER: f64 = 2.0;
 
 pub(crate) const fn models() -> &'static [ModelEntry] {
     &[
+        // `deepseek-flash` is V4.1 Flash. `deepseek-v4-flash` is the retired
+        // name the API still accepts, served by V4.1 Flash at its rates.
         ModelEntry {
-            prefixes: &["deepseek-v4-flash"],
+            prefixes: &["deepseek-flash", "deepseek-v4-flash"],
             tier: ModelTier::Medium,
             family: ModelFamily::Generic,
-            vision: false,
+            vision: true,
             default: true,
             pricing: ModelPricing {
-                input: 0.22,
-                output: 0.66,
+                input: 0.15,
+                output: 0.60,
                 cache_write: 0.00,
-                cache_read: 0.007,
+                cache_read: 0.003,
                 fast: None,
             },
             max_output_tokens: Some(384_000),
@@ -234,15 +236,26 @@ impl Provider for DeepSeek {
     }
 }
 
-/// DeepSeek's two reasoning models disagree about `reasoning_content`: V4 in
-/// thinking mode wants it on every assistant turn (missing = 400), R1 refuses
-/// it as input. So we gate on the V4 substring, same trick Vercel's AI SDK
-/// uses, and back-fill the turns that have none (plain replies, tool-only
-/// turns). The API only checks the field exists, so `""` is enough.
+/// Whether a model speaks the thinking protocol DeepSeek introduced with V4:
+/// an explicit toggle, and `reasoning_content` echoed back on input. Only
+/// `deepseek-reasoner` (R1) sits outside it, reasoning unconditionally and
+/// refusing the field as input, so we name that one id rather than match a
+/// version marker the next rename would break. Providers that resell DeepSeek
+/// share the gate, after stripping their vendor prefix.
 ///
 /// Ref: <https://api-docs.deepseek.com/guides/thinking_mode>
+pub(crate) fn uses_v4_thinking_protocol(model_id: &str) -> bool {
+    !model_id.starts_with(REASONER_ID)
+}
+
+/// V4 and later want `reasoning_content` on every assistant turn of a request
+/// carrying `tools` (missing = 400), so we back-fill the turns that have none:
+/// plain replies and tool-only turns. The API only checks the field exists, so
+/// `""` is enough. Requests without tools are left alone, since nothing asks
+/// for the field there and this runs for any id a DeepSeek-based custom
+/// provider is pointed at.
 fn pad_reasoning_content(model_id: &str, body: &mut Value) {
-    if !model_id.contains(V4_MARKER) {
+    if !uses_v4_thinking_protocol(model_id) || body.get("tools").is_none() {
         return;
     }
     let Some(messages) = body.get_mut("messages").and_then(Value::as_array_mut) else {
@@ -266,9 +279,10 @@ mod tests {
     use super::*;
     use crate::manifest::ManifestRegistry;
     use serde_json::json;
+    use test_case::test_case;
 
-    const V4: &str = "deepseek-v4-pro";
-    const R1: &str = "deepseek-reasoner";
+    /// No version marker in the id, which is what the old substring gate missed.
+    const FLASH: &str = "deepseek-flash";
     /// The hours, days and surcharge as the pricing page states them.
     const PUBLISHED_PEAK_HOURS: &str = "2x during 01:00-04:00, 06:00-10:00 UTC, Mon-Fri";
 
@@ -286,16 +300,23 @@ mod tests {
         assert_eq!(PEAK_HOURS.to_string(), PUBLISHED_PEAK_HOURS);
     }
 
+    fn tool_call_body() -> Value {
+        json!({
+            "tools": [{"type": "function", "function": {"name": "read"}}],
+            "messages": [
+                {"role": "system",    "content": "sys"},
+                {"role": "user",      "content": "hi"},
+                {"role": "assistant", "content": "ok", "reasoning_content": "kept"},
+                {"role": "assistant", "content": "",   "tool_calls": [{"id": "c1"}]},
+                {"role": "tool",      "tool_call_id": "c1", "content": "out"},
+            ],
+        })
+    }
+
     #[test]
-    fn v4_pads_only_assistant_turns_without_reasoning() {
-        let mut body = json!({"messages": [
-            {"role": "system",    "content": "sys"},
-            {"role": "user",      "content": "hi"},
-            {"role": "assistant", "content": "ok", "reasoning_content": "kept"},
-            {"role": "assistant", "content": "",   "tool_calls": [{"id": "c1"}]},
-            {"role": "tool",      "tool_call_id": "c1", "content": "out"},
-        ]});
-        pad_reasoning_content(V4, &mut body);
+    fn pads_only_assistant_turns_without_reasoning() {
+        let mut body = tool_call_body();
+        pad_reasoning_content(FLASH, &mut body);
         let msgs = body["messages"].as_array().unwrap();
         assert_eq!(msgs[2]["reasoning_content"], "kept");
         assert_eq!(msgs[3]["reasoning_content"], PAD);
@@ -304,14 +325,28 @@ mod tests {
         }
     }
 
-    #[test]
-    fn non_v4_model_is_untouched() {
-        let input = json!({"messages": [
-            {"role": "assistant", "content": "", "tool_calls": [{"id": "c1"}]},
-            {"role": "assistant", "content": "hi"},
-        ]});
+    /// Padding exists for one 400, raised on requests that carry `tools`, by
+    /// models that echo the field. Everything else has to come back byte for
+    /// byte, and the tool-less case matters because the gate now lets through
+    /// any id a DeepSeek-based custom provider is pointed at.
+    #[test_case(REASONER_ID, true; "the one model that refuses the field")]
+    #[test_case(FLASH, false; "a request that never carried tools")]
+    fn bodies_outside_the_workaround_are_untouched(model_id: &str, tools: bool) {
+        let mut input = tool_call_body();
+        if !tools {
+            input.as_object_mut().unwrap().remove("tools");
+        }
         let mut body = input.clone();
-        pad_reasoning_content(R1, &mut body);
+        pad_reasoning_content(model_id, &mut body);
         assert_eq!(body, input);
+    }
+
+    /// The gate the rename broke once already: it has to key off the one id that
+    /// refuses the field, never off a version marker in the others.
+    #[test_case(FLASH, true; "current flash")]
+    #[test_case("deepseek-v9-turbo", true; "a release the table has never seen")]
+    #[test_case(REASONER_ID, false; "the one model that refuses it")]
+    fn only_the_legacy_reasoner_is_outside_the_v4_protocol(model_id: &str, expected: bool) {
+        assert_eq!(uses_v4_thinking_protocol(model_id), expected);
     }
 }

--- a/maki-providers/src/providers/opencode.rs
+++ b/maki-providers/src/providers/opencode.rs
@@ -148,8 +148,8 @@ impl Provider for Opencode {
 
             let stream_model = Model {
                 id: actual_id.to_string(),
-                max_output_tokens: Some(meta.output),
-                context_window: meta.context,
+                max_output_tokens: Some(meta.max_output()),
+                context_window: meta.context_window(),
                 ..model.clone()
             };
 

--- a/maki-providers/src/providers/tensorx.rs
+++ b/maki-providers/src/providers/tensorx.rs
@@ -9,7 +9,11 @@ use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
-use super::{KeyPool, ResolvedAuth};
+use super::{KeyPool, ResolvedAuth, deepseek};
+
+/// TensorX namespaces resold models by vendor, so DeepSeek ids arrive as
+/// `deepseek/deepseek-flash`.
+const DEEPSEEK_VENDOR_PREFIX: &str = "deepseek/";
 
 static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     slug: "tensorx",
@@ -105,10 +109,15 @@ impl Provider for TensorX {
                 opts.thinking
                     .apply_reasoning_effort(&mut body, &dialect::TENSORX, model);
             }
-            // Fallback for deepseek models that use chat_template_kwargs
+            // DeepSeek takes the toggle through the chat template and TensorX
+            // advertises neither knob for it. Sharing DeepSeek's own predicate
+            // means a rename upstream cannot quietly turn thinking off here.
             else if !has_thinking
                 && opts.thinking.is_enabled()
-                && model.id.starts_with("deepseek/deepseek-v4")
+                && model
+                    .id
+                    .strip_prefix(DEEPSEEK_VENDOR_PREFIX)
+                    .is_some_and(deepseek::uses_v4_thinking_protocol)
             {
                 body["chat_template_kwargs"] = json!({"thinking": true});
             }

--- a/maki-providers/src/providers/zai/mod.rs
+++ b/maki-providers/src/providers/zai/mod.rs
@@ -115,9 +115,14 @@ inventory::submit!(BuiltInProvider {
     needs_url: false,
 });
 
-/// Rates come from the pay as you go table on docs.z.ai. models.dev looks like
-/// a good source but still lists the launch promo for the GLM-5 line, which
-/// expired, so copying from there halves the numbers below.
+/// Rates come from the pay as you go table on docs.z.ai, not models.dev, which
+/// carries a launch promo past its expiry and so halves the GLM-5 line. A later
+/// `glm-5.x` nobody has curated yet still reads models.dev: a promo rate is the
+/// wrong number, but it beats the zero an unpriced model gets, which renders as
+/// free.
+///
+/// The coding plan (`zai-coding-plan`) is blocked from the catalog instead. The
+/// plan already paid for those models, so every row in it really is zero.
 pub(crate) const fn models() -> &'static [ModelEntry] {
     &[
         ModelEntry {

--- a/site/docs/content/acp/_index.md
+++ b/site/docs/content/acp/_index.md
@@ -21,7 +21,7 @@ Add Maki as a custom agent in Zed's `settings.json`:
 "agent_servers": {
   "Maki": {
     "default_config_options": {
-      "model": "deepseek/deepseek-v4-flash"
+      "model": "deepseek/deepseek-flash"
     },
     "type": "custom",
     "command": "maki",

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -220,10 +220,10 @@ Defaults: glm-5-code (strong), glm-4.7-flash (weak), glm-4.7 (medium)
 
 | Tier | Models | Pricing (in/out per 1M tokens) | Context |
 |------|--------|-------------------------------|---------|
-| Medium | **deepseek-v4-flash** (default) | $0.22 / $0.66 | 1000K ctx / 384K out |
+| Medium | **deepseek-flash, deepseek-v4-flash** (default) | $0.15 / $0.60 | 1000K ctx / 384K out |
 | Strong | **deepseek-v4-pro** (default) | $0.66 / $1.98 | 1000K ctx / 384K out |
 
-Defaults: deepseek-v4-flash (medium), deepseek-v4-pro (strong)
+Defaults: deepseek-flash (medium), deepseek-v4-pro (strong)
 
 ### OpenRouter
 
@@ -335,6 +335,14 @@ zai/glm-4.7
 ```
 
 If the model name is unique across providers, the prefix can be omitted.
+
+### Models newer than your Maki version
+
+The tables above list the models Maki curates. Any other id a provider accepts works too: type it into `/model` or pass it to `--model`. The picker also lists what the provider's own model endpoint reports, so same-day releases are selectable there.
+
+Rates, context window, vision and thinking support for a model missing from the tables come from [models.dev](https://models.dev/), refreshed daily (`maki models --refresh` forces it). Curated entries win where they exist, because they are checked against each provider's pricing page. A model neither source knows still runs, with the provider's default limits and no cost estimate.
+
+New models start at the **medium** tier until you assign one in the picker.
 
 ## providers.toml
 

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -340,7 +340,17 @@ If the model name is unique across providers, the prefix can be omitted.
 
 The tables above list the models Maki curates. Any other id a provider accepts works too: type it into `/model` or pass it to `--model`. The picker also lists what the provider's own model endpoint reports, so same-day releases are selectable there.
 
-Rates, context window, vision and thinking support for a model missing from the tables come from [models.dev](https://models.dev/), refreshed daily (`maki models --refresh` forces it). Curated entries win where they exist, because they are checked against each provider's pricing page. A model neither source knows still runs, with the provider's default limits and no cost estimate.
+For an id no table covers, rates, context window, vision and thinking support come from [models.dev](https://models.dev/), refreshed daily (`maki models --refresh` forces it). Maki reads each field on its own, so a row that lists a price but no context window still leaves the window to the sources below.
+
+Sources rank by how sure they are to describe the exact model you asked for:
+
+1. What the provider's own model endpoint reported this session.
+2. A curated row for that id, including its dated snapshots. `claude-sonnet-4-5-20250929` reads the `claude-sonnet-4-5` row.
+3. models.dev.
+4. A curated row for a close relative, reached by shared prefix. `glm-5.4` falls back to `glm-5` here, and takes its family and tier from it either way.
+5. The provider's defaults, with no cost estimate.
+
+A curated row is checked against the provider's own pricing page, so it wins for the id it names. For a relative it loses to models.dev, because a rate nobody checked against the id you typed is only a guess.
 
 New models start at the **medium** tier until you assign one in the picker.
 


### PR DESCRIPTION
DeepSeek shipped V4.1 Flash as `deepseek-flash`. Our static table only knew the
retired `deepseek-v4-flash`, at its old $0.22/$0.66 with vision off, and that was
the third release in a row that needed a code change just to be priced.

A model with no curated row now reads its rates, context window, vision and
thinking support from [models.dev](https://models.dev/), which already lists
`deepseek-flash`, so the next release works untouched.

## Where a model's metadata comes from

Ranked by how sure a source is to describe the exact id you asked for:

1. What the provider's own model endpoint reported this session.
2. A curated row naming that id, dated snapshots included.
3. models.dev.
4. A curated row for a close relative, reached by shared prefix.
5. The provider's defaults.

Curated rows are checked against each provider's pricing page, so they win for
the id they name. They lose to models.dev for a relative, because a rate nobody
checked against the id you typed is a guess: otherwise `glm-5.4` would bill at
`glm-5` rates forever without ever looking stale. Every field is read on its own,
so a models.dev row with a price but no context window still leaves the window to
the sources below it.

## Also in here

- Builtins keep their catalog metadata without entering `CatalogData::providers`,
  the map behind the login pickers, so DeepSeek does not show up twice. The npm
  allowlist, base URL check and blocklist used to run first and dropped nine of
  the twelve builtins on the way in.
- `github-copilot` and `regolo-ai` go by other names upstream and are mapped onto
  our slugs.
- Catalog limits stay `Option` instead of collapsing to the 128k/64k guess at
  parse time, or DeepSeek's 1M window would shrink every time models.dev omits a
  limit, which it does on a fair few entries.
- `pad_reasoning_content` gated on the `deepseek-v4` substring, so every
  multi-turn tool call on `deepseek-flash` would have 400'd. It now skips only
  `deepseek-reasoner`, the one model that rejects the field, and the TensorX
  thinking toggle asks the same predicate after stripping the vendor prefix.
- `deepseek-flash` is added to the table with the real $0.15/$0.60 and vision on.
  Curated entries still win, since models.dev prices `deepseek-v4-pro` at
  $0.435/$0.87 against the official $0.66/$1.98.
