### PR TITLE
fix(providers): stop one bad image from killing a session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2968,6 +2968,7 @@ dependencies = [
  "futures-lite",
  "getrandom 0.3.4",
  "hmac",
+ "image",
  "inventory",
  "isahc",
  "jiff",

--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -772,10 +772,10 @@ fn extract_prompt_content(blocks: &[ContentBlock]) -> (String, Vec<ImageSource>)
             ContentBlock::Text(TextContent { text: t, .. }) => append(&mut text, t),
             ContentBlock::Image(ImageContent {
                 data, mime_type, ..
-            }) => images.push(ImageSource {
-                media_type: image_media_type(mime_type),
-                data: Arc::from(data.as_str()),
-            }),
+            }) => images.push(ImageSource::new(
+                image_media_type(mime_type),
+                Arc::from(data.as_str()),
+            )),
             ContentBlock::Resource(res) => {
                 if let EmbeddedResourceResource::TextResourceContents(trc) = &res.resource {
                     append(&mut text, &format!("--- {} ---\n{}", trc.uri, trc.text));

--- a/maki-acp/src/translate.rs
+++ b/maki-acp/src/translate.rs
@@ -609,10 +609,10 @@ mod tests {
     fn replay_user_image_keeps_mime_type() {
         let msg = Message::user_with_images(
             String::new(),
-            vec![ImageSource {
-                media_type: ImageMediaType::Png,
-                data: std::sync::Arc::from("b64data"),
-            }],
+            vec![ImageSource::new(
+                ImageMediaType::Png,
+                std::sync::Arc::from("b64data"),
+            )],
         );
         let json = updates_json(&[msg]);
         assert_eq!(json.len(), 1);

--- a/maki-agent/src/agent/streaming.rs
+++ b/maki-agent/src/agent/streaming.rs
@@ -137,8 +137,20 @@ pub(crate) async fn stream_with_retry(
         }
     });
     let model = fitted.as_ref().unwrap_or(model);
-    let messages = maki_providers::adapt_images_for_model(model, messages);
-    let messages = &*messages;
+    // Rebuilding images a provider would refuse can take real time on the
+    // first request of a session full of screenshots, and it all happens
+    // before anything below can observe a cancel.
+    let adapted = futures_lite::future::race(
+        async { Ok(maki_providers::adapt_images_for_model(model, messages).await) },
+        async {
+            cancel.cancelled().await;
+            Err(StreamError::Cancelled {
+                streamed: String::new(),
+            })
+        },
+    )
+    .await?;
+    let messages = &*adapted;
     let mut retry = RetryState::new();
     loop {
         let started = Instant::now();

--- a/maki-providers/Cargo.toml
+++ b/maki-providers/Cargo.toml
@@ -17,6 +17,7 @@ futures-lite = { workspace = true }
 futures = { workspace = true }
 isahc = { workspace = true }
 base64 = { workspace = true }
+image = { workspace = true, features = ["jpeg", "gif", "webp"] }
 sha2 = { workspace = true }
 hmac = { workspace = true }
 wait-timeout = { workspace = true }

--- a/maki-providers/src/image.rs
+++ b/maki-providers/src/image.rs
@@ -1,0 +1,320 @@
+//! Wire safety for image blocks. Providers cap pixel dimensions and payload
+//! size, and check the media type we declare against the magic bytes we send.
+//! An image that trips any of that poisons the whole session, since it stays
+//! in history and every later request fails on it again. Images come in from
+//! all over (paste, file attach, tool results, ACP, SDK) and none of those
+//! places knows the model, so the check lives where they all meet:
+//! [`crate::adapt_images_for_model`].
+
+use std::io::Cursor;
+use std::sync::Arc;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+use image::imageops::{self, FilterType};
+use image::{DynamicImage, ImageFormat, ImageReader, RgbImage, Rgba, RgbaImage};
+use tracing::warn;
+
+use crate::types::{ImageMediaType, ImageSource};
+
+/// Anthropic rejects any dimension over 2000px as soon as a request carries
+/// many images, and downscales past 1568px server side anyway. Staying under
+/// the smaller number is both safe everywhere and cheaper in tokens.
+pub(crate) const MAX_EDGE: u32 = 1568;
+/// Anthropic refuses a request carrying more than 100 images, and no other
+/// provider is more generous.
+pub(crate) const MAX_IMAGES: usize = 100;
+/// Providers reject images over 5MB base64, and 3MB of raw bytes encodes to
+/// roughly 4MB.
+const MAX_RAW_BYTES: usize = 3 * 1024 * 1024;
+/// Decode-bomb guard: a tiny header can declare gigabytes of RGBA.
+const MAX_PIXELS: u64 = 50_000_000;
+/// How often the long edge may halve before an image is given up on.
+const LOSSY_ATTEMPTS: u32 = 4;
+
+#[derive(Clone)]
+pub(crate) enum Fix {
+    /// Already wire-safe.
+    Keep,
+    Replace(ImageSource),
+    /// Undecodable here, so no provider will take it either.
+    Drop,
+}
+
+/// The formats a provider will take. Anything else has to be transcoded,
+/// however well it decodes here.
+fn media_type(format: ImageFormat) -> Option<ImageMediaType> {
+    Some(match format {
+        ImageFormat::Png => ImageMediaType::Png,
+        ImageFormat::Jpeg => ImageMediaType::Jpeg,
+        ImageFormat::Gif => ImageMediaType::Gif,
+        ImageFormat::WebP => ImageMediaType::Webp,
+        _ => return None,
+    })
+}
+
+/// Approximate: padding makes it off by at most two bytes, which no limit
+/// here is tight enough to care about.
+fn raw_len(base64_len: usize) -> usize {
+    base64_len / 4 * 3
+}
+
+fn probe(bytes: &[u8]) -> Result<(ImageFormat, u32, u32), String> {
+    let format = image::guess_format(bytes).map_err(|_| "unrecognized image format".to_owned())?;
+    let (width, height) = ImageReader::with_format(Cursor::new(bytes), format)
+        .into_dimensions()
+        .map_err(|e| format!("cannot read image header: {e}"))?;
+    Ok((format, width, height))
+}
+
+fn fits(width: u32, height: u32, base64_len: usize) -> bool {
+    width.max(height) <= MAX_EDGE && raw_len(base64_len) <= MAX_RAW_BYTES
+}
+
+/// Re-encode attempts, least destructive first: lossless at the cap, then
+/// lossy at the cap, then halvings of the long edge. Shrinking before trying
+/// the cheaper encoder would cost a screenshot half its resolution when JPEG
+/// alone would have fit it. A photo skips the lossless attempt, where PNG is
+/// both slower and larger than the payload that was already too big.
+fn plan(decoded: ImageFormat) -> impl Iterator<Item = (ImageMediaType, u32)> {
+    let lossless = (decoded != ImageFormat::Jpeg).then_some((ImageMediaType::Png, MAX_EDGE));
+    let lossy = (0..LOSSY_ATTEMPTS).map(|halvings| (ImageMediaType::Jpeg, MAX_EDGE >> halvings));
+    lossless.into_iter().chain(lossy)
+}
+
+/// Composes alpha over white. `to_rgb8` alone drops the channel rather than
+/// resolving it, which leaves whatever colour sat under a transparent pixel,
+/// usually black.
+fn flatten(img: &DynamicImage) -> RgbImage {
+    if !img.color().has_alpha() {
+        return img.to_rgb8();
+    }
+    let mut canvas = RgbaImage::from_pixel(img.width(), img.height(), Rgba([u8::MAX; 4]));
+    imageops::overlay(&mut canvas, img, 0, 0);
+    DynamicImage::ImageRgba8(canvas).into_rgb8()
+}
+
+/// The label is chosen before the bytes exist, so an output can never be sent
+/// under a media type its own magic bytes disagree with.
+fn encode(img: &DynamicImage, media: ImageMediaType) -> Result<Vec<u8>, String> {
+    let (format, flattened) = match media {
+        ImageMediaType::Png => (ImageFormat::Png, None),
+        // JPEG carries no alpha channel, and the encoder refuses RGBA outright.
+        ImageMediaType::Jpeg => (
+            ImageFormat::Jpeg,
+            Some(DynamicImage::ImageRgb8(flatten(img))),
+        ),
+        ImageMediaType::Gif | ImageMediaType::Webp => {
+            return Err(format!("no encoder for {}", media.mime()));
+        }
+    };
+    let mut out = Vec::new();
+    flattened
+        .as_ref()
+        .unwrap_or(img)
+        .write_to(&mut Cursor::new(&mut out), format)
+        .map_err(|e| format!("cannot encode: {e}"))?;
+    Ok(out)
+}
+
+/// Decode, judge, and if need be shrink and re-encode. Runs off the async
+/// executor, so it may take its time.
+fn decide(data: Arc<str>, declared: ImageMediaType) -> Result<Fix, String> {
+    let bytes = STANDARD
+        .decode(&*data)
+        .map_err(|e| format!("bad base64: {e}"))?;
+    let (format, width, height) = probe(&bytes)?;
+    if let Some(detected) = media_type(format)
+        && fits(width, height, data.len())
+    {
+        // Providers match the magic bytes against the declared media type and
+        // answer a mismatch with the same 400 an oversized image gets. A `.png`
+        // that is really a JPEG only needs its label corrected, which costs no
+        // pixels at all.
+        if detected == declared {
+            return Ok(Fix::Keep);
+        }
+        warn!(
+            declared = declared.mime(),
+            detected = detected.mime(),
+            "relabelled an image whose bytes disagree with its media type"
+        );
+        return Ok(Fix::Replace(ImageSource::new(detected, data)));
+    }
+    if u64::from(width) * u64::from(height) > MAX_PIXELS {
+        return Err(format!("image too large to decode ({width}x{height})"));
+    }
+    let mut img = image::load_from_memory_with_format(&bytes, format)
+        .map_err(|e| format!("cannot decode: {e}"))?;
+
+    for (media, edge) in plan(format) {
+        if img.width().max(img.height()) > edge {
+            img = img.resize(edge, edge, FilterType::Triangle);
+        }
+        // The plan is a list of fallbacks, so one encoder refusing these
+        // pixels is no reason to give up on the ones after it.
+        let encoded = match encode(&img, media) {
+            Ok(encoded) => encoded,
+            Err(error) => {
+                warn!(%error, attempted = media.mime(), "an encoder refused an image");
+                continue;
+            }
+        };
+        if encoded.len() <= MAX_RAW_BYTES {
+            warn!(
+                declared = declared.mime(),
+                rewritten_as = media.mime(),
+                original_bytes = raw_len(data.len()),
+                rewritten_bytes = encoded.len(),
+                width = img.width(),
+                height = img.height(),
+                "rewrote an image that no provider would accept"
+            );
+            return Ok(Fix::Replace(ImageSource::new(
+                media,
+                Arc::from(STANDARD.encode(&encoded)),
+            )));
+        }
+    }
+    Err(format!(
+        "no encoding got the image under {MAX_RAW_BYTES} bytes"
+    ))
+}
+
+/// What has to happen to `source` before it can go on the wire. The verdict
+/// rides on the image itself, so every clone shares it and history hands it
+/// back for free on every later request of this process. It is not persisted
+/// with the pixels, so a session reloaded from disk decides once more.
+pub(crate) async fn fix_for_wire(source: &ImageSource) -> Fix {
+    if let Some(fix) = source.verdict.get() {
+        return fix.clone();
+    }
+    let declared = source.media_type;
+    let data = Arc::clone(&source.data);
+    let fix = smol::unblock(move || decide(data, declared))
+        .await
+        .unwrap_or_else(|error| {
+            warn!(
+                %error,
+                media_type = declared.mime(),
+                "dropping an unusable image so the request can still go through"
+            );
+            Fix::Drop
+        });
+    // A concurrent request may have settled it first. Either verdict is sound,
+    // and taking the winner keeps what a request sends stable across turns.
+    source.verdict.get_or_init(|| fix).clone()
+}
+
+/// Shared with the [`crate::adapt_images_for_model`] tests next door.
+#[cfg(test)]
+pub(crate) fn png_base64(width: u32, height: u32) -> String {
+    let img = DynamicImage::new_rgb8(width, height);
+    STANDARD.encode(encode(&img, ImageMediaType::Png).unwrap())
+}
+
+#[cfg(test)]
+pub(crate) fn dimensions(source: &ImageSource) -> (u32, u32) {
+    let bytes = STANDARD.decode(source.data.as_bytes()).unwrap();
+    let (_, width, height) = probe(&bytes).unwrap();
+    (width, height)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::Rgb;
+    use test_case::test_case;
+
+    const NOT_AN_IMAGE: &str = "abc123";
+    /// Not base64, and not even ASCII.
+    const NOT_TEXT: &str = "€€";
+    /// Incompressible pixels: PNG cannot get this under the byte cap at the
+    /// full edge, so the plan has to reach for the lossy encoder.
+    const NOISE_HEIGHT: u32 = 800;
+
+    fn png(width: u32, height: u32) -> ImageSource {
+        ImageSource::new(ImageMediaType::Png, Arc::from(png_base64(width, height)))
+    }
+
+    /// A deterministic xorshift beats a real photo: no fixture, and PNG has
+    /// nothing to compress.
+    fn noise_png() -> ImageSource {
+        let mut state = 0x2545_f491_4f6c_dd1d_u64;
+        let img = DynamicImage::ImageRgb8(RgbImage::from_fn(MAX_EDGE, NOISE_HEIGHT, |_, _| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            Rgb([state as u8, (state >> 8) as u8, (state >> 16) as u8])
+        }));
+        let data = STANDARD.encode(encode(&img, ImageMediaType::Png).unwrap());
+        assert!(
+            raw_len(data.len()) > MAX_RAW_BYTES,
+            "the fixture must not fit"
+        );
+        ImageSource::new(ImageMediaType::Png, Arc::from(data))
+    }
+
+    fn rewrite(source: &ImageSource) -> ImageSource {
+        let Fix::Replace(fixed) = smol::block_on(fix_for_wire(source)) else {
+            panic!("expected a rewrite");
+        };
+        fixed
+    }
+
+    #[test_case(3000, 100 ; "wide")]
+    #[test_case(100, 3000 ; "tall")]
+    #[test_case(2001, 2001 ; "just_over_the_many_image_cap")]
+    fn oversized_images_are_shrunk_to_fit(width: u32, height: u32) {
+        let (w, h) = dimensions(&rewrite(&png(width, height)));
+        assert_eq!(w.max(h), MAX_EDGE, "the long edge must land on the cap");
+        assert_eq!(w > h, width > height, "orientation must survive");
+    }
+
+    /// The lossy encoder at the full edge comes before any shrink, or an
+    /// image JPEG alone would have fit loses half its resolution for nothing.
+    #[test]
+    fn a_payload_too_heavy_for_lossless_keeps_its_resolution() {
+        let fixed = rewrite(&noise_png());
+        assert_eq!(fixed.media_type, ImageMediaType::Jpeg);
+        assert_eq!(dimensions(&fixed), (MAX_EDGE, NOISE_HEIGHT));
+    }
+
+    #[test]
+    fn images_within_the_limits_are_left_alone() {
+        let source = png(MAX_EDGE, 10);
+        assert!(matches!(smol::block_on(fix_for_wire(&source)), Fix::Keep));
+    }
+
+    /// Extensions lie (a JPEG saved as `.png`), and ACP hands us whatever mime
+    /// the client claimed. The bytes are fine, so only the label moves.
+    #[test]
+    fn a_mislabelled_payload_is_relabelled_rather_than_re_encoded() {
+        let pixels = png(32, 32).data;
+        let source = ImageSource::new(ImageMediaType::Jpeg, Arc::clone(&pixels));
+        let fixed = rewrite(&source);
+        assert_eq!(fixed.media_type, ImageMediaType::Png);
+        assert!(
+            Arc::ptr_eq(&fixed.data, &pixels),
+            "the pixels must not be touched"
+        );
+    }
+
+    #[test_case(NOT_AN_IMAGE ; "not_an_image")]
+    #[test_case(NOT_TEXT ; "not_even_text")]
+    fn undecodable_payloads_are_dropped(data: &str) {
+        let source = ImageSource::new(ImageMediaType::Png, Arc::from(data));
+        assert!(matches!(smol::block_on(fix_for_wire(&source)), Fix::Drop));
+    }
+
+    /// Every request walks the whole history, and the copy it carries is a
+    /// clone of the one history holds, so a verdict either one reaches has to
+    /// be visible to the other or a repair is paid for again on every turn.
+    #[test]
+    fn a_verdict_is_reached_once_and_shared_with_every_clone() {
+        let source = png(MAX_EDGE + 1, 4);
+        let first = rewrite(&source);
+        assert!(Arc::ptr_eq(&rewrite(&source).data, &first.data));
+        assert!(Arc::ptr_eq(&rewrite(&source.clone()).data, &first.data));
+    }
+}

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -1,4 +1,5 @@
 pub(crate) mod error;
+pub(crate) mod image;
 pub mod manifest;
 pub mod model;
 pub mod model_registry;
@@ -26,8 +27,9 @@ pub use providers::dynamic;
 pub use providers::openai::auth as openai_auth;
 pub use providers::xai::auth as xai_auth;
 pub use types::{
-    ContentBlock, EMPTY_RESPONSE_MARKER, Effort, EffortDialect, IMAGE_OMITTED_NOTE,
-    IMAGE_PLACEHOLDER, ImageMediaType, ImageSource, Message, MessageKind, ModelUsageRow,
-    ProviderEvent, ProviderUsage, RequestOptions, Role, StopReason, StreamResponse, THINKING_USAGE,
-    ThinkingConfig, UsageLimit, adapt_images_for_model, dialect,
+    ContentBlock, EMPTY_RESPONSE_MARKER, Effort, EffortDialect, IMAGE_EVICTED_NOTE,
+    IMAGE_OMITTED_NOTE, IMAGE_PLACEHOLDER, IMAGE_UNUSABLE_NOTE, ImageMediaType, ImageSource,
+    Message, MessageKind, ModelUsageRow, ProviderEvent, ProviderUsage, RequestOptions, Role,
+    StopReason, StreamResponse, THINKING_USAGE, ThinkingConfig, UsageLimit, adapt_images_for_model,
+    dialect,
 };

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -8,7 +8,8 @@
 
 use std::borrow::Cow;
 use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::fmt;
+use std::sync::{Arc, OnceLock};
 
 use maki_storage::intern;
 pub use maki_storage::sessions::Effort;
@@ -19,6 +20,7 @@ use strum::{Display, IntoStaticStr};
 use tracing::warn;
 
 use crate::TokenUsage;
+use crate::image::{Fix, MAX_IMAGES, fix_for_wire};
 use crate::model::Model;
 
 const LOCAL_BUDGET_FIELD: &str = "thinking_budget_tokens";
@@ -70,10 +72,26 @@ impl<'de> Deserialize<'de> for ImageMediaType {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ImageSource {
     pub media_type: ImageMediaType,
     pub data: Arc<str>,
+    /// What [`adapt_images_for_model`] has to do with `data` before a provider
+    /// will take it, decided at most once. It describes the payload, so it
+    /// rides with it: every clone shares one verdict, and it dies with the
+    /// pixels instead of outliving them in a side table.
+    pub(crate) verdict: Arc<OnceLock<Fix>>,
+}
+
+/// The payload is the largest string a session holds, and a verdict can carry
+/// a second one, so neither belongs in a log line.
+impl fmt::Debug for ImageSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ImageSource")
+            .field("media_type", &self.media_type)
+            .field("base64_len", &self.data.len())
+            .finish()
+    }
 }
 
 impl<'de> Deserialize<'de> for ImageSource {
@@ -84,12 +102,9 @@ impl<'de> Deserialize<'de> for ImageSource {
             data: String,
         }
         let wire = Wire::deserialize(deserializer)?;
-        Ok(Self {
-            media_type: wire.media_type,
-            // Base64 image payloads are the largest strings a session holds,
-            // and a load decodes each one once per record that carries it.
-            data: intern::shared_str(wire.data),
-        })
+        // Base64 image payloads are the largest strings a session holds, and a
+        // load decodes each one once per record that carries it.
+        Ok(Self::new(wire.media_type, intern::shared_str(wire.data)))
     }
 }
 
