### PR TITLE
feat(ui): pick a thinking level from a picker

### DIFF
--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -77,6 +77,7 @@ pub const DEFAULT_BUILTINS: &[&str] = &[
     "sessions",
     "skill",
     "task",
+    "thinking",
     "todo_write",
     "view_image",
     "webfetch",

--- a/maki-docgen/src/gen_commands.rs
+++ b/maki-docgen/src/gen_commands.rs
@@ -83,7 +83,7 @@ pub fn generate() -> String {
     .unwrap();
     writeln!(
         out,
-        "- **`/thinking`**: extended thinking. Optional arg: `off`, `adaptive`, an effort level (`minimal` … `max`), or a token budget number. Config: `always_thinking`."
+        "- **`/thinking`**: extended thinking. Bare, or `Alt+T`, it opens a picker of the effort levels with what each one costs in tokens; `Enter` applies the selected level and `Esc` closes without changing anything. With an argument it sets the level directly: `off`, `adaptive`, an effort level (`minimal` … `max`), or a token budget number. Config: `always_thinking`."
     )
     .unwrap();
     writeln!(

--- a/maki-docgen/src/gen_keybindings.rs
+++ b/maki-docgen/src/gen_keybindings.rs
@@ -12,11 +12,22 @@ const LUA_CONTEXT_BINDS: &[(&str, &str, &str)] = &[
     ("Session Picker", "`Ctrl+N`", "New session"),
     ("Session Picker", "`Ctrl+R`", "Rename session"),
     ("Session Picker", "`Ctrl+D`", "Delete session (press twice)"),
+    ("Thinking Picker", "`↑`/`↓`", "Move between effort levels"),
+    ("Thinking Picker", "`0`-`9`", "Type a token budget"),
+    ("Thinking Picker", "`Enter`", "Apply and close"),
+    (
+        "Thinking Picker",
+        "`Esc`",
+        "Close without changing anything",
+    ),
 ];
 
 // Built-in plugins own these globally, so they never reach `KEYBINDS`.
-const PLUGIN_BINDS: &[(&str, &str)] =
-    &[("`Ctrl+P`", "Browse sessions"), ("`Ctrl+X`", "Open tasks")];
+const PLUGIN_BINDS: &[(&str, &str)] = &[
+    ("`Ctrl+P`", "Browse sessions"),
+    ("`Ctrl+X`", "Open tasks"),
+    ("`Alt+T`", "Thinking effort"),
+];
 
 const MAIN_CONTEXTS: &[KeybindContext] = &[
     KeybindContext::General,

--- a/maki-lua/src/api/model.rs
+++ b/maki-lua/src/api/model.rs
@@ -25,11 +25,21 @@ async fn roundtrip(
 /// `thinking` comes back in the spelling `set` accepts, so a table from here
 /// can go straight back in.
 ///
-/// @return (table|nil, string|nil) `{spec, id, provider, thinking, fast,
-///   supports_thinking, supports_fast}`, or nil and an error.
+/// `thinking_options` is every thinking value this model accepts, cheapest
+/// first: `{name, tokens?}` per row, where `tokens` is the budget maki would
+/// send for that row and is absent on `off` and `adaptive`. It is empty exactly
+/// when `supports_thinking` is false, so a picker can render the ladder from it
+/// without knowing the levels.
+///
+/// @return (table|nil, string|nil) `{spec, id, provider, thinking,
+///   thinking_options, fast, supports_thinking, supports_fast}`, or nil and an
+///   error.
 /// @example
 /// local m = maki.model.get()
 /// if m.spec ~= "anthropic/claude-opus-4-6" then ... end
+/// for _, option in ipairs(m.thinking_options) do
+///   print(option.name, option.tokens)
+/// end
 #[lua_fn]
 async fn get(lua: Lua, #[ctx] tx: Option<flume::Sender<UiAction>>) -> LuaResult<Pair<Value>> {
     roundtrip(lua, tx, ModelRequest::Get).await

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -57,6 +57,10 @@ static BUNDLED_PLUGINS: &[BundledPlugin] = &[
         dir: include_dir!("$CARGO_MANIFEST_DIR/../plugins/sessions"),
     },
     BundledPlugin {
+        name: "thinking",
+        dir: include_dir!("$CARGO_MANIFEST_DIR/../plugins/thinking"),
+    },
+    BundledPlugin {
         name: "index",
         dir: include_dir!("$CARGO_MANIFEST_DIR/../plugins/index"),
     },

--- a/maki-lua/tests/spec.rs
+++ b/maki-lua/tests/spec.rs
@@ -13,6 +13,7 @@ use test_case::test_case;
 #[test_case("read", include_str!("../../plugins/read/tests/spec.lua") ; "read_plugin_spec")]
 #[test_case("skill", include_str!("../../plugins/skill/tests/spec.lua") ; "skill_plugin_spec")]
 #[test_case("task", include_str!("../../plugins/task/tests/spec.lua") ; "task_plugin_spec")]
+#[test_case("thinking", include_str!("../../plugins/thinking/tests/spec.lua") ; "thinking_plugin_spec")]
 #[test_case("view_image", include_str!("../../plugins/view_image/tests/spec.lua") ; "view_image_plugin_spec")]
 #[test_case("webfetch", include_str!("../../plugins/webfetch/tests/spec.lua") ; "webfetch_plugin_spec")]
 #[test_case("websearch", include_str!("../../plugins/websearch/tests/spec.lua") ; "websearch_plugin_spec")]

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -12,7 +12,7 @@ pub use error::AgentError;
 pub use maki_storage::sessions::add_cost;
 pub use model::{
     FastPricing, Model, ModelEntry, ModelError, ModelFamily, ModelInfo, ModelPricing, ModelTier,
-    ThinkingSupport, TokenUsage, format_tokens,
+    ThinkingOption, ThinkingSupport, TokenUsage, format_tokens,
 };
 pub use pricing::{model_cost, settle_session};
 pub use providers::Timeouts;

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -11,14 +11,14 @@ use std::sync::Arc;
 
 use jiff::Timestamp;
 use maki_config::ModelPolicy;
-use maki_storage::sessions::{MIN_THINKING_BUDGET, StoredTokenUsage};
+use maki_storage::sessions::{Effort, MIN_THINKING_BUDGET, StoredTokenUsage};
 use serde::{Deserialize, Serialize};
 
 use crate::manifest::{ManifestRegistry, ProviderManifest};
 use crate::model_registry;
 use crate::providers::catalog::{self, CatalogMeta};
 use crate::providers::{anthropic, custom, dynamic};
-use crate::types::ThinkingFields;
+use crate::types::{FALLBACK_MAX_THINKING_BUDGET, THINKING_ADAPTIVE, THINKING_OFF, ThinkingFields};
 
 const PER_MILLION: f64 = 1_000_000.0;
 
@@ -314,6 +314,18 @@ impl ThinkingSupport {
     }
 }
 
+/// One row of the thinking ladder: a value this model accepts, and what it
+/// costs here. Frontends render the ladder from this instead of keeping their
+/// own copy of the levels.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct ThinkingOption {
+    pub name: &'static str,
+    /// The budget maki would send for this row, already floored and capped.
+    /// Absent on rows that are not a token budget.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tokens: Option<u32>,
+}
+
 #[derive(Debug, Clone)]
 pub struct Model {
     pub id: String,
@@ -463,6 +475,29 @@ impl Model {
     pub fn max_thinking_budget(&self) -> Option<u32> {
         self.max_output_tokens
             .map(|n| (n / 2).max(MIN_THINKING_BUDGET))
+    }
+
+    /// Every thinking value this model accepts, cheapest first, with the budget
+    /// each effort level resolves to here. Empty exactly when the model has no
+    /// thinking support, so an empty list is the one check a caller needs
+    /// before offering the ladder.
+    pub fn thinking_options(&self) -> Vec<ThinkingOption> {
+        if !self.supports_thinking() {
+            return Vec::new();
+        }
+        let max = self
+            .max_thinking_budget()
+            .unwrap_or(FALLBACK_MAX_THINKING_BUDGET);
+        (!self.requires_thinking())
+            .then_some(THINKING_OFF)
+            .into_iter()
+            .chain([THINKING_ADAPTIVE])
+            .map(|name| ThinkingOption { name, tokens: None })
+            .chain(Effort::ALL.map(|level| ThinkingOption {
+                name: level.as_str(),
+                tokens: Some(level.budget(max)),
+            }))
+            .collect()
     }
 
     /// A model supports fast mode exactly when it carries fast-tier pricing, so
@@ -1396,5 +1431,64 @@ mod tests {
             }
         );
         assert_eq!(COUNTERS.billed(None).cost, None);
+    }
+
+    /// Twice [`FALLBACK_MAX_THINKING_BUDGET`], so a declared window and a
+    /// missing one land on the same ceiling.
+    const ROOMY_OUTPUT: u32 = 65_536;
+    /// Halves to 1024, the floor, so every level collapses onto it.
+    const TINY_OUTPUT: u32 = 2_048;
+    /// 10% to 100% of 32k.
+    const CEILING_BUDGETS: [u32; 6] = [3_276, 6_553, 13_107, 19_660, 26_214, 32_768];
+    const LADDER: [&str; 8] = [
+        "off", "adaptive", "minimal", "low", "medium", "high", "xhigh", "max",
+    ];
+
+    fn ladder_model(support: ThinkingSupport, max_output_tokens: Option<u32>) -> Model {
+        Model {
+            id: "test-model".into(),
+            provider: Arc::from("anthropic"),
+            tier: ModelTier::Medium,
+            family: ModelFamily::Claude,
+            supports_tool_examples_override: None,
+            thinking_override: Some(support),
+            supports_vision_override: None,
+            pricing: ModelPricing::default(),
+            discovered_free: false,
+            max_output_tokens,
+            context_window: 200_000,
+            thinking_fields: None,
+        }
+    }
+
+    /// The Lua picker draws its rows straight from this list, so the shape is
+    /// the contract: no thinking means no rows, and a model that refuses to
+    /// turn thinking off never offers `off`.
+    #[test_case(ThinkingSupport::No, &[] ; "no_support_no_rows")]
+    #[test_case(ThinkingSupport::Yes, &LADDER ; "the_whole_ladder")]
+    #[test_case(ThinkingSupport::Required, &LADDER[1..] ; "required_thinking_drops_off")]
+    fn thinking_options_list_what_the_model_accepts(support: ThinkingSupport, expected: &[&str]) {
+        let options = ladder_model(support, Some(ROOMY_OUTPUT)).thinking_options();
+        let names: Vec<&str> = options.iter().map(|option| option.name).collect();
+        assert_eq!(names, expected);
+    }
+
+    /// The numbers are [`Effort::budget`]'s, so what this pins is which ceiling
+    /// the ladder hands it: the declared window, the fallback when there is
+    /// none, and the floor when the window is too small to split.
+    #[test_case(Some(ROOMY_OUTPUT), CEILING_BUDGETS ; "declared_ceiling")]
+    #[test_case(None, CEILING_BUDGETS ; "missing_ceiling_falls_back")]
+    #[test_case(Some(TINY_OUTPUT), [MIN_THINKING_BUDGET; 6] ; "tiny_ceiling_collapses_onto_the_floor")]
+    fn thinking_options_resolve_budgets_against_the_ceiling(
+        max_output_tokens: Option<u32>,
+        levels: [u32; 6],
+    ) {
+        let tokens: Vec<Option<u32>> = ladder_model(ThinkingSupport::Yes, max_output_tokens)
+            .thinking_options()
+            .into_iter()
+            .map(|option| option.tokens)
+            .collect();
+        let expected: Vec<Option<u32>> = [None, None].into_iter().chain(levels.map(Some)).collect();
+        assert_eq!(tokens, expected);
     }
 }

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -23,6 +23,12 @@ use crate::model::Model;
 
 const LOCAL_BUDGET_FIELD: &str = "thinking_budget_tokens";
 
+/// The two thinking modes that are neither an effort level nor a token count.
+/// `Display` and [`Model::thinking_options`] both spell them from here, so the
+/// picker offers exactly the strings the parser accepts.
+pub(crate) const THINKING_OFF: &str = "off";
+pub(crate) const THINKING_ADAPTIVE: &str = "adaptive";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ImageMediaType {
     Png,
@@ -418,7 +424,7 @@ pub const THINKING_USAGE: &str =
 /// Effort levels are percentages, so they need a ceiling even when the model
 /// never told us its output window. 32k matches common frontier thinking
 /// caps. Explicit user budgets never go through this.
-const FALLBACK_MAX_THINKING_BUDGET: u32 = 32_768;
+pub(crate) const FALLBACK_MAX_THINKING_BUDGET: u32 = 32_768;
 
 /// First Claude version that speaks adaptive thinking. Opus got there a
 /// generation early, at 4.7; the other families joined at 5.
@@ -776,12 +782,28 @@ impl ThinkingConfig {
         }
     }
 
+    /// The status bar already wraps this in brackets, so a level just names
+    /// itself. A raw count keeps its unit, or it reads like any other number
+    /// up there.
+    /// What the model will really run, so stored state can never disagree with
+    /// the request. Clamps both ways: down to `Off` where thinking is
+    /// unsupported, up to minimal effort where it is mandatory.
+    pub fn clamped(self, model: &Model) -> Self {
+        if !model.supports_thinking() {
+            return Self::Off;
+        }
+        if model.requires_thinking() && !self.is_enabled() {
+            return Self::Effort(Effort::Minimal);
+        }
+        self
+    }
+
     pub fn status_label(self) -> Option<Cow<'static, str>> {
         match self {
             Self::Off => None,
-            Self::Adaptive => Some(Cow::Borrowed("thinking")),
-            Self::Effort(e) => Some(Cow::Owned(format!("thinking: {e}"))),
-            Self::Budget(n) => Some(Cow::Owned(format!("thinking: {n}"))),
+            Self::Adaptive => Some(Cow::Borrowed(THINKING_ADAPTIVE)),
+            Self::Effort(e) => Some(Cow::Borrowed(e.as_str())),
+            Self::Budget(n) => Some(Cow::Owned(format!("{n} tokens"))),
         }
     }
 }
@@ -789,8 +811,8 @@ impl ThinkingConfig {
 impl std::fmt::Display for ThinkingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Off => f.write_str("off"),
-            Self::Adaptive => f.write_str("adaptive"),
+            Self::Off => f.write_str(THINKING_OFF),
+            Self::Adaptive => f.write_str(THINKING_ADAPTIVE),
             Self::Effort(e) => f.write_str(e.as_str()),
             Self::Budget(n) => write!(f, "{n}"),
         }
@@ -838,17 +860,10 @@ pub struct RequestOptions {
 impl RequestOptions {
     /// Reconciles options with the model's capabilities. Called once before
     /// every request so UI state, restored sessions, and subagent flags all go
-    /// through the same gate. Despite the name, thinking clamps both ways:
-    /// down to `Off` when unsupported, up to minimal effort when required.
-    pub fn clamped(self, model: &crate::model::Model) -> Self {
+    /// through the same gate.
+    pub fn clamped(self, model: &Model) -> Self {
         Self {
-            thinking: if !model.supports_thinking() {
-                ThinkingConfig::Off
-            } else if model.requires_thinking() && !self.thinking.is_enabled() {
-                ThinkingConfig::Effort(Effort::Minimal)
-            } else {
-                self.thinking
-            },
+            thinking: self.thinking.clamped(model),
             fast: self.fast && model.supports_fast(),
         }
     }
@@ -1186,6 +1201,16 @@ mod tests {
             Some(e) => assert_eq!(body["reasoning_effort"], e),
             None => assert!(body.get("reasoning_effort").is_none()),
         }
+    }
+
+    /// The badge reads as whatever the session is set to, and stays quiet when
+    /// thinking is off.
+    #[test_case(ThinkingConfig::Off, None ; "off_shows_no_badge")]
+    #[test_case(ThinkingConfig::Adaptive, Some("adaptive") ; "adaptive")]
+    #[test_case(ThinkingConfig::Effort(High), Some("high") ; "effort_names_the_level")]
+    #[test_case(ThinkingConfig::Budget(8192), Some("8192 tokens") ; "budget_keeps_its_unit")]
+    fn thinking_status_label(config: ThinkingConfig, expected: Option<&str>) {
+        assert_eq!(config.status_label().as_deref(), expected);
     }
 
     #[test_case(ThinkingConfig::Off,             Some(4096), Budgeted::Off            ; "off")]

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -410,14 +410,18 @@ impl App {
         );
     }
 
-    /// Takes the spelling both `/thinking` and `maki.model.set` accept; a
-    /// blank {input} toggles.
+    /// Takes the spelling `maki.model.set` accepts, which is what the
+    /// `/thinking` plugin passes through. A blank {input} toggles.
+    ///
+    /// Stores the clamped value rather than the typed one, so the status bar
+    /// can never read `off` on a model that is really sending minimal effort.
     pub(crate) fn set_thinking(&mut self, input: &str) -> Result<ThinkingConfig, String> {
         if !self.state.model.supports_thinking() {
             return Err(THINKING_UNSUPPORTED_MSG.into());
         }
-        self.state.thinking =
-            ThinkingConfig::parse(input.trim(), self.state.thinking).map_err(str::to_owned)?;
+        self.state.thinking = ThinkingConfig::parse(input.trim(), self.state.thinking)
+            .map_err(str::to_owned)?
+            .clamped(&self.state.model);
         Ok(self.state.thinking)
     }
 
@@ -437,6 +441,7 @@ impl App {
             "id": model.id,
             "provider": model.provider.to_string(),
             "thinking": self.state.thinking.to_string(),
+            "thinking_options": model.thinking_options(),
             "fast": self.state.fast,
             "supports_thinking": model.supports_thinking(),
             "supports_fast": model.supports_fast(),
@@ -1422,13 +1427,6 @@ impl App {
                     "YOLO mode disabled"
                 };
                 self.flash(msg.into());
-                vec![]
-            }
-            "/thinking" => {
-                match self.set_thinking(&cmd.args) {
-                    Ok(thinking) => self.flash(format!("Thinking: {thinking}")),
-                    Err(msg) => self.flash(msg),
-                }
                 vec![]
             }
             "/fast" => {

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -56,6 +56,7 @@ const RESUMED_PROMPT: &str = "carry me over";
 const SONNET_SPEC: &str = "anthropic/claude-sonnet-4-5";
 const OPUS_SPEC: &str = "anthropic/claude-opus-4-8";
 const PLAIN_MODEL_SPEC: &str = "ollama/qwen3";
+const THINKING_OPTIONS: &str = "thinking_options";
 const MODEL_CHANGED_EVENT: &str = "ModelChanged";
 const PLAN_READY_EVENT: &str = "PlanReady";
 const PLAN_DRAFT_PATH: &str = "/tmp/plan.md";
@@ -4225,53 +4226,6 @@ fn bash_prefix_overrides_mode() {
 }
 
 #[test]
-fn thinking_toggle_cycles_off_adaptive() {
-    let mut app = test_app();
-    assert_eq!(app.state.thinking, ThinkingConfig::Off);
-
-    app.execute_command(cmd("/thinking"), 0);
-    assert_eq!(app.state.thinking, ThinkingConfig::Adaptive);
-
-    app.execute_command(cmd("/thinking"), 0);
-    assert_eq!(app.state.thinking, ThinkingConfig::Off);
-}
-
-#[test]
-fn thinking_explicit_args() {
-    let mut app = test_app();
-
-    app.execute_command(
-        ParsedCommand {
-            name: "/thinking".into(),
-            args: "8192".into(),
-            bang: false,
-        },
-        0,
-    );
-    assert_eq!(app.state.thinking, ThinkingConfig::Budget(8192));
-
-    app.execute_command(
-        ParsedCommand {
-            name: "/thinking".into(),
-            args: "high".into(),
-            bang: false,
-        },
-        0,
-    );
-    assert_eq!(app.state.thinking, ThinkingConfig::Effort(Effort::High));
-}
-
-#[test]
-fn thinking_unsupported_model_flashes_error() {
-    let mut app = test_app();
-    app.state.model.thinking_override = Some(maki_providers::ThinkingSupport::No);
-
-    app.execute_command(cmd("/thinking"), 0);
-    assert_eq!(app.state.thinking, ThinkingConfig::Off);
-    assert_eq!(app.status_bar.flash_text(), Some(THINKING_UNSUPPORTED_MSG));
-}
-
-#[test]
 fn package_commands_are_user_only_and_preserve_update_bang() {
     let mut app = test_app();
     let typed = || ParsedCommand {
@@ -4488,7 +4442,7 @@ fn model_state_reports_the_model_and_what_it_supports() {
     let mut app = test_app();
     app.state.model = maki_providers::Model::from_spec(PLAIN_MODEL_SPEC).unwrap();
     assert_eq!(
-        app.model_state(),
+        model_state_scalars(&app),
         serde_json::json!({
             "spec": PLAIN_MODEL_SPEC,
             "id": "qwen3",
@@ -4504,7 +4458,7 @@ fn model_state_reports_the_model_and_what_it_supports() {
     app.set_thinking("high").unwrap();
     app.set_fast(true).unwrap();
     assert_eq!(
-        app.model_state(),
+        model_state_scalars(&app),
         serde_json::json!({
             "spec": OPUS_SPEC,
             "id": "claude-opus-4-8",
@@ -4515,6 +4469,53 @@ fn model_state_reports_the_model_and_what_it_supports() {
             "supports_fast": true,
         })
     );
+}
+
+/// The ladder moves with the model table, so it gets its own test and the
+/// pinned payloads stay on the fields that do not.
+fn model_state_scalars(app: &App) -> serde_json::Value {
+    let mut state = app.model_state();
+    state
+        .as_object_mut()
+        .expect("model_state is an object")
+        .remove(THINKING_OPTIONS);
+    state
+}
+
+/// The `/thinking` picker draws its rows from this payload alone, so the state
+/// has to carry the ladder, named rows with their budgets, and an empty one
+/// where there is nothing to pick from. Which rows there are is
+/// `Model::thinking_options`'s business.
+#[test]
+fn model_state_carries_the_thinking_ladder() {
+    let mut app = test_app();
+    set_opus_model(&mut app);
+
+    let ladder = app.model_state()[THINKING_OPTIONS].clone();
+    assert_eq!(ladder[0]["name"], "off");
+    assert!(
+        ladder
+            .as_array()
+            .expect("the ladder is an array")
+            .iter()
+            .any(|option| option["tokens"].is_u64()),
+        "an effort row carries what it costs: {ladder}"
+    );
+
+    app.state.model = maki_providers::Model::from_spec(PLAIN_MODEL_SPEC).unwrap();
+    assert_eq!(app.model_state()[THINKING_OPTIONS], serde_json::json!([]));
+}
+
+/// `Off` is not a state a model that requires thinking can be in, so storing it
+/// would report one level while the request sent another.
+#[test]
+fn set_thinking_clamps_to_what_the_model_will_run() {
+    let mut app = test_app();
+    app.state.model.thinking_override = Some(maki_providers::ThinkingSupport::Required);
+
+    let lifted = ThinkingConfig::Effort(Effort::Minimal);
+    assert_eq!(app.set_thinking("off").unwrap(), lifted);
+    assert_eq!(app.state.thinking, lifted);
 }
 
 /// A plugin redraws its badge from the payload alone, and only when the model

--- a/maki-ui/src/components/command.rs
+++ b/maki-ui/src/components/command.rs
@@ -100,12 +100,6 @@ pub const BUILTIN_COMMANDS: &[BuiltinCommand] = &[
         bang: false,
     },
     BuiltinCommand {
-        name: "/thinking",
-        description: "Toggle extended thinking (off, adaptive, effort level, or budget)",
-        max_args: 1,
-        bang: false,
-    },
-    BuiltinCommand {
         name: "/fast",
         description: "Toggle Anthropic fast mode (Opus only)",
         max_args: 0,

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -1225,8 +1225,8 @@ impl<'t> EventLoop<'t> {
         }
     }
 
-    /// Lua acts on the focused session, the same target the model picker and
-    /// `/thinking` write to.
+    /// Lua acts on the focused session, the same target the model picker
+    /// writes to.
     fn handle_model_request(&mut self, req: ModelRequest) -> UiReply {
         match req {
             ModelRequest::Get => Ok(self.focused_app().model_state()),

--- a/maki-ui/src/theme.rs
+++ b/maki-ui/src/theme.rs
@@ -367,6 +367,7 @@ pub fn style_by_name(name: &str) -> Style {
         "tool_error" => t.tool_error,
         "tool_annotation" => t.tool_annotation,
         "spinner" => t.spinner,
+        "thinking" => t.thinking,
         "error" => t.error,
         "bold" => t.bold,
         "italic" => t.italic,
@@ -1368,6 +1369,7 @@ diff_new_line_nr = { fg = "red" }
         assert_eq!(style_by_name("warning"), t.todo_in_progress);
         assert_eq!(style_by_name("match"), t.item_match);
         assert_eq!(style_by_name("match_selected"), t.item_match_selected);
+        assert_eq!(style_by_name("thinking"), t.thinking);
     }
 
     #[test_case("nonexistent_style")]

--- a/plugins/thinking/init.lua
+++ b/plugins/thinking/init.lua
@@ -1,0 +1,19 @@
+-- /thinking: a picker over the ladder the host reports, and the direct form
+-- `/thinking <level>` that sets a value without opening anything.
+
+local Window = require("thinking_window")
+
+maki.api.register_command({
+  name = "/thinking",
+  description = "Extended thinking: pick an effort level, or set one directly",
+  nargs = "?",
+  handler = function(opts)
+    if opts.args == "" then
+      Window.open()
+    else
+      Window.set(opts.args)
+    end
+  end,
+})
+
+maki.keymap.set("n", "<M-t>", Window.open, { desc = "Thinking effort" })

--- a/plugins/thinking/plugin.toml
+++ b/plugins/thinking/plugin.toml
@@ -1,0 +1,1 @@
+[permissions]

--- a/plugins/thinking/tests/spec.lua
+++ b/plugins/thinking/tests/spec.lua
@@ -1,0 +1,322 @@
+local Picker = require("thinking_picker")
+local Window = require("thinking_window")
+local th = require("maki.test_helpers")
+
+local case = th.case
+local eq = th.eq
+
+local MODEL_ID = "claude-opus-5"
+local WIDE = 52
+local NARROW = 30
+local MEDIUM = "medium"
+local RAW_BUDGET = "8192"
+local REJECTED = "Usage: /thinking [off|adaptive|minimal|low|medium|high|xhigh|max|<budget>]"
+local UNSUPPORTED = "Thinking requires a model that supports it"
+local CUSTOM_ROW_NAME = "custom…"
+local BOOM = "the event loop blew up"
+-- Shaped like the host's ladder: two modes, then six levels at 10% to 100% of
+-- a 32k ceiling.
+local LADDER = {
+  { name = "off" },
+  { name = "adaptive" },
+  { name = "minimal", tokens = 3276 },
+  { name = "low", tokens = 6553 },
+  { name = "medium", tokens = 13107 },
+  { name = "high", tokens = 19660 },
+  { name = "xhigh", tokens = 26214 },
+  { name = "max", tokens = 32768 },
+}
+-- A model whose output window is so small that every level clamps onto the
+-- floor, so no gauge may claim one level buys more than another.
+local CLAMPED_LADDER = {
+  { name = "off" },
+  { name = "adaptive" },
+  { name = "minimal", tokens = 1024 },
+  { name = "low", tokens = 1024 },
+  { name = "max", tokens = 1024 },
+}
+
+local function model_with(thinking, options)
+  return {
+    id = MODEL_ID,
+    thinking = thinking,
+    thinking_options = options or LADDER,
+  }
+end
+
+local function picker_on(thinking, options)
+  return Picker.new(model_with(thinking, options))
+end
+
+local function dispw(s)
+  return utf8.len(s) or #s
+end
+
+local function line_text(line)
+  local parts = {}
+  for _, span in ipairs(line) do
+    parts[#parts + 1] = span[1]
+  end
+  return table.concat(parts)
+end
+
+-- The filled half of a gauge is its own span, the third one on a level row.
+local function gauge_cells(state, lines, name)
+  for i, row in ipairs(state.rows) do
+    if row.option and row.option.name == name then
+      return dispw(lines[i][3][1])
+    end
+  end
+  error("no row named " .. name)
+end
+
+local function level_lines(state, lines)
+  local out = {}
+  for i, row in ipairs(state.rows) do
+    if row.option and row.option.tokens then
+      out[#out + 1] = lines[i]
+    end
+  end
+  return out
+end
+
+-- Feeds keys and reports what came out: the value a commit would send, or the
+-- action that ended the picker. That pair is the whole contract with the
+-- window.
+local function press(state, keys)
+  for _, key in ipairs(keys) do
+    local action = Picker.handle_key(state, key)
+    if action then
+      return action == "commit" and Picker.value(state) or action
+    end
+  end
+  return Picker.value(state)
+end
+
+case("the_picker_opens_on_the_row_the_session_runs", function()
+  eq(press(picker_on(MEDIUM), { "enter" }), MEDIUM)
+end)
+
+-- The one fallback: a value no row names is a raw token budget.
+case("a_raw_budget_opens_the_custom_row_pre_filled", function()
+  local state = picker_on(RAW_BUDGET)
+  eq(state.cursor, state.custom_row)
+  th.has(line_text(Picker.render(state, WIDE)[state.custom_row]), RAW_BUDGET .. " tokens")
+  eq(press(state, { "enter" }), RAW_BUDGET)
+end)
+
+case("keys_pick_a_value_or_dismiss_the_picker", function()
+  eq(press(picker_on(MEDIUM), { "down", "down", "enter" }), "xhigh")
+  eq(press(picker_on(MEDIUM), { "up", "enter" }), "low")
+  eq(press(picker_on(MEDIUM), { "esc" }), "cancel")
+  eq(press(picker_on(MEDIUM), { "8", "1", "9", "2", "enter" }), "8192")
+  eq(press(picker_on(MEDIUM), { "4", "0", "9", "6", "backspace", "enter" }), "409")
+  eq(press(picker_on(MEDIUM), { "4", "esc", "enter" }), "4", "esc leaves the editor, not the picker")
+end)
+
+case("the_cursor_walks_over_blank_rows_and_stops_at_the_ends", function()
+  local walked = {}
+  local state = picker_on("off")
+  eq(press(state, { "up" }), "off", "nothing above the first row")
+  for _ = 1, #LADDER + 1 do
+    Picker.handle_key(state, "down")
+    walked[#walked + 1] = Picker.value(state)
+  end
+  -- The last step falls off the end of the list and stays on the custom row,
+  -- which reports what is typed there: nothing yet.
+  eq(table.concat(walked, ","), "adaptive,minimal,low,medium,high,xhigh,max,,")
+end)
+
+case("a_click_selects_a_row_and_ignores_the_rest", function()
+  local state = picker_on(MEDIUM)
+  local blank_row, off_row = 1, 2
+  Picker.click(state, blank_row)
+  eq(Picker.value(state), MEDIUM, "a blank row is not selectable")
+  Picker.click(state, #state.rows + 1)
+  eq(Picker.value(state), MEDIUM, "a row past the end is not a row")
+  Picker.click(state, off_row)
+  eq(Picker.value(state), "off")
+end)
+
+case("gauges_are_proportional_to_what_a_level_actually_costs", function()
+  local state = picker_on(MEDIUM)
+  local lines = Picker.render(state, WIDE)
+  local previous = 0
+  for _, option in ipairs(LADDER) do
+    if option.tokens then
+      local cells = gauge_cells(state, lines, option.name)
+      eq(cells > previous, true, option.name .. " must draw a longer gauge than the level below")
+      previous = cells
+    end
+  end
+
+  local clamped = picker_on(MEDIUM, CLAMPED_LADDER)
+  local clamped_lines = Picker.render(clamped, WIDE)
+  eq(
+    gauge_cells(clamped, clamped_lines, "minimal"),
+    gauge_cells(clamped, clamped_lines, "max"),
+    "levels that resolve to the same budget must draw the same gauge"
+  )
+end)
+
+case("token_counts_stay_aligned_and_the_gauge_is_what_a_narrow_window_drops", function()
+  local state = picker_on(MEDIUM)
+  for _, width in ipairs({ WIDE, NARROW }) do
+    local lines = Picker.render(state, width)
+    for _, line in ipairs(lines) do
+      eq(dispw(line_text(line)) <= width, true, "no row may run past a window " .. width .. " wide")
+    end
+    local rows = level_lines(state, lines)
+    for _, line in ipairs(rows) do
+      eq(dispw(line_text(line)), dispw(line_text(rows[1])), "every level ends in the same column at width " .. width)
+    end
+  end
+  eq(#level_lines(state, Picker.render(state, WIDE))[1], 5, "a wide level carries a filled span and a rail")
+  eq(#level_lines(state, Picker.render(state, NARROW))[1], 3, "a narrow one drops both")
+end)
+
+-- Proof that the ladder lives in Rust: a level this plugin has never heard of
+-- is navigable and drawn like any other.
+case("an_option_the_plugin_never_heard_of_renders_as_a_normal_row", function()
+  local extended = {}
+  for i, option in ipairs(LADDER) do
+    extended[i] = option
+  end
+  extended[#extended + 1] = { name = "ultra", tokens = 65536 }
+  local state = picker_on("max", extended)
+
+  eq(press(state, { "down", "enter" }), "ultra")
+  local lines = Picker.render(state, WIDE)
+  th.has(line_text(lines[state.cursor]), "ultra")
+  th.has(line_text(lines[state.cursor]), "65.5k")
+  eq(gauge_cells(state, lines, "ultra") > gauge_cells(state, lines, "max"), true)
+end)
+
+case("the_custom_row_is_named_for_what_it_does", function()
+  local state = picker_on(MEDIUM)
+  th.has(line_text(Picker.render(state, WIDE)[state.custom_row]), CUSTOM_ROW_NAME)
+end)
+
+-- The stubbed half: the window against a scripted event list. Each case is one
+-- way a picker can end, and asserts on what the host was asked to set.
+local function key(name)
+  return { type = "key", key = name }
+end
+
+local CLOSE = { type = "close" }
+
+local function run(events, opts)
+  opts = opts or {}
+  local saved = { model = maki.model, ui = maki.ui }
+  local sets, flashes, closed = {}, {}, false
+  local index = 0
+
+  local win = {
+    recv = function()
+      index = index + 1
+      local ev = events[index]
+      if ev == "raise" then
+        error(BOOM)
+      end
+      return ev
+    end,
+    set_cursor = function() end,
+    close = function()
+      closed = true
+    end,
+  }
+
+  maki.model = {
+    get = function()
+      return model_with(opts.thinking or MEDIUM, opts.options)
+    end,
+    set = function(args)
+      sets[#sets + 1] = args.thinking
+      if opts.reject then
+        return nil, REJECTED
+      end
+      return { thinking = args.thinking }
+    end,
+  }
+  maki.ui = {
+    buf = function()
+      return {
+        set_lines = function() end,
+        on = function() end,
+      }
+    end,
+    open_win = function()
+      return win
+    end,
+    flash = function(msg)
+      flashes[#flashes + 1] = msg
+    end,
+    display_width = dispw,
+    truncate_text = function(text)
+      return { head = text }
+    end,
+    terminal_size = function()
+      return { cols = 120, rows = 40 }
+    end,
+  }
+
+  local ok, err = pcall(opts.direct and Window.set or Window.open, opts.direct)
+  maki.model, maki.ui = saved.model, saved.ui
+  return {
+    sets = table.concat(sets, ","),
+    flashes = table.concat(flashes, ","),
+    closed = closed,
+    err = not ok and tostring(err) or nil,
+  }
+end
+
+case("enter_sends_the_picked_value_once_and_says_so", function()
+  local result = run({ key("down"), key("down"), key("enter") })
+  eq(result.sets, "xhigh")
+  eq(result.flashes, "Thinking: xhigh")
+  eq(result.closed, true)
+end)
+
+-- Nothing reaches the host until Enter, so there is never a value to undo.
+case("a_dismissed_picker_sends_nothing", function()
+  for name, events in pairs({
+    esc = { key("down"), key("esc") },
+    ["external close"] = { key("down"), CLOSE },
+    ["dead channel"] = { key("down") },
+  }) do
+    local result = run(events)
+    eq(result.sets, "", name)
+    eq(result.closed, true, name)
+  end
+end)
+
+-- A crash inside the loop still closes the window, and it is loud: a picker
+-- that silently swallowed the error would leave the guard set and /thinking
+-- dead for the rest of the run.
+case("a_crash_closes_the_window_and_is_reported", function()
+  local result = run({ "raise" })
+  eq(result.sets, "")
+  eq(result.closed, true)
+  th.has(result.err or "", BOOM)
+  eq(run({ key("enter") }).sets, MEDIUM, "the window reopens after a crash")
+end)
+
+case("a_refused_value_flashes_what_the_host_answered", function()
+  eq(run({ key("enter") }, { reject = true }).flashes, REJECTED)
+  eq(run({}, { direct = "nonsense", reject = true }).flashes, REJECTED)
+end)
+
+case("the_direct_form_skips_the_picker", function()
+  local result = run({}, { direct = "high" })
+  eq(result.sets, "high")
+  eq(result.flashes, "Thinking: high")
+  eq(result.closed, false, "nothing was opened")
+end)
+
+case("a_model_without_thinking_gets_the_flash_instead_of_a_picker", function()
+  local result = run({}, { options = {} })
+  eq(result.flashes, UNSUPPORTED)
+  eq(result.sets, "")
+end)
+
+th.report()

--- a/plugins/thinking/thinking_picker.lua
+++ b/plugins/thinking/thinking_picker.lua
@@ -1,0 +1,261 @@
+-- State and rendering for the /thinking picker: a radio list of the ladder
+-- `maki.model.get()` reported, where each effort level draws a gauge of what it
+-- costs next to the priciest one. The rows, their order and their budgets all
+-- come from Rust, so a level added there shows up here untouched.
+--
+-- Nothing in this file calls `maki.*`. It takes a model table in and answers
+-- with lines and an action, which is what lets the spec drive it with plain
+-- tables. `thinking_window.lua` owns the window and the round-trips.
+--
+-- Module names are shared across bundled plugins, hence the prefix: a plain
+-- `picker` would collide with the one the task plugin ships.
+
+local M = {}
+
+local PICKED = "● "
+local UNPICKED = "○ "
+local INDENT = "  "
+local NAME_GAP = 3
+local VALUE_GAP = 2
+local RIGHT_PAD = 2
+-- Under this many cells a gauge cannot show a proportion honestly, so it goes.
+local MIN_TRACK = 8
+local CUSTOM_NAME = "custom…"
+local CUSTOM_HINT = "type a budget"
+local TOKENS_LABEL = " tokens"
+local CARET = "▏"
+local MAX_DIGITS = 7
+local FILL = "━"
+local RAIL = "┄"
+local THOUSAND = 1000
+local DIGIT = "^%d$"
+-- Rows without a budget fill the wide column with this. A mode we have never
+-- heard of gets nothing rather than invented prose.
+local MODE_NOTES = { off = "no reasoning", adaptive = "model decides" }
+
+local STYLE_NAME = "item"
+local STYLE_NAME_PICKED = "bold"
+local STYLE_DIM = "dim"
+local STYLE_PICKED = "accent"
+local STYLE_GAUGE = "thinking"
+
+local function width_of(s)
+  return utf8.len(s) or #s
+end
+
+local function pad_right(s, width)
+  return s .. string.rep(" ", math.max(width - width_of(s), 0))
+end
+
+local function pad_left(s, width)
+  return string.rep(" ", math.max(width - width_of(s), 0)) .. s
+end
+
+-- Notes are prose, so a window too narrow for one cuts it rather than letting
+-- the row run past the border.
+local function clip(s, width)
+  if width_of(s) <= width then
+    return s
+  end
+  return s:sub(1, math.max(width, 0))
+end
+
+local function token_label(tokens)
+  if tokens < THOUSAND then
+    return tostring(tokens)
+  end
+  return string.format("%.1fk", tokens / THOUSAND)
+end
+
+-- A row is an option, the custom one, or a blank spacer. Options that carry a
+-- budget are the effort scale and the rest are modes, so the blank line keeps
+-- dividing the two however the ladder changes.
+local function build_rows(options)
+  local modes, levels = {}, {}
+  for _, option in ipairs(options) do
+    local group = option.tokens and levels or modes
+    group[#group + 1] = { option = option }
+  end
+  local rows = { {} }
+  for _, group in ipairs({ modes, levels }) do
+    for _, row in ipairs(group) do
+      rows[#rows + 1] = row
+    end
+    rows[#rows + 1] = {}
+  end
+  rows[#rows + 1] = { custom = true }
+  rows[#rows + 1] = {}
+  return rows
+end
+
+local function selectable(row)
+  return row.option ~= nil or row.custom == true
+end
+
+local function row_name(row)
+  if row.option then
+    return row.option.name
+  end
+  return row.custom and CUSTOM_NAME or ""
+end
+
+-- {model} is a `maki.model.get()` table. The cursor opens on the row named by
+-- the value the session runs. A value no row names is a raw token budget, so
+-- the custom row takes it, pre-filled.
+function M.new(model)
+  local rows = build_rows(model.thinking_options)
+  local state = { rows = rows, custom = "", editing = false, max_tokens = 0 }
+  for i, row in ipairs(rows) do
+    if row.custom then
+      state.custom_row = i
+    elseif row.option then
+      state.max_tokens = math.max(state.max_tokens, row.option.tokens or 0)
+      if row.option.name == model.thinking then
+        state.cursor = i
+      end
+    end
+  end
+  if not state.cursor then
+    state.cursor = state.custom_row
+    state.custom = model.thinking
+  end
+  return state
+end
+
+function M.value(state)
+  local row = state.rows[state.cursor]
+  return row.option and row.option.name or state.custom
+end
+
+-- Skips the blank spacers, and stops at either end instead of wrapping.
+local function move(state, delta)
+  local i = state.cursor + delta
+  while state.rows[i] do
+    if selectable(state.rows[i]) then
+      state.cursor = i
+      return
+    end
+    i = i + delta
+  end
+end
+
+local function editor_key(state, key)
+  if key:match(DIGIT) then
+    if #state.custom < MAX_DIGITS then
+      state.custom = state.custom .. key
+    end
+  elseif key == "backspace" then
+    state.custom = state.custom:sub(1, -2)
+  elseif key == "esc" then
+    state.editing = false
+  elseif key == "enter" and state.custom ~= "" then
+    state.editing = false
+    return "commit"
+  end
+end
+
+-- Answers "commit", "cancel", or nothing for a key that only changed what is
+-- on screen.
+function M.handle_key(state, key)
+  if state.editing then
+    return editor_key(state, key)
+  end
+  if key:match(DIGIT) then
+    state.cursor, state.custom, state.editing = state.custom_row, key, true
+  elseif key == "up" or key == "k" then
+    move(state, -1)
+  elseif key == "down" or key == "j" then
+    move(state, 1)
+  elseif key == "enter" then
+    -- An empty custom row has nothing to send yet, so Enter starts typing
+    -- instead of committing.
+    if state.cursor == state.custom_row and state.custom == "" then
+      state.editing = true
+    else
+      return "commit"
+    end
+  elseif key == "esc" or key == "ctrl+c" then
+    return "cancel"
+  end
+end
+
+function M.click(state, row)
+  if state.rows[row] and selectable(state.rows[row]) then
+    state.cursor, state.editing = row, false
+  end
+end
+
+-- What a budget-less row says in the wide column where the gauges are: a mode
+-- describes itself, the custom row shows what is typed.
+local function note_spans(state, row)
+  if row.option then
+    return { { MODE_NOTES[row.option.name] or "", STYLE_DIM } }
+  end
+  if state.editing then
+    return { { state.custom, STYLE_NAME_PICKED }, { CARET, STYLE_PICKED }, { TOKENS_LABEL, STYLE_DIM } }
+  end
+  if state.custom == "" then
+    return { { CUSTOM_HINT, STYLE_DIM } }
+  end
+  return { { state.custom .. TOKENS_LABEL, STYLE_DIM } }
+end
+
+-- Columns are budgeted in this order: names, then the token counts on the
+-- right, then whatever is left over becomes the gauge track. A window too
+-- narrow to hold an honest gauge drops the track and keeps the counts aligned.
+local function layout(state, width)
+  local name, value = 0, 0
+  for _, row in ipairs(state.rows) do
+    name = math.max(name, width_of(row_name(row)))
+    if row.option and row.option.tokens then
+      value = math.max(value, width_of(token_label(row.option.tokens)))
+    end
+  end
+  name = name + NAME_GAP
+  local room = width - width_of(INDENT) - width_of(PICKED) - name - RIGHT_PAD
+  local track = room - value - VALUE_GAP
+  return {
+    name = name,
+    value = value + VALUE_GAP,
+    room = room,
+    track = track >= MIN_TRACK and track or 0,
+  }
+end
+
+local function row_spans(state, row, picked, cols)
+  local spans = {
+    { INDENT .. (picked and PICKED or UNPICKED), picked and STYLE_PICKED or STYLE_DIM },
+    { pad_right(row_name(row), cols.name), picked and STYLE_NAME_PICKED or STYLE_NAME },
+  }
+  local tokens = row.option and row.option.tokens
+  if not tokens then
+    local left = cols.room
+    for _, span in ipairs(note_spans(state, row)) do
+      local text = clip(span[1], left)
+      left = left - width_of(text)
+      spans[#spans + 1] = { text, span[2] }
+    end
+    return spans
+  end
+  if cols.track > 0 then
+    -- Proportional to the largest budget in the list rather than to a nominal
+    -- percentage: when a small output window clamps several levels onto one
+    -- budget, their gauges come out equal, as they should.
+    local filled = math.max(math.floor(tokens / state.max_tokens * cols.track + 0.5), 1)
+    spans[#spans + 1] = { string.rep(FILL, filled), picked and STYLE_PICKED or STYLE_GAUGE }
+    spans[#spans + 1] = { string.rep(RAIL, cols.track - filled), STYLE_DIM }
+  end
+  spans[#spans + 1] = { pad_left(token_label(tokens), cols.value), picked and STYLE_NAME_PICKED or STYLE_DIM }
+  return spans
+end
+
+function M.render(state, width)
+  local cols = layout(state, width)
+  local lines = {}
+  for i, row in ipairs(state.rows) do
+    lines[i] = selectable(row) and row_spans(state, row, i == state.cursor, cols) or { { "" } }
+  end
+  return lines
+end
+
+return M

--- a/plugins/thinking/thinking_window.lua
+++ b/plugins/thinking/thinking_window.lua
@@ -1,0 +1,109 @@
+-- The /thinking picker window, plus the direct `/thinking <level>` form. Both
+-- end up in `set`, the one place that talks to the host and says what it
+-- answered, so the picker itself never has to undo anything: nothing is sent
+-- until Enter.
+
+local Picker = require("thinking_picker")
+
+-- Mirrors THINKING_UNSUPPORTED_MSG in maki-ui, which is also what
+-- `maki.model.set` answers on a model without thinking support.
+local UNSUPPORTED = "Thinking requires a model that supports it"
+local FLASH_PREFIX = "Thinking: "
+local TITLE_PREFIX = " Thinking · "
+local FOOTER = { { "↑↓", "move" }, { "⏎", "apply" }, { "esc", "cancel" } }
+-- The content is a fixed-column table, so the window keeps an absolute width
+-- instead of stretching across an ultrawide terminal.
+local WIDTH = 52
+local MARGIN = 4
+-- `height` is the outer box, so the border owes it a row at each end: without
+-- them the last rows of the ladder fall outside and the list starts scrolling.
+local CHROME = 2
+
+local M = {}
+
+local open_win = nil
+
+local function title_for(id, width)
+  local room = width - maki.ui.display_width(TITLE_PREFIX) - 1
+  return TITLE_PREFIX .. maki.ui.truncate_text(id, room).head .. " "
+end
+
+function M.set(value)
+  local model, err = maki.model.set({ thinking = value })
+  maki.ui.flash(err or (FLASH_PREFIX .. model.thinking))
+end
+
+function M.open()
+  if open_win then
+    return
+  end
+  local model, err = maki.model.get()
+  if err then
+    maki.ui.flash(err)
+    return
+  end
+  -- The ladder is empty exactly when the model cannot think, so this one check
+  -- covers both.
+  if #model.thinking_options == 0 then
+    maki.ui.flash(UNSUPPORTED)
+    return
+  end
+
+  local state = Picker.new(model)
+  local width = math.min(WIDTH, maki.ui.terminal_size().cols - MARGIN)
+  local buf = maki.ui.buf({ scratch = true })
+  local win = maki.ui.open_win(buf, {
+    title = title_for(model.id, width),
+    width = width,
+    height = #state.rows + CHROME,
+    border = "rounded",
+    focus = true,
+    footer = FOOTER,
+  })
+  open_win = win
+
+  local function draw()
+    buf:set_lines(Picker.render(state, width))
+    win:set_cursor(state.cursor)
+  end
+
+  buf:on("click", function(ev)
+    Picker.click(state, ev.row)
+    draw()
+  end)
+
+  -- Returns the value to send, or nil when the picker was dismissed.
+  local function loop()
+    draw()
+    while true do
+      local ev = win:recv()
+      if not ev or ev.type == "close" then
+        return nil
+      elseif ev.type == "key" then
+        local action = Picker.handle_key(state, ev.key)
+        if action == "commit" then
+          return Picker.value(state)
+        elseif action == "cancel" then
+          return nil
+        end
+      elseif ev.type == "resize" then
+        width = ev.width
+      end
+      draw()
+    end
+  end
+
+  -- However the loop ends, an error included, the window closes and the guard
+  -- clears before anything is sent.
+  local ok, value = pcall(loop)
+  win:close()
+  open_win = nil
+  if not ok then
+    error(value)
+  end
+  if value then
+    M.set(value)
+  end
+end
+
+return M

--- a/site/docs/content/commands/_index.md
+++ b/site/docs/content/commands/_index.md
@@ -25,7 +25,6 @@ Type `/` in the input box to open the command palette.
 | `/cd` | Change working directory |
 | `/btw` | Ask a quick question (no tools, no history pollution) |
 | `/yolo` | Toggle YOLO mode (skip all permission prompts) |
-| `/thinking` | Toggle extended thinking (off, adaptive, effort level, or budget) |
 | `/fast` | Toggle Anthropic fast mode (Opus only) |
 | `/workflow` | Toggle workflow mode (task callable inside code_execution) |
 | `/exit` | Exit the application |
@@ -36,6 +35,7 @@ Type `/` in the input box to open the command palette.
 | `/rename` | Rename the current session |
 | `/sessions` | Browse and switch sessions |
 | `/tasks` | Browse and search tasks |
+| `/thinking` | Extended thinking: pick an effort level, or set one directly |
 
 ## Sessions
 
@@ -44,7 +44,7 @@ Sessions run concurrently. `/new` starts a fresh session while the old one keeps
 ## Modes and toggles
 
 - **`/yolo`**: skip permission prompts for this session (deny rules still apply). The toggle survives a resume, and `--yolo` only sets the starting value. Config: `always_yolo = true`.
-- **`/thinking`**: extended thinking. Optional arg: `off`, `adaptive`, an effort level (`minimal` … `max`), or a token budget number. Config: `always_thinking`.
+- **`/thinking`**: extended thinking. Bare, or `Alt+T`, it opens a picker of the effort levels with what each one costs in tokens; `Enter` applies the selected level and `Esc` closes without changing anything. With an argument it sets the level directly: `off`, `adaptive`, an effort level (`minimal` … `max`), or a token budget number. Config: `always_thinking`.
 - **`/fast`**: Anthropic fast mode (Opus only; ignored on other models). Config: `always_fast = true`.
 - **`/workflow`**: let `code_execution` call the `task` tool (and other workflow-only tools) from inside the Python sandbox. Config: `always_workflow = true`.
 - **Plan / build**: not a slash command. Press `Tab` in the input to toggle plan mode (plan-file writes only).

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -87,6 +87,10 @@ Some pickers add extra bindings on top of the defaults:
 | Session Picker | `Ctrl+N` | New session |
 | Session Picker | `Ctrl+R` | Rename session |
 | Session Picker | `Ctrl+D` | Delete session (press twice) |
+| Thinking Picker | `↑`/`↓` | Move between effort levels |
+| Thinking Picker | `0`-`9` | Type a token budget |
+| Thinking Picker | `Enter` | Apply and close |
+| Thinking Picker | `Esc` | Close without changing anything |
 
 ## Plugins
 
@@ -96,6 +100,7 @@ Built-in plugins register these themselves, and your own plugins can add more wi
 |-----|--------|
 | `Ctrl+P` | Browse sessions |
 | `Ctrl+X` | Open tasks |
+| `Alt+T` | Thinking effort |
 
 ## Context Inheritance
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -3225,14 +3225,24 @@ Reads the focused session's model, thinking level, and fast mode.
 `thinking` comes back in the spelling `set` accepts, so a table from here
 can go straight back in.
 
-**Returns:** (`table|nil`, `string|nil`) `{spec, id, provider, thinking, fast,
-  supports_thinking, supports_fast}`, or nil and an error.
+`thinking_options` is every thinking value this model accepts, cheapest
+first: `{name, tokens?}` per row, where `tokens` is the budget maki would
+send for that row and is absent on `off` and `adaptive`. It is empty exactly
+when `supports_thinking` is false, so a picker can render the ladder from it
+without knowing the levels.
+
+**Returns:** (`table|nil`, `string|nil`) `{spec, id, provider, thinking,
+  thinking_options, fast, supports_thinking, supports_fast}`, or nil and an
+  error.
 
 **Example:**
 
 ```lua
 local m = maki.model.get()
 if m.spec ~= "anthropic/claude-opus-4-6" then ... end
+for _, option in ipairs(m.thinking_options) do
+  print(option.name, option.tokens)
+end
 ```
 
 ---


### PR DESCRIPTION

<img width="641" height="402" alt="image" src="https://github.com/user-attachments/assets/b366e5aa-8ceb-4ee0-8264-6b02ddfb8627" />


`/thinking` moved out of Rust into a bundled Lua plugin, where a bare `/thinking` or `Alt+T` opens a radio list of the effort levels with a bar of what each one costs in tokens. `Enter` applies the selected level, `Esc` closes and leaves the session where it was, and an argument still sets the level directly as before.

Nothing reaches the host until `Enter`, so the picker keeps no half-applied value to undo and the window stays a plain read-keys-until-done loop.

The ladder itself stays in Rust and arrives as `thinking_options` on `maki.model.get()`, so the plugin hardcodes no level, no order and no budget formula, and a seventh level added in `Effort::ALL` shows up in the picker on its own. A model that requires thinking just leaves `off` out of the list.

Module names resolve across all bundled plugins, so the files carry a `thinking_` prefix and the window lives next to `init.lua` rather than inside it, since `require("init")` would find whichever plugin comes first.

`set_thinking` now stores the clamped value instead of the raw one, which is what a model that requires thinking was reporting wrong: it could sit on `off` in the status bar while sending minimal effort. The clamp moved onto `ThinkingConfig`, so the request path and the UI read it from one place.

The status badge also dropped its `thinking: ` prefix and reads `[high]` or `[8192 tokens]` now, since the brackets already say it is a badge.