### PR TITLE
fix(storage): keep logging when another process rotates the log

### DIFF
--- a/maki-lua/src/docs_render.rs
+++ b/maki-lua/src/docs_render.rs
@@ -151,9 +151,11 @@ settings in a local table, or export a `setup(opts)` function `init.lua` calls.
 runs, an edited plugin is still the old one.
 
 To debug, add `maki.log.info|warn|error(...)` calls. They write to `maki.log`
-in the dir `maki.env.logs_dir()` returns (Linux: `~/.local/logs/maki/`). When
-a backtrace comes out useless, start maki with `--no-jit`: plugins then run on
-the interpreter, with full debug info.
+in the dir `maki.env.logs_dir()` returns (Linux: `~/.local/logs/maki/`). The
+log keeps `info` and above. Set `MAKI_LOG=debug` to also keep `maki.log.debug`,
+or `MAKI_LOG=maki_lua=trace` to narrow it to one target. When a backtrace comes
+out useless, start maki with `--no-jit`: plugins then run on the interpreter,
+with full debug info.
 
 {AGENT_NOTES}## Conventions
 

--- a/maki-storage/src/log.rs
+++ b/maki-storage/src/log.rs
@@ -1,17 +1,16 @@
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, File, Metadata, OpenOptions};
 use std::io::{self, Write};
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
-use tracing::warn;
-
 use crate::paths;
 
 const LOG_FILE_NAME: &str = "maki.log";
 const LOCK_FILE_NAME: &str = "maki.log.lock";
