### PR TITLE
feat(thinking): remember the last thinking level across runs

### DIFF
--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -217,7 +217,7 @@ pub const TOP_LEVEL_FIELDS: &[ConfigField] = &[
         default: ConfigValue::Bool(false),
         min: None,
         env: None,
-        description: "Start every session with extended thinking (true/\"adaptive\", \"off\", an effort level (\"minimal\" to \"max\"), or a token budget)",
+        description: "Start every session with extended thinking (true/\"adaptive\", \"off\", an effort level (\"minimal\" to \"max\"), or a token budget). Unset, a fresh session starts at the level `/thinking` last set",
     },
 ];
 

--- a/maki-docgen/src/gen_commands.rs
+++ b/maki-docgen/src/gen_commands.rs
@@ -83,7 +83,7 @@ pub fn generate() -> String {
     .unwrap();
     writeln!(
         out,
-        "- **`/thinking`**: extended thinking. Bare, or `Alt+T`, it opens a picker of the effort levels with what each one costs in tokens; `Enter` applies the selected level and `Esc` closes without changing anything. With an argument it sets the level directly: `off`, `adaptive`, an effort level (`minimal` … `max`), or a token budget number. Config: `always_thinking`."
+        "- **`/thinking`**: extended thinking. Bare, or `Alt+T`, it opens a picker of the effort levels with what each one costs in tokens; `Enter` applies the selected level and `Esc` closes without changing anything. With an argument it sets the level directly: `off`, `adaptive`, an effort level (`minimal` … `max`), or a token budget number. The level is remembered across runs; `always_thinking` pins it instead."
     )
     .unwrap();
     writeln!(

--- a/maki-storage/src/model.rs
+++ b/maki-storage/src/model.rs
@@ -2,10 +2,12 @@ use std::fs;
 
 use serde::{Deserialize, Serialize};
 
+use crate::sessions::StoredThinking;
 use crate::{StateDir, atomic_write};
 
 const MODEL_FILE: &str = "model";
 const RECENT_FILE: &str = "recent-models";
+const THINKING_FILE: &str = "thinking";
 const MAX_RECENTS: usize = 4;
 
 pub fn persist_model(dir: &StateDir, spec: &str) {
@@ -16,6 +18,20 @@ pub fn read_model(dir: &StateDir) -> Option<String> {
     let raw = fs::read_to_string(dir.path().join(MODEL_FILE)).ok()?;
     let spec = raw.trim();
     (!spec.is_empty()).then(|| spec.to_owned())
+}
+
+/// Written in the `/thinking` spelling so the file reads like the command
+/// that produced it, and a hand-edited or stale value just fails to parse.
+pub fn persist_thinking(dir: &StateDir, thinking: StoredThinking) {
+    let _ = atomic_write(
+        &dir.path().join(THINKING_FILE),
+        thinking.to_string().as_bytes(),
+    );
+}
+
+pub fn read_thinking(dir: &StateDir) -> Option<StoredThinking> {
+    let raw = fs::read_to_string(dir.path().join(THINKING_FILE)).ok()?;
+    StoredThinking::parse_setting(&raw).ok()
 }
 
 #[derive(Serialize, Deserialize, Default)]
@@ -55,7 +71,9 @@ fn write_recents(dir: &StateDir, recents: &[String]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sessions::Effort;
     use tempfile::TempDir;
+    use test_case::test_case;
 
     #[test]
     fn round_trip() {
@@ -84,6 +102,31 @@ mod tests {
 
         fs::write(dir.path().join(MODEL_FILE), "").unwrap();
         assert!(read_model(&dir).is_none());
+    }
+
+    #[test_case(StoredThinking::Off)]
+    #[test_case(StoredThinking::Adaptive)]
+    #[test_case(StoredThinking::Effort { level: Effort::High })]
+    #[test_case(StoredThinking::Budget { tokens: 8192 })]
+    fn thinking_round_trip(thinking: StoredThinking) {
+        let tmp = TempDir::new().unwrap();
+        let dir = StateDir::from_path(tmp.path().to_path_buf());
+
+        assert!(read_thinking(&dir).is_none());
+        persist_thinking(&dir, thinking);
+        assert_eq!(read_thinking(&dir), Some(thinking));
+    }
+
+    #[test_case("" ; "empty")]
+    #[test_case("  \n" ; "whitespace")]
+    #[test_case("turbo" ; "unknown level")]
+    #[test_case("0" ; "zero budget")]
+    fn read_thinking_ignores_invalid(raw: &str) {
+        let tmp = TempDir::new().unwrap();
+        let dir = StateDir::from_path(tmp.path().to_path_buf());
+
+        fs::write(dir.path().join(THINKING_FILE), raw).unwrap();
+        assert!(read_thinking(&dir).is_none());
     }
 
     #[test]

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -55,6 +55,8 @@ const ARCHIVE_KEEP: usize = 3;
 const ARCHIVE_MAX_BYTES: u64 = 32 * 1024 * 1024;
 /// A `msg` line starts with this. Matching the prefix beats parsing the log.
 const MSG_PREFIX: &[u8] = br#"{"t":"msg""#;
+const THINKING_OFF: &str = "off";
+const THINKING_ADAPTIVE: &str = "adaptive";
 
 /// Hands out the token that tags one append-only run of a message list.
 /// Process wide, so two runs never pick the same number.
@@ -395,8 +397,8 @@ impl StoredThinking {
     /// config, and the Lua agent API all delegate here.
     pub fn parse_setting(input: &str) -> Result<Self, ThinkingParseError> {
         match input.trim() {
-            "off" => Ok(Self::Off),
-            "adaptive" => Ok(Self::Adaptive),
+            THINKING_OFF => Ok(Self::Off),
+            THINKING_ADAPTIVE => Ok(Self::Adaptive),
             other => {
                 if let Ok(level) = other.parse::<Effort>() {
                     return Ok(Self::Effort { level });
@@ -407,6 +409,18 @@ impl StoredThinking {
                     Err(_) => Err(ThinkingParseError::Unknown(other.to_string())),
                 }
             }
+        }
+    }
+}
+
+/// Inverse of [`StoredThinking::parse_setting`].
+impl fmt::Display for StoredThinking {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Off => f.write_str(THINKING_OFF),
+            Self::Adaptive => f.write_str(THINKING_ADAPTIVE),
+            Self::Effort { level } => f.write_str(level.as_str()),
+            Self::Budget { tokens } => write!(f, "{tokens}"),
         }
     }
 }

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -69,7 +69,7 @@ use maki_lua::{
 use maki_providers::{ContentBlock, Message, Model, ThinkingConfig, add_cost};
 use maki_storage::StateDir;
 use maki_storage::input_history::InputHistory;
-use maki_storage::model::persist_model;
+use maki_storage::model::{persist_model, persist_thinking};
 
 use crate::storage_writer::StorageWriter;
 use ratatui::layout::Position;
@@ -415,6 +415,11 @@ impl App {
     ///
     /// Stores the clamped value rather than the typed one, so the status bar
     /// can never read `off` on a model that is really sending minimal effort.
+    ///
+    /// The value is also written to disk here, and only here: the next run
+    /// seeds its sessions from it (`SessionDefaults`), the same way the model
+    /// is remembered. A clamp on model change is not the user's choice, so it
+    /// does not overwrite the file.
     pub(crate) fn set_thinking(&mut self, input: &str) -> Result<ThinkingConfig, String> {
         if !self.state.model.supports_thinking() {
             return Err(THINKING_UNSUPPORTED_MSG.into());
@@ -422,6 +427,7 @@ impl App {
         self.state.thinking = ThinkingConfig::parse(input.trim(), self.state.thinking)
             .map_err(str::to_owned)?
             .clamped(&self.state.model);
+        persist_thinking(&self.storage, self.state.thinking.into());
         Ok(self.state.thinking)
     }
 

--- a/site/docs/content/commands/_index.md
+++ b/site/docs/content/commands/_index.md
@@ -44,7 +44,7 @@ Sessions run concurrently. `/new` starts a fresh session while the old one keeps
 ## Modes and toggles
 
 - **`/yolo`**: skip permission prompts for this session (deny rules still apply). The toggle survives a resume, and `--yolo` only sets the starting value. Config: `always_yolo = true`.
-- **`/thinking`**: extended thinking. Bare, or `Alt+T`, it opens a picker of the effort levels with what each one costs in tokens; `Enter` applies the selected level and `Esc` closes without changing anything. With an argument it sets the level directly: `off`, `adaptive`, an effort level (`minimal` … `max`), or a token budget number. Config: `always_thinking`.
+- **`/thinking`**: extended thinking. Bare, or `Alt+T`, it opens a picker of the effort levels with what each one costs in tokens; `Enter` applies the selected level and `Esc` closes without changing anything. With an argument it sets the level directly: `off`, `adaptive`, an effort level (`minimal` … `max`), or a token budget number. The level is remembered across runs; `always_thinking` pins it instead.
 - **`/fast`**: Anthropic fast mode (Opus only; ignored on other models). Config: `always_fast = true`.
 - **`/workflow`**: let `code_execution` call the `task` tool (and other workflow-only tools) from inside the Python sandbox. Config: `always_workflow = true`.
 - **Plan / build**: not a slash command. Press `Tab` in the input to toggle plan mode (plan-file writes only).

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -66,7 +66,7 @@ All fields are optional. Typos in field names cause an error right away.
 | `always_yolo` | bool | `false` | Start every session with YOLO mode (skip permission prompts, deny rules still apply) |
 | `always_fast` | bool | `false` | Start every session with Anthropic fast mode (Opus only; ignored otherwise) |
 | `always_workflow` | bool | `false` | Start every session with workflow mode (task callable inside code_execution) |
-| `always_thinking` | bool \| string | `false` | Start every session with extended thinking (true/"adaptive", "off", an effort level ("minimal" to "max"), or a token budget) |
+| `always_thinking` | bool \| string | `false` | Start every session with extended thinking (true/"adaptive", "off", an effort level ("minimal" to "max"), or a token budget). Unset, a fresh session starts at the level `/thinking` last set |
 
 ### `ui`
 

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -30,7 +30,7 @@ pub fn run(
     let mut plugin_host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
         .context("initialize lua plugin host")?;
 
-    let (config, warnings) = super::load_plugins(
+    let (mut config, warnings) = super::load_plugins(
         &mut plugin_host,
         no_plugins,
         super::BuiltinFailure::Fatal,
@@ -60,6 +60,7 @@ pub fn run(
     };
 
     let model = setup::resolve_model(model_arg.as_deref(), &config.provider, &storage)?;
+    setup::remember_thinking(&mut config.session_defaults, &storage);
 
     setup::init_logging(&config.storage);
     setup::init_telemetry(&config.telemetry);

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -152,7 +152,7 @@ fn build_stack(
         .context("initialize lua plugin host")?;
 
     let (fallback_config, fallback_model) = fallback.unzip();
-    let (config, mut warnings) = super::load_plugins(
+    let (mut config, mut warnings) = super::load_plugins(
         &mut plugin_host,
         cli.no_plugins,
         if fallback_model.is_some() {
@@ -177,6 +177,7 @@ fn build_stack(
 
     let commands = discover_commands(cli.no_commands, cwd);
 
+    setup::remember_thinking(&mut config.session_defaults, storage);
     let model_result = setup::resolve_model(cli.model.as_deref(), &config.provider, storage);
     let (model, needs_login) = match (model_result, fallback_model) {
         (Ok(m), _) => (m, false),

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -5,11 +5,12 @@ use std::sync::{Mutex, MutexGuard, PoisonError};
 use color_eyre::Result;
 use color_eyre::eyre::{Context, eyre};
 
+use maki_config::SessionDefaults;
 use maki_providers::manifest::ManifestRegistry;
 use maki_providers::model::{Model, ModelError, ModelTier};
 use maki_storage::StateDir;
 use maki_storage::log::RotatingFileWriter;
-use maki_storage::model::read_model;
+use maki_storage::model::{read_model, read_thinking};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::fmt::MakeWriter;
@@ -72,6 +73,15 @@ pub fn resolve_model(
             "no provider available - set an API key (e.g. ANTHROPIC_API_KEY), run `maki auth login`, or use -m to specify a model{policy_note}\n\nSee https://maki.sh/docs/providers/ for setup instructions"
         )
     })
+}
+
+/// `always_thinking` pins the level. Without it, a fresh session starts at
+/// whatever `/thinking` last set, the way the model comes back too; a model
+/// that cannot run that level clamps it when the session loads.
+pub fn remember_thinking(defaults: &mut SessionDefaults, storage: &StateDir) {
+    if defaults.thinking.is_none() {
+        defaults.thinking = read_thinking(storage);
+    }
 }
 
 /// An unknown slug may just mean the models.dev catalog has not been loaded


### PR DESCRIPTION
## summary

* `/thinking`, the picker, and `maki.model.set` write the level to a `thinking` file in the state dir, next to the saved model
* every entry point that seeds a session (tui, `-p`, sdk, acp) starts from it, the same way the saved model comes back
* `always_thinking` still pins: the file only fills in a level the config left unset, like `default_model` and the saved model
* only an explicit set writes the file. a clamp from switching to a model that cannot think is not the user's choice, so a detour through one never loses the remembered level

closes the persistence half of #972 . one global level rather than per-model, matching how the model is remembered; a model that cannot run the level clamps it on load as before.

headless modes (`-p`, sdk, acp) now inherit the level last set in the tui unless `always_thinking` is configured.

## testing

* storage round-trip and invalid-file tests for the new `thinking` file
* workspace clippy, formatting, and generated docs passed
* full workspace suite has two known failures in untouched macOS tests (`permissions::universal_scope::root_by_parent`, `trusted_folders::non_utf8_paths_are_refused`)
* manually verified: set a level, quit, restart; switch provider and back; detour through a non-thinking model; `always_thinking` overriding the file