@@ -106,7 +121,11 @@ impl Serialize for ImageSource {
 
 impl ImageSource {
     pub fn new(media_type: ImageMediaType, data: Arc<str>) -> Self {
-        Self { media_type, data }
+        Self {
+            media_type,
+            data,
+            verdict: Arc::default(),
+        }
     }
 
     pub fn to_data_url(&self) -> String {
@@ -116,38 +135,77 @@ impl ImageSource {
 
 pub const IMAGE_OMITTED_NOTE: &str =
     "[image omitted: the current model does not support image input]";
+/// A broken payload has to leave the request, or every turn after it fails.
+pub const IMAGE_UNUSABLE_NOTE: &str = "[image omitted: the image could not be decoded]";
+/// Past [`MAX_IMAGES`] the request itself is refused, so the oldest pixels
+/// make way rather than taking the whole session down.
+pub const IMAGE_EVICTED_NOTE: &str = "[image omitted: too many images in this conversation]";
 /// Stands in for the text of a message that carries only images, both in model
 /// context and in the transcript. One const so the two can never drift apart.
 pub const IMAGE_PLACEHOLDER: &str = "[image]";
 /// See [`Message::empty_marker`].
 pub const EMPTY_RESPONSE_MARKER: &str = "(empty)";
 
-/// For models without vision, image blocks become a text note instead of a
-/// wire block the API would reject. History keeps the pixels, so switching
-/// back to a vision-capable model restores them.
-pub fn adapt_images_for_model<'a>(model: &Model, messages: &'a [Message]) -> Cow<'a, [Message]> {
-    let has_image = |m: &Message| {
-        m.content
-            .iter()
-            .any(|b| matches!(b, ContentBlock::Image { .. }))
-    };
-    if model.supports_vision() || !messages.iter().any(has_image) {
-        return Cow::Borrowed(messages);
-    }
-    let adapted = messages
+/// The last stop before the wire for every image in a request, whatever put
+/// it there. For models without vision, image blocks become a text note
+/// instead of a block the API would reject, and history keeps the pixels, so
+/// switching back to a vision-capable model restores them. For the rest,
+/// oversized payloads are rewritten to fit provider limits, because one image
+/// a provider refuses would otherwise fail every later request in the session
+/// too.
+pub async fn adapt_images_for_model<'a>(
+    model: &Model,
+    messages: &'a [Message],
+) -> Cow<'a, [Message]> {
+    // Newest first: the stale screenshots are the ones a long session can
+    // spare once the request runs out of room for them. Collected rather than
+    // walked lazily, since a borrow of `messages` held across the await below
+    // leaves callers unable to prove their own futures `Send`.
+    let images: Vec<(usize, usize, ImageSource)> = messages
         .iter()
-        .map(|m| {
-            let mut m = m.clone();
-            for block in &mut m.content {
-                if matches!(block, ContentBlock::Image { .. }) {
-                    *block = ContentBlock::Text {
-                        text: IMAGE_OMITTED_NOTE.into(),
-                    };
-                }
-            }
-            m
+        .enumerate()
+        .rev()
+        .flat_map(|(m, message)| {
+            message
+                .content
+                .iter()
+                .enumerate()
+                .rev()
+                .filter_map(move |(b, block)| match block {
+                    ContentBlock::Image { source } => Some((m, b, source.clone())),
+                    _ => None,
+                })
         })
         .collect();
+    let note = |text: &str| ContentBlock::Text { text: text.into() };
+    let vision = model.supports_vision();
+    let mut edits: Vec<(usize, usize, ContentBlock)> = Vec::new();
+    // Counts survivors, not blocks, or an image nobody can read would cost a
+    // good one its place. Nothing past the cap is decoded at all.
+    let mut kept = 0;
+    for (m, b, source) in images {
+        if !vision {
+            edits.push((m, b, note(IMAGE_OMITTED_NOTE)));
+        } else if kept == MAX_IMAGES {
+            edits.push((m, b, note(IMAGE_EVICTED_NOTE)));
+        } else {
+            match fix_for_wire(&source).await {
+                Fix::Keep => kept += 1,
+                Fix::Replace(source) => {
+                    kept += 1;
+                    edits.push((m, b, ContentBlock::Image { source }));
+                }
+                Fix::Drop => edits.push((m, b, note(IMAGE_UNUSABLE_NOTE))),
+            }
+        }
+    }
+    if edits.is_empty() {
+        return Cow::Borrowed(messages);
+    }
+    let mut adapted = messages.to_vec();
+    for (m, b, block) in edits {
+        adapted[m].content[b] = block;
+    }
     Cow::Owned(adapted)
 }
 
@@ -932,6 +990,8 @@ mod tests {
     use test_case::test_case;
 
     const INTERNED_DATA: &str = "aW50ZXJuZWQtcGF5bG9hZA==";
+    /// Valid ASCII, but no image ever started with these bytes.
+    const UNREADABLE_PAYLOAD: &str = "abc123";
     const OTHER_DATA: &str = "b3RoZXItcGF5bG9hZA==";
     /// Below `Minimal` against [`FALLBACK_MAX_THINKING_BUDGET`].
     const SMALL_BUDGET: u32 = 2048;
@@ -1005,18 +1065,47 @@ mod tests {
         assert_eq!(ImageMediaType::from_mime(mime), expected);
     }
 
+    fn png_block(edge: usize) -> ContentBlock {
+        let data = crate::image::png_base64(edge as u32, edge as u32);
+        ContentBlock::Image {
+            source: ImageSource::new(ImageMediaType::Png, Arc::from(data)),
+        }
+    }
+
+    fn unreadable_block() -> ContentBlock {
+        ContentBlock::Image {
+            source: ImageSource::new(ImageMediaType::Png, Arc::from(UNREADABLE_PAYLOAD)),
+        }
+    }
+
+    fn adapt(model: &Model, content: Vec<ContentBlock>) -> Vec<ContentBlock> {
+        let messages = vec![Message {
+            role: Role::User,
+            content,
+            ..Default::default()
+        }];
+        smol::block_on(adapt_images_for_model(model, &messages))[0]
+            .content
+            .clone()
+    }
+
+    fn image_count(blocks: &[ContentBlock]) -> usize {
+        blocks
+            .iter()
+            .filter(|b| matches!(b, ContentBlock::Image { .. }))
+            .count()
+    }
+
     #[test]
-    fn adapt_images_borrows_when_model_has_vision_or_no_images() {
+    fn adapt_images_borrows_when_nothing_has_to_change() {
         let model = clamp_test_model(crate::provider::ProviderKind::Anthropic);
         let with_image = vec![Message {
             role: Role::User,
-            content: vec![ContentBlock::Image {
-                source: ImageSource::new(ImageMediaType::Png, Arc::from("abc123")),
-            }],
+            content: vec![png_block(32)],
             ..Default::default()
         }];
         assert!(matches!(
-            adapt_images_for_model(&model, &with_image),
+            smol::block_on(adapt_images_for_model(&model, &with_image)),
             Cow::Borrowed(_)
         ));
 
@@ -1024,38 +1113,73 @@ mod tests {
         text_only_model.supports_vision_override = Some(false);
         let no_images = vec![Message::user("hi".into())];
         assert!(matches!(
-            adapt_images_for_model(&text_only_model, &no_images),
+            smol::block_on(adapt_images_for_model(&text_only_model, &no_images)),
             Cow::Borrowed(_)
         ));
+    }
+
+    #[test]
+    fn adapt_images_shrinks_what_a_provider_would_refuse() {
+        let model = clamp_test_model(crate::provider::ProviderKind::Anthropic);
+        let oversized = ContentBlock::Image {
+            source: ImageSource::new(
+                ImageMediaType::Png,
+                Arc::from(crate::image::png_base64(2600, 30)),
+            ),
+        };
+        let text = ContentBlock::Text {
+            text: "look".into(),
+        };
+        let blocks = adapt(&model, vec![text, oversized]);
+        assert!(matches!(&blocks[0], ContentBlock::Text { .. }));
+        let ContentBlock::Image { source } = &blocks[1] else {
+            panic!("an image block must stay an image block");
+        };
+        let (width, height) = crate::image::dimensions(source);
+        assert!(
+            width.max(height) <= crate::image::MAX_EDGE,
+            "{width}x{height}"
+        );
+    }
+
+    #[test]
+    fn adapt_images_evicts_the_oldest_past_the_request_cap() {
+        const EXTRA: usize = 3;
+        let model = clamp_test_model(crate::provider::ProviderKind::Anthropic);
+        let blocks = adapt(&model, (1..=MAX_IMAGES + EXTRA).map(png_block).collect());
+        assert_eq!(image_count(&blocks), MAX_IMAGES);
+        assert!(
+            matches!(&blocks[EXTRA - 1], ContentBlock::Text { text } if text == IMAGE_EVICTED_NOTE),
+            "the oldest images are the ones that make way"
+        );
+        assert!(matches!(&blocks[EXTRA], ContentBlock::Image { .. }));
+    }
+
+    /// An image no provider could read frees no room, so the cap is spent on
+    /// survivors: counting blocks instead would evict a good one in its place.
+    #[test]
+    fn adapt_images_drops_what_it_cannot_read_without_spending_the_cap() {
+        let model = clamp_test_model(crate::provider::ProviderKind::Anthropic);
+        let mut content = vec![png_block(1), unreadable_block()];
+        content.extend((2..=MAX_IMAGES).map(png_block));
+        let blocks = adapt(&model, content);
+        assert_eq!(image_count(&blocks), MAX_IMAGES);
+        assert!(matches!(&blocks[1], ContentBlock::Text { text } if text == IMAGE_UNUSABLE_NOTE));
     }
 
     #[test]
     fn adapt_images_replaces_blocks_for_text_only_model() {
         let mut model = clamp_test_model(crate::provider::ProviderKind::Anthropic);
         model.supports_vision_override = Some(false);
-        let messages = vec![Message {
-            role: Role::User,
-            content: vec![
-                ContentBlock::ToolResult {
-                    tool_use_id: "t1".into(),
-                    content: "[image: pic.png 1KB]".into(),
-                    is_error: false,
-                },
-                ContentBlock::Image {
-                    source: ImageSource::new(ImageMediaType::Png, Arc::from("abc123")),
-                },
-            ],
-            ..Default::default()
-        }];
-        let adapted = adapt_images_for_model(&model, &messages);
-        assert_eq!(adapted[0].content.len(), 2);
-        assert!(matches!(
-            &adapted[0].content[0],
-            ContentBlock::ToolResult { .. }
-        ));
-        assert!(
-            matches!(&adapted[0].content[1], ContentBlock::Text { text } if text == IMAGE_OMITTED_NOTE)
-        );
+        let tool_result = ContentBlock::ToolResult {
+            tool_use_id: "t1".into(),
+            content: "[image: pic.png 1KB]".into(),
+            is_error: false,
+        };
+        let blocks = adapt(&model, vec![tool_result, unreadable_block()]);
+        assert_eq!(blocks.len(), 2);
+        assert!(matches!(&blocks[0], ContentBlock::ToolResult { .. }));
+        assert!(matches!(&blocks[1], ContentBlock::Text { text } if text == IMAGE_OMITTED_NOTE));
     }
 
     #[test]

--- a/maki-ui/src/app/btw.rs
+++ b/maki-ui/src/app/btw.rs
@@ -74,7 +74,7 @@ async fn run_btw(
 ) {
     let (event_tx, event_rx) = flume::unbounded();
     let tools = Value::Array(vec![]);
-    let messages = maki_providers::adapt_images_for_model(&model, &messages);
+    let messages = maki_providers::adapt_images_for_model(&model, &messages).await;
 
     let stream_fut = provider.stream_message(
         &model,

--- a/maki-ui/src/components/messages/render.rs
+++ b/maki-ui/src/components/messages/render.rs
@@ -159,10 +159,10 @@ mod tests {
         let pixels = RgbaImage::from_fn(8, 12, |_, y| Rgba([y as u8 * 20, 80, 160, 255]));
         let mut png = Cursor::new(Vec::new());
         DynamicImage::ImageRgba8(pixels).write_to(&mut png, ImageFormat::Png)?;
-        let source = ImageSource {
-            media_type: ImageMediaType::Png,
-            data: STANDARD.encode(png.into_inner()).into(),
-        };
+        let source = ImageSource::new(
+            ImageMediaType::Png,
+            STANDARD.encode(png.into_inner()).into(),
+        );
         let mut image = InlineImage::new_prepared(source, &picker, VIEWPORT.width)?;
         assert_eq!(image.height(), IMAGE_HEIGHT);
         let mut terminal = Terminal::new(TestBackend::new(8, 8))?;

--- a/maki-ui/src/terminal_image.rs
+++ b/maki-ui/src/terminal_image.rs
@@ -307,16 +307,16 @@ mod tests {
         let mut png = Cursor::new(Vec::new());
         DynamicImage::new_rgb8(IMAGE_WIDTH.into(), IMAGE_HEIGHT.into())
             .write_to(&mut png, ImageFormat::Png)?;
-        let source = ImageSource {
-            media_type: ImageMediaType::Png,
-            data: STANDARD
+        let source = ImageSource::new(
+            ImageMediaType::Png,
+            STANDARD
                 .encode(if malformed {
                     MALFORMED_IMAGE
                 } else {
                     png.get_ref()
                 })
                 .into(),
-        };
+        );
         #[allow(deprecated)]
         let mut picker = Picker::from_fontsize(FontSize::new(1, 1));
         picker.set_protocol_type(ProtocolType::Halfblocks);


### PR DESCRIPTION
A screenshot pasted at full size went to the API untouched, and Anthropic caps every dimension at 2000px once a request carries many images, so the 400 it answered with came back on every later turn too: the image sits in history, and nothing in the session can ever be sent again.

`adapt_images_for_model` is the one place all images pass on their way to the wire, whatever created them (paste, file attach, tool result, ACP, SDK), so it now also shrinks anything over 1568px or 3MB, replaces a payload we cannot decode with a note, and evicts the oldest images past the hundred a request may carry. Sessions already poisoned repair themselves on the next turn, since the pixels in history are left alone and only the copy going out is rewritten.

The cheap path stays cheap: dimensions come from a 192KB base64 prefix instead of the whole payload, and a repair is remembered by pointer on the interned string, so an oversized image is decoded once per process and not once per turn.

1568 rather than the 8000 a single image is allowed, because it sits under the many-image cap, holds on every provider, and Anthropic downscales past it server side anyway, so it costs fewer tokens as well.