-pub const DEFAULT_MAX_BYTES: u64 = 200 * 1024 * 1024;
-pub const DEFAULT_MAX_FILES: u32 = 10;
+const ROTATED_PREFIX: &str = "maki.";
+const ROTATED_SUFFIX: &str = ".log";
+const MIN_MAX_FILES: u32 = 1;
 
 fn file_path(dir: &Path, index: u32) -> PathBuf {
     if index == 0 {
@@ -21,8 +20,39 @@ fn file_path(dir: &Path, index: u32) -> PathBuf {
     }
 }
 
+/// The one place that decides whether a file name belongs to us, so migration,
+/// pruning and rotation cannot drift apart on what `maki.2.log` means.
+fn rotated_index(name: &str) -> Option<u32> {
+    if name == LOG_FILE_NAME {
+        return Some(0);
+    }
+    name.strip_prefix(ROTATED_PREFIX)?
+        .strip_suffix(ROTATED_SUFFIX)?
+        .parse()
+        .ok()
+}
+
+fn open_append(path: &Path) -> io::Result<File> {
+    OpenOptions::new().create(true).append(true).open(path)
+}
+
 fn flock_exclusive(file: &File) -> io::Result<()> {
     file.lock()
+}
+
+/// A handle whose last name was removed. Every write it accepts goes to an
+/// inode no reader can open, so on unix this is the difference between logging
+/// and only appearing to.
+#[cfg(unix)]
+fn is_unlinked(meta: &Metadata) -> bool {
+    meta.nlink() == 0
+}
+
+/// Windows refuses to rename or delete a file another process holds open, so a
+/// handle here cannot be pulled out from under us.
+#[cfg(not(unix))]
+fn is_unlinked(_meta: &Metadata) -> bool {
+    false
 }
 
 /// Logs used to live in the state dir. Move any leftover `maki.*.log` files
@@ -44,7 +74,7 @@ fn migrate_stale_logs(old_dir: &Path, new_dir: &Path) {
             fs::remove_file(entry.path()).ok();
             continue;
         }
-        if !name.starts_with("maki.") || !name.ends_with(".log") {
+        if rotated_index(name).is_none() {
             continue;
         }
         let dst = new_dir.join(name);
@@ -54,12 +84,66 @@ fn migrate_stale_logs(old_dir: &Path, new_dir: &Path) {
     }
 }
 
+/// Delete every rotated file from `first` upwards. Rotation used to remove the
+/// single index it was about to overwrite, so lowering `max_log_files` stranded
+/// everything above the new ceiling on disk forever.
+///
+/// A file that will not go away is reported and skipped instead of failing the
+/// rotation. `shift_up` is what frees `maki.log`, so a leftover file costs disk
+/// space while a refused rotation costs the log.
+fn prune_from(dir: &Path, first: u32) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(index) = name.to_str().and_then(rotated_index) else {
+            continue;
+        };
+        if index >= first
+            && let Err(e) = fs::remove_file(entry.path())
+            && e.kind() != io::ErrorKind::NotFound
+        {
+            report(format_args!(
+                "cannot remove {}: {e}",
+                entry.path().display()
+            ));
+        }
+    }
+}
+
+/// Walk the chain downwards, so every file lands in the slot the one above it
+/// just left and `maki.log` moves last.
+///
+/// A refused rename comes back as an error, because the caller has to learn
+/// that `maki.log` is still the full file it was. Reporting it and carrying on
+/// is what turned a log dir that will not accept renames into a directory scan
+/// and a line of stderr per log event.
+fn shift_up(dir: &Path, last: u32) -> io::Result<()> {
+    for i in (0..last).rev() {
+        let src = file_path(dir, i);
+        if src.exists() {
+            fs::rename(&src, file_path(dir, i + 1))?;
+        }
+    }
+    Ok(())
+}
+
+/// How this file reports trouble, and the reason it is not `tracing::warn`.
+/// `RotatingFileWriter` is the subscriber's own writer, so everything here runs
+/// with its lock held, and a log line would take that same lock again on the
+/// same thread and hang the process.
+fn report(args: std::fmt::Arguments<'_>) {
+    eprintln!("maki: log rotation: {args}");
+}
+
 pub struct RotatingFileWriter {
     dir: PathBuf,
     file: File,
-    written: u64,
     max_bytes: u64,
     max_files: u32,
+    /// Length the file has to reach before rotation is tried again.
+    retry_above: u64,
 }
 
 impl RotatingFileWriter {
@@ -71,81 +155,119 @@ impl RotatingFileWriter {
         Self::with_limits(&logs, max_bytes, max_files)
     }
 
+    /// `max_files` is clamped rather than trusted: config validation rejects
+    /// zero, but this is a public constructor, and zero used to underflow into
+    /// four billion `exists` calls made while holding the rotation lock, which
+    /// wedged every other maki process on the machine along with this one.
     fn with_limits(dir: &Path, max_bytes: u64, max_files: u32) -> io::Result<Self> {
         let dir = dir.to_path_buf();
-        let path = file_path(&dir, 0);
-        let file = OpenOptions::new().create(true).append(true).open(&path)?;
-        let written = file.metadata()?.len();
+        let file = open_append(&file_path(&dir, 0))?;
         Ok(Self {
             dir,
             file,
-            written,
             max_bytes,
-            max_files,
+            max_files: max_files.max(MIN_MAX_FILES),
+            retry_above: 0,
         })
+    }
+
+    /// Asks the open handle, not a counter.
+    ///
+    /// A per-process byte count was both too small and too large: several maki
+    /// processes appending to one file each counted only their own bytes, so
+    /// the file grew past `max_bytes` once per process, and a quiet process
+    /// never reached its own limit at all, so it never looked at its handle
+    /// again while peers rotated that handle out and eventually deleted it. One
+    /// `fstat` per line costs far less than the write it guards.
+    ///
+    /// A file that lost its last name is due at any size, since every line it
+    /// takes goes to an inode nobody can open. After a failed attempt both
+    /// triggers wait for another `max_bytes` of writing, so a log dir that
+    /// refuses renames costs one attempt per `max_bytes` instead of one per
+    /// line.
+    fn rotation_due(&self, meta: &Metadata) -> bool {
+        meta.len() >= self.retry_above && (is_unlinked(meta) || meta.len() >= self.max_bytes)
+    }
+
+    /// Under the rotation lock, whether `maki.log` still names our handle. A
+    /// peer that rotated first already did the work and all we owe is a reopen.
+    #[cfg(unix)]
+    fn holds_primary(&self, primary: &Path) -> io::Result<bool> {
+        let ours = self.file.metadata()?;
+        if is_unlinked(&ours) {
+            return Ok(false);
+        }
+        Ok(match fs::metadata(primary) {
+            Ok(m) => m.ino() == ours.ino(),
+            Err(_) => true,
+        })
+    }
+
+    /// Windows has no stable way to count the names an open handle still has,
+    /// so we assume ours and let the rename decide. That rename is refused as
+    /// well, because `OpenOptions` never asks for `FILE_SHARE_DELETE`, so
+    /// rotation always fails here and the log grows past `max_log_bytes`.
+    /// Asking for the share mode is the real fix, and it wants a Windows box to
+    /// test on, since it also lets a peer delete the file under us where
+    /// `is_unlinked` is blind.
+    #[cfg(not(unix))]
+    fn holds_primary(&self, _primary: &Path) -> io::Result<bool> {
+        Ok(true)
     }
 
     fn rotate(&mut self) -> io::Result<()> {
         self.file.flush()?;
 
-        let _lock = OpenOptions::new()
+        // People clearing their logs sometimes take the whole folder, and then
+        // our handle has no name left and every attempt below dies on the
+        // missing lock file, so the lines pile up in an inode nobody can open.
+        fs::create_dir_all(&self.dir)?;
+
+        let lock = OpenOptions::new()
             .create(true)
             .truncate(false)
             .write(true)
             .open(self.dir.join(LOCK_FILE_NAME))?;
-        flock_exclusive(&_lock)?;
+        flock_exclusive(&lock)?;
 
         let primary = file_path(&self.dir, 0);
-        #[cfg(unix)]
-        let needs_rotate = {
-            let our_inode = self.file.metadata()?.ino();
-            match fs::metadata(&primary) {
-                Ok(m) => m.ino() == our_inode,
-                Err(_) => true,
-            }
-        };
-        #[cfg(not(unix))]
-        let needs_rotate = true;
-
-        if needs_rotate {
+        if self.holds_primary(&primary)? {
             let last = self.max_files - 1;
-            match fs::remove_file(file_path(&self.dir, last)) {
-                Ok(()) => {}
-                Err(e) if e.kind() == io::ErrorKind::NotFound => {}
-                Err(e) => warn!(error = %e, "log rotate: failed to remove oldest file"),
-            }
-
-            for i in (0..last).rev() {
-                let src = file_path(&self.dir, i);
-                if src.exists() {
-                    let dst = file_path(&self.dir, i + 1);
-                    if let Err(e) = fs::rename(&src, &dst) {
-                        eprintln!("maki: log rotate rename {src:?} -> {dst:?}: {e}");
-                    }
-                }
-            }
+            prune_from(&self.dir, last);
+            shift_up(&self.dir, last)?;
         }
 
-        self.file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&primary)?;
-        self.written = self.file.metadata()?.len();
+        self.file = open_append(&primary)?;
 
         Ok(())
+    }
+
+    /// The one `fstat` per write, lent to both the decision and the backoff. A
+    /// second one would cost every log line for nothing.
+    fn rotate_if_due(&mut self) {
+        let Ok(meta) = self.file.metadata() else {
+            return;
+        };
+        if !self.rotation_due(&meta) {
+            return;
+        }
+        match self.rotate() {
+            Ok(()) => self.retry_above = 0,
+            Err(e) => {
+                report(format_args!(
+                    "{}: {e}, still writing to the open file",
+                    self.dir.display()
+                ));
+                self.retry_above = meta.len().saturating_add(self.max_bytes);
+            }
+        }
     }
 }
 
 impl Write for RotatingFileWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        if self.written >= self.max_bytes
-            && let Err(e) = self.rotate()
-        {
-            eprintln!("maki: log rotation failed: {e}");
-        }
-        let n = self.file.write(buf)?;
-        self.written += n as u64;
-        Ok(n)
+        self.rotate_if_due();
+        self.file.write(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -155,13 +277,25 @@ impl Write for RotatingFileWriter {
 
 #[cfg(test)]
 mod tests {
+    use test_case::test_case;
+
     use super::*;
 
     const TEST_MAX_BYTES: u64 = 32;
     const TEST_MAX_FILES: u32 = 3;
+    const NEEDLE: &str = "needle";
 
     fn test_writer(dir: &Path) -> RotatingFileWriter {
         RotatingFileWriter::with_limits(dir, TEST_MAX_BYTES, TEST_MAX_FILES).unwrap()
+    }
+
+    fn read_all_logs(dir: &Path) -> String {
+        fs::read_dir(dir)
+            .unwrap()
+            .flatten()
+            .filter(|e| rotated_index(&e.file_name().to_string_lossy()).is_some())
+            .filter_map(|e| fs::read_to_string(e.path()).ok())
+            .collect()
     }
 
     #[test]
@@ -302,10 +436,177 @@ mod tests {
         w2.write_all(b"from-w2").unwrap();
         w2.flush().unwrap();
 
-        let all_content: String = (0..TEST_MAX_FILES)
-            .filter_map(|i| fs::read_to_string(file_path(tmp.path(), i)).ok())
-            .collect();
+        let all_content = read_all_logs(tmp.path());
         assert!(all_content.contains("from-w1"));
         assert!(all_content.contains("from-w2"));
+    }
+
+    /// The bug this whole file was rewritten for. A quiet process kept its
+    /// original handle while a busy peer rotated that handle down the chain
+    /// and finally deleted it, after which every line it wrote went to an
+    /// inode with no name and nobody noticed for months.
+    #[test]
+    fn peer_rotation_never_strands_our_writes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut quiet = test_writer(tmp.path());
+        let mut busy = test_writer(tmp.path());
+
+        let filler = "x".repeat(TEST_MAX_BYTES as usize);
+        for _ in 0..TEST_MAX_FILES + 1 {
+            busy.write_all(filler.as_bytes()).unwrap();
+            busy.flush().unwrap();
+            busy.write_all(b"tick").unwrap();
+            busy.flush().unwrap();
+        }
+
+        quiet.write_all(NEEDLE.as_bytes()).unwrap();
+        quiet.flush().unwrap();
+
+        assert!(
+            read_all_logs(tmp.path()).contains(NEEDLE),
+            "{NEEDLE} reached no file on disk"
+        );
+    }
+
+    /// Two processes sharing one file used to count only their own bytes, so
+    /// the file quietly grew to `max_bytes` per process.
+    #[test]
+    fn size_limit_counts_every_writer() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut w1 = test_writer(tmp.path());
+        let mut w2 = test_writer(tmp.path());
+
+        let half = "x".repeat(TEST_MAX_BYTES as usize / 2 + 1);
+        w1.write_all(half.as_bytes()).unwrap();
+        w1.flush().unwrap();
+        w2.write_all(half.as_bytes()).unwrap();
+        w2.flush().unwrap();
+
+        w1.write_all(NEEDLE.as_bytes()).unwrap();
+        w1.flush().unwrap();
+
+        assert_eq!(
+            fs::read_to_string(file_path(tmp.path(), 0)).unwrap(),
+            NEEDLE
+        );
+    }
+
+    /// Zero used to reach `max_files - 1` and wrap to `u32::MAX`, spending
+    /// four billion syscalls under the rotation lock that every other process
+    /// was waiting on.
+    #[test]
+    fn zero_max_files_keeps_one_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut w = RotatingFileWriter::with_limits(tmp.path(), TEST_MAX_BYTES, 0).unwrap();
+
+        w.write_all("x".repeat(TEST_MAX_BYTES as usize).as_bytes())
+            .unwrap();
+        w.write_all(NEEDLE.as_bytes()).unwrap();
+        w.flush().unwrap();
+
+        assert_eq!(
+            fs::read_to_string(file_path(tmp.path(), 0)).unwrap(),
+            NEEDLE
+        );
+        assert!(!file_path(tmp.path(), 1).exists());
+    }
+
+    #[test]
+    fn lowering_the_limit_prunes_the_files_above_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stranded = TEST_MAX_FILES + 3;
+        for i in 1..=stranded {
+            fs::write(file_path(tmp.path(), i), "old").unwrap();
+        }
+
+        let mut w = test_writer(tmp.path());
+        w.write_all("x".repeat(TEST_MAX_BYTES as usize).as_bytes())
+            .unwrap();
+        w.write_all(NEEDLE.as_bytes()).unwrap();
+        w.flush().unwrap();
+
+        for i in TEST_MAX_FILES..=stranded {
+            assert!(!file_path(tmp.path(), i).exists(), "maki.{i}.log survived");
+        }
+    }
+
+    /// The size trigger cannot see this one: the file is nowhere near the
+    /// limit, it simply has no name left. Someone clearing their logs by hand
+    /// is the everyday version.
+    /// Same story one level up, and the one the backoff would otherwise punish:
+    /// a missing dir fails every retry, so the writer would sit out a whole
+    /// `max_bytes` before looking again.
+    #[cfg(unix)]
+    #[test]
+    fn deleted_log_dir_comes_back() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("logs");
+        fs::create_dir(&dir).unwrap();
+        let mut w = test_writer(&dir);
+
+        w.write_all(b"before").unwrap();
+        fs::remove_dir_all(&dir).unwrap();
+
+        w.write_all(NEEDLE.as_bytes()).unwrap();
+        w.flush().unwrap();
+
+        assert_eq!(fs::read_to_string(file_path(&dir, 0)).unwrap(), NEEDLE);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deleted_log_file_comes_back() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut w = test_writer(tmp.path());
+
+        w.write_all(b"before").unwrap();
+        fs::remove_file(file_path(tmp.path(), 0)).unwrap();
+
+        w.write_all(NEEDLE.as_bytes()).unwrap();
+        w.flush().unwrap();
+
+        assert_eq!(
+            fs::read_to_string(file_path(tmp.path(), 0)).unwrap(),
+            NEEDLE
+        );
+    }
+
+    /// A directory in the last slot is a rename nothing can complete, and the
+    /// file below it has to move there first, so the whole chain is stuck.
+    ///
+    /// The write after the slot is freed is the interesting one: a writer that
+    /// kept retrying per line would have rotated there and left the tail alone
+    /// in a fresh `maki.log`.
+    #[test]
+    fn failed_rotation_keeps_the_lines_and_stops_asking() {
+        let tmp = tempfile::tempdir().unwrap();
+        let last = TEST_MAX_FILES - 1;
+        let blocked = file_path(tmp.path(), last);
+        fs::create_dir(&blocked).unwrap();
+        fs::write(file_path(tmp.path(), last - 1), "rotated").unwrap();
+
+        let mut w = test_writer(tmp.path());
+        let filler = "x".repeat(TEST_MAX_BYTES as usize);
+        w.write_all(filler.as_bytes()).unwrap();
+        w.write_all(NEEDLE.as_bytes()).unwrap();
+
+        fs::remove_dir(&blocked).unwrap();
+        let tail = "after-the-slot-is-free";
+        w.write_all(tail.as_bytes()).unwrap();
+        w.flush().unwrap();
+
+        assert_eq!(
+            fs::read_to_string(file_path(tmp.path(), 0)).unwrap(),
+            format!("{filler}{NEEDLE}{tail}")
+        );
+    }
+
+    #[test_case(LOG_FILE_NAME, Some(0) ; "primary_is_index_zero")]
+    #[test_case("maki.7.log", Some(7) ; "rotated_index_parses")]
+    #[test_case(LOCK_FILE_NAME, None ; "lock_file_is_not_a_log")]
+    #[test_case("maki.old.log", None ; "non_numeric_index_is_not_ours")]
+    #[test_case("other.1.log", None ; "foreign_prefix_is_not_ours")]
+    fn rotated_index_reads_our_names_only(name: &str, expected: Option<u32>) {
+        assert_eq!(rotated_index(name), expected);
     }
 }

--- a/site/docs/content/plugins/_index.md
+++ b/site/docs/content/plugins/_index.md
@@ -83,9 +83,11 @@ in [the reference](/docs/lua-api/#plugin-permissions). Set
 runs, an edited plugin is still the old one.
 
 To debug, add `maki.log.info|warn|error(...)` calls. They write to `maki.log`
-in the dir `maki.env.logs_dir()` returns (Linux: `~/.local/logs/maki/`). When
-a backtrace comes out useless, start maki with `--no-jit`: plugins then run on
-the interpreter, with full debug info.
+in the dir `maki.env.logs_dir()` returns (Linux: `~/.local/logs/maki/`). The
+log keeps `info` and above. Set `MAKI_LOG=debug` to also keep `maki.log.debug`,
+or `MAKI_LOG=maki_lua=trace` to narrow it to one target. When a backtrace comes
+out useless, start maki with `--no-jit`: plugins then run on the interpreter,
+with full debug info.
 
 ## Conventions
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
-use std::sync::Mutex;
+use std::io::{self, Write};
+use std::sync::{Mutex, MutexGuard, PoisonError};
 
 use color_eyre::Result;
 use color_eyre::eyre::{Context, eyre};
@@ -10,6 +11,12 @@ use maki_storage::StateDir;
 use maki_storage::log::RotatingFileWriter;
 use maki_storage::model::read_model;
 use tracing_subscriber::EnvFilter;
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::fmt::MakeWriter;
+
+const LOG_ENV: &str = "MAKI_LOG";
+const LOG_ENV_SHARED: &str = "RUST_LOG";
+const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::INFO;
 
 const PROVIDER_PRIORITY: &[&str] = &[
     "anthropic",
@@ -153,17 +160,129 @@ pub fn report_session_start(start_type: &'static str, session_id: Option<impl Di
     maki_otel::emit::session_started(start_type, id.as_deref());
 }
 
+/// The writer every event goes through.
+///
+/// A bare `Mutex` would do, except `tracing_subscriber`'s blanket impl unwraps
+/// the poison, so a single panic raised while a line was being written turned
+/// every later log call into a panic of its own. Taking the guard back out of
+/// the poison keeps a wounded process writing its own post mortem.
+struct SharedWriter(Mutex<RotatingFileWriter>);
+
+struct SharedGuard<'a>(MutexGuard<'a, RotatingFileWriter>);
+
+impl Write for SharedGuard<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}
+
+impl<'a> MakeWriter<'a> for SharedWriter {
+    type Writer = SharedGuard<'a>;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        SharedGuard(self.0.lock().unwrap_or_else(PoisonError::into_inner))
+    }
+}
+
+/// `MAKI_LOG` is ours and is taken literally, `MAKI_LOG=off` included.
+///
+/// `RUST_LOG` belongs to every Rust program on the machine, and `EnvFilter`
+/// drops any target no directive names, so a `RUST_LOG=other_crate=debug` left
+/// in a shell profile for an unrelated project silenced maki entirely. We still
+/// read it, and a value that names a level decides ours, but a value that only
+/// lists other people's targets gets our level added underneath, so a foreign
+/// variable can add to our logs and never take them away.
+fn log_filter() -> EnvFilter {
+    let read = |name: &str| std::env::var(name).ok().filter(|v| !v.trim().is_empty());
+    build_log_filter(read(LOG_ENV).as_deref(), read(LOG_ENV_SHARED).as_deref())
+}
+
+/// Pure core of `log_filter`, so tests never have to set a process wide
+/// variable and race every other test in the binary.
+fn build_log_filter(ours: Option<&str>, shared: Option<&str>) -> EnvFilter {
+    for (name, value, is_ours) in [(LOG_ENV, ours, true), (LOG_ENV_SHARED, shared, false)] {
+        let Some(value) = value else {
+            continue;
+        };
+        match EnvFilter::builder().parse(value) {
+            Ok(filter) if is_ours || sets_a_level(value) => return filter,
+            Ok(filter) => return filter.add_directive(DEFAULT_LOG_LEVEL.into()),
+            Err(error) => eprintln!("maki: ignoring {name}={value:?}: {error}"),
+        }
+    }
+    EnvFilter::default().add_directive(DEFAULT_LOG_LEVEL.into())
+}
+
+/// Whether a filter string carries a bare level such as `debug`, as opposed to
+/// only per target directives like `foo=debug`.
+///
+/// Empty pieces are skipped here, as `EnvFilter` skips them too. `LevelFilter`
+/// reads an empty string as `error`, so the trailing comma in
+/// `RUST_LOG=other_crate=debug,` would look like a level and cost us the log.
+fn sets_a_level(value: &str) -> bool {
+    value
+        .split(',')
+        .map(str::trim)
+        .any(|part| !part.is_empty() && part.parse::<LevelFilter>().is_ok())
+}
+
+/// Logging is the first thing to set up and the last thing allowed to stop the
+/// program, but a failure here used to be swallowed whole, so an unwritable log
+/// dir looked exactly like an idle one: no logs, no reason, no clue.
 pub fn init_logging(storage_config: &maki_config::StorageConfig) {
-    let Ok(writer) =
-        RotatingFileWriter::new(storage_config.max_log_bytes, storage_config.max_log_files)
-    else {
-        return;
-    };
-    let writer = Mutex::new(writer);
-    let filter = EnvFilter::try_from_env("RUST_LOG").unwrap_or_else(|_| EnvFilter::new("info"));
+    let writer =
+        match RotatingFileWriter::new(storage_config.max_log_bytes, storage_config.max_log_files) {
+            Ok(writer) => writer,
+            Err(error) => {
+                eprintln!("maki: logging disabled, cannot open the log file: {error}");
+                return;
+            }
+        };
     tracing_subscriber::fmt()
         .json()
-        .with_env_filter(filter)
-        .with_writer(writer)
+        .with_env_filter(log_filter())
+        .with_writer(SharedWriter(Mutex::new(writer)))
         .init();
+}
+
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    use super::{DEFAULT_LOG_LEVEL, build_log_filter};
+
+    const FOREIGN: &str = "other_crate=debug";
+    const FOREIGN_EMPTY_PIECES: &str = ",other_crate=debug,,";
+    const BROKEN: &str = "not a directive=!!";
+
+    #[test_case(None, None, "info" ; "nothing_set_logs_at_info")]
+    #[test_case(Some("warn"), None, "warn" ; "our_variable_wins")]
+    #[test_case(Some("off"), None, "off" ; "our_variable_can_silence_us")]
+    #[test_case(Some("warn"), Some("trace"), "warn" ; "our_variable_beats_the_shared_one")]
+    #[test_case(None, Some("debug"), "debug" ; "shared_variable_with_a_level_is_taken_as_is")]
+    #[test_case(None, Some(FOREIGN), "info" ; "foreign_directive_cannot_silence_us")]
+    #[test_case(None, Some(FOREIGN_EMPTY_PIECES), "info" ; "empty_pieces_are_not_a_level")]
+    #[test_case(None, Some(BROKEN), "info" ; "unparsable_value_falls_back")]
+    fn log_filter_keeps_our_own_logs_alive(
+        ours: Option<&str>,
+        shared: Option<&str>,
+        expected: &str,
+    ) {
+        let rendered = build_log_filter(ours, shared).to_string();
+        assert!(
+            rendered.split(',').any(|d| d == expected),
+            "{ours:?} + {shared:?} rendered as {rendered:?}, wanted {expected:?}"
+        );
+    }
+
+    #[test]
+    fn foreign_directive_is_kept_alongside_our_level() {
+        let rendered = build_log_filter(None, Some(FOREIGN)).to_string();
+        assert!(rendered.contains(FOREIGN), "{FOREIGN} was dropped");
+        assert!(rendered.contains(&DEFAULT_LOG_LEVEL.to_string()));
+    }
 }


### PR DESCRIPTION
Every maki process kept its own handle on `maki.log` plus its own byte counter, and it only looked at that handle again once its own counter passed `max_log_bytes`, which for a quiet session meant never, so a busy peer could rename the handle down to `maki.9.log` and then delete it while the quiet one wrote on into an inode with no name, and the user saw logs that stopped one day and never came back until a restart.

The counter is gone and every write asks the open file instead, one `fstat` that reports the real size, which now counts what all the processes wrote rather than only ours, and whether the file still has a name, so a handle that was rotated away or deleted gets reopened on the next line, and the logs dir is recreated on the way for the people who clear their logs by deleting the whole folder.

Four smaller traps went with it: `max_files` is clamped because zero underflowed into four billion `exists` calls made under the rotation lock that every other process waits on, the writer no longer calls `tracing::warn` because it runs with the subscriber's lock held and would deadlock on itself, lowering `max_log_files` now prunes the files above the new ceiling instead of stranding them forever, and a rotation that cannot rename waits for another `max_bytes` before trying again rather than scanning the dir once per log line, which is what Windows does every time since it refuses to rename a file you hold open.

`init_logging` also stopped swallowing its error, so an unwritable log dir says so instead of looking like an idle one, and the filter reads `MAKI_LOG` before `RUST_LOG` because `EnvFilter` drops any target no directive names, which let a `RUST_LOG=other_crate=debug` left in a shell profile for an unrelated project silence maki completely.