### PR TITLE
fix(agent): stop sizing the output budget off the prompt estimate

### DIFF
--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -279,7 +279,7 @@ async fn new_session(
         params,
         req.cwd,
         None,
-        Vec::new(),
+        InitialHistory::default(),
         mcp,
         project_config,
         None,
@@ -331,7 +331,10 @@ async fn load_session(
         params,
         req.cwd,
         Some(session_ref),
-        restored.history,
+        InitialHistory {
+            messages: restored.history,
+            context_size: restored.context_size,
+        },
         mcp,
         project_config,
         restored_cost,
@@ -352,7 +355,7 @@ fn start_session(
     params: &AcpParams,
     cwd: PathBuf,
     session_id: Option<SessionRef>,
-    history: Vec<Message>,
+    initial: InitialHistory,
     mcp: Option<McpHandle>,
     project_config: ProjectConfig,
     initial_cost: Option<f64>,
@@ -383,7 +386,8 @@ fn start_session(
         mcp_handle: mcp.clone(),
         initial_wd: cwd.clone(),
         session_id,
-        initial_history: history,
+        initial_history: initial.messages,
+        initial_context_size: initial.context_size,
         yolo: params.yolo,
         system_prompt_override: None,
         append_system_prompt: None,
@@ -594,12 +598,22 @@ async fn close_session(srv: &mut Server, reason: SessionEndReason) {
     }
 }
 
+/// The transcript a session starts from, with the provider's own count for it.
+/// Paired so a resumed session cannot get its history while its gauge falls
+/// back to estimating that same history.
+#[derive(Default)]
+struct InitialHistory {
+    messages: Vec<Message>,
+    context_size: u32,
+}
+
 #[derive(Debug)]
 struct Restored {
     history: Vec<Message>,
     /// Only set when the session recorded an absolute cwd.
     cwd: Option<PathBuf>,
     usage: TokenUsage,
+    context_size: u32,
     by_model: HashMap<String, StoredTokenUsage>,
     model: String,
 }
@@ -632,6 +646,7 @@ fn load_history_from(
     Ok(Restored {
         cwd: recorded,
         usage: session.token_usage,
+        context_size: session.meta.context_size,
         by_model: session.usage_by_model().clone(),
         model: session.model.clone(),
         history: session.take_messages(),

--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -1,15 +1,15 @@
 use std::env;
 
-use maki_config::{AgentConfig, CompactionBuffer};
+use maki_config::AgentConfig;
 use maki_providers::{
-    ContentBlock, IMAGE_PLACEHOLDER, Message, Model, RequestOptions, Role, StreamResponse,
-    TokenUsage,
+    ContentBlock, ContextGauge, IMAGE_PLACEHOLDER, Message, Model, RequestOptions, Role,
+    StreamResponse, TokenUsage,
 };
 use maki_storage::id::SessionRef;
 use tracing::info;
 
 use super::history::{History, remove_orphaned_tool_results};
-use super::streaming::{StreamError, stream_with_retry};
+use super::streaming::{StreamError, StreamRequest, min_output, stream_with_retry};
 use crate::cancel::CancelToken;
 use crate::prompt::COMPACTION_USER;
 use crate::{AgentError, AgentEvent, DoneReason, EventSender, TurnCompleteEvent};
@@ -21,6 +21,10 @@ const TOOL_RESULT_PLACEHOLDER: &str = "[tool result]";
 /// cheap ones, so one giant MCP dump could sit in the protected tail and blow
 /// the window on every retry.
 const RECENT_TOOL_RESULT_BUDGET: usize = 64 * 1024;
+/// A summary runs to a few thousand tokens. Giving compaction the full turn
+/// budget would reserve tens of thousands it cannot use, on the one request
+/// already sent under the most context pressure a session ever sees.
+const SUMMARY_OUTPUT_BUDGET: u32 = 16_384;
 
 fn normalize(text: Option<&str>) -> Option<&str> {
     text.map(str::trim).filter(|t| !t.is_empty())
@@ -84,18 +88,23 @@ pub(super) async fn compact_history(
 
     for attempt in 0..max_attempts {
         match stream_with_retry(
-            provider,
-            model,
-            &compaction_history,
-            crate::prompt::COMPACTION_SYSTEM,
-            &empty_tools,
+            StreamRequest {
+                provider,
+                model,
+                messages: &compaction_history,
+                system: crate::prompt::COMPACTION_SYSTEM,
+                tools: &empty_tools,
+                opts: RequestOptions::default(),
+                output_budget: SUMMARY_OUTPUT_BUDGET,
+                session_id,
+            },
+            // A stripped, collapsed rewrite of the transcript, far smaller than
+            // it. Sizing this request as the session would trim the
+            // summariser's budget by the weight of the messages it is deleting,
+            // and its measurement describes a prompt the session never had.
+            None,
             event_tx,
             cancel,
-            RequestOptions::default(),
-            // The compaction prompt is built here, so the estimate is all we
-            // have and the session's measured size describes other messages.
-            0,
-            session_id,
         )
         .await
         {
@@ -167,16 +176,19 @@ fn finish_compact(
     Ok(response.usage)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn compact(
     provider: &dyn maki_providers::provider::Provider,
     model: &Model,
     history: &mut History,
+    gauge: &mut ContextGauge,
     event_tx: &EventSender,
     config: &AgentConfig,
     instructions: Option<&str>,
     session_id: Option<&SessionRef>,
 ) -> Result<(), AgentError> {
     let cancel = CancelToken::none();
+    let size_before = gauge.size();
     let usage = compact_history(
         provider,
         model,
@@ -192,12 +204,13 @@ pub async fn compact(
     if let Some(post) = normalize(config.post_compaction_instructions.as_deref()) {
         history.push(Message::synthetic(post.to_string()));
     }
+    gauge.reset(history.as_slice());
 
-    // There is no running context gauge on the manual `/compact` path, so the
-    // summariser stands in for it: what it read is the size before, what it
-    // wrote is the size after.
-    let context_size_before = usage.total_input();
-    let context_size_after = usage.output;
+    // The summariser read a subset of the session's prompt, so its own count is
+    // a floor on the size before, and the only number a gauge that has not seen
+    // a turn yet can offer.
+    let context_size_before = size_before.max(usage.total_input());
+    let context_size_after = gauge.size();
     event_tx.send(AgentEvent::CompactionDone {
         context_size_before,
         context_size_after,
@@ -219,11 +232,26 @@ pub async fn compact(
     Ok(())
 }
 
-pub(super) fn is_overflow(usage: &TokenUsage, model: &Model, buffer: CompactionBuffer) -> bool {
-    let usable = model
-        .context_window
-        .saturating_sub(buffer.resolve(model.context_window));
-    usage.context_tokens() >= usable
+/// Context held back from the transcript.
+///
+/// Never below [`min_output`], the floor a request may ask for, so under this
+/// threshold the window still houses the prompt and an answer and a server
+/// checking `prompt + max_tokens <= context_window` has nothing to object to.
+/// That floor tracks the model's own cap, or a small-window model would compact
+/// itself over output tokens it could never emit.
+///
+/// Reserving a whole [`AgentConfig::max_turn_output`] would guarantee more and
+/// cost more: on a small window that is half the context, and compacting that
+/// early hurts worse than the odd turn whose output budget gets trimmed.
+pub(super) fn reserved(model: &Model, config: &AgentConfig) -> u32 {
+    config
+        .compaction_buffer
+        .resolve(model.context_window)
+        .max(min_output(model))
+}
+
+pub(super) fn is_overflow(context_tokens: u32, model: &Model, config: &AgentConfig) -> bool {
+    context_tokens >= model.context_window.saturating_sub(reserved(model, config))
 }
 
 fn strip_images(messages: &mut [Message]) {
@@ -319,6 +347,7 @@ mod tests {
 
     use super::*;
     use crate::AgentConfig;
+    use maki_config::CompactionBuffer;
 
     const CONFIG_EXTRA: &str = "Record anything that belongs in plan.md";
     const REQUEST_EXTRA: &str = "Keep the failing test names";
@@ -406,14 +435,53 @@ mod tests {
         }
     }
 
+    async fn summarize(
+        provider: &MockProvider,
+        history: &mut History,
+        gauge: &mut ContextGauge,
+        config: &AgentConfig,
+        instructions: Option<&str>,
+    ) -> Result<(), AgentError> {
+        let (raw_tx, _rx) = flume::unbounded();
+        compact(
+            provider,
+            &default_model(),
+            history,
+            gauge,
+            &EventSender::new(raw_tx, 0),
+            config,
+            instructions,
+            None,
+        )
+        .await
+    }
+
+    async fn summarize_history(
+        provider: &MockProvider,
+        history: &mut History,
+        carry_len: usize,
+        session_id: Option<&SessionRef>,
+    ) {
+        let (raw_tx, _rx) = flume::unbounded();
+        compact_history(
+            provider,
+            &default_model(),
+            history,
+            &EventSender::new(raw_tx, 0),
+            &CancelToken::none(),
+            &AgentConfig::default(),
+            None,
+            carry_len,
+            session_id,
+        )
+        .await
+        .unwrap();
+    }
+
     #[test]
     fn compact_replaces_history_with_summary() {
         smol::block_on(async {
-            let provider: std::sync::Arc<dyn Provider> = std::sync::Arc::new(MockProvider::new(
-                vec![Ok(text_response(StopReason::EndTurn))],
-            ));
-            let model = default_model();
-            let (raw_tx, _rx) = flume::unbounded();
+            let provider = MockProvider::new(vec![Ok(text_response(StopReason::EndTurn))]);
             let mut history = History::new(vec![
                 Message::user("first".into()),
                 Message {
@@ -425,13 +493,11 @@ mod tests {
                 },
             ]);
 
-            compact(
-                &*provider,
-                &model,
+            summarize(
+                &provider,
                 &mut history,
-                &EventSender::new(raw_tx, 0),
+                &mut ContextGauge::default(),
                 &AgentConfig::default(),
-                None,
                 None,
             )
             .await
@@ -441,6 +507,81 @@ mod tests {
             assert_eq!(msgs.len(), 2);
             assert!(matches!(msgs[0].role, Role::User));
             assert!(matches!(msgs[1].role, Role::Assistant));
+        });
+    }
+
+    const SUMMARISED_PROMPT: u32 = 150_000;
+
+    /// The measurement the gauge holds is of the transcript compaction just
+    /// deleted, so left in place it sizes every later turn against a session
+    /// that no longer exists.
+    #[test]
+    fn compact_leaves_the_gauge_describing_the_summary() {
+        smol::block_on(async {
+            let provider = MockProvider::new(vec![Ok(StreamResponse {
+                usage: TokenUsage {
+                    input: SUMMARISED_PROMPT,
+                    ..Default::default()
+                },
+                ..text_response(StopReason::EndTurn)
+            })]);
+            let mut history = History::new(vec![Message::user("first".into())]);
+            let mut gauge = ContextGauge::restored(SUMMARISED_PROMPT);
+
+            summarize(
+                &provider,
+                &mut history,
+                &mut gauge,
+                &AgentConfig::default(),
+                None,
+            )
+            .await
+            .unwrap();
+
+            assert!(
+                gauge.size() < SUMMARISED_PROMPT,
+                "the gauge still sizes the session by the transcript it summarized away"
+            );
+        });
+    }
+
+    /// The summariser reads a stripped, collapsed subset of the transcript, so
+    /// its count is well under the session's real prompt. Left in the gauge by
+    /// a compaction that then failed, it reads as a session with room to spare
+    /// and silences the threshold that would have tried again.
+    #[test]
+    fn a_failed_compaction_leaves_the_gauge_alone() {
+        smol::block_on(async {
+            let provider = MockProvider::new(vec![Ok(StreamResponse {
+                message: Message {
+                    role: Role::Assistant,
+                    content: Vec::new(),
+                    ..Default::default()
+                },
+                usage: TokenUsage {
+                    input: SUMMARISED_PROMPT / 2,
+                    ..Default::default()
+                },
+                stop_reason: Some(StopReason::EndTurn),
+            })]);
+            let mut history = History::new(vec![Message::user("first".into())]);
+            let mut gauge = ContextGauge::restored(SUMMARISED_PROMPT);
+
+            summarize(
+                &provider,
+                &mut history,
+                &mut gauge,
+                &AgentConfig::default(),
+                None,
+            )
+            .await
+            .expect_err("empty summary must fail");
+
+            assert_eq!(
+                gauge.size(),
+                SUMMARISED_PROMPT,
+                "the summariser's own prompt was written over the session's size"
+            );
         });
     }
 
@@ -459,15 +600,12 @@ mod tests {
             })]);
             const KEPT: &str = "first";
             let mut history = History::new(vec![Message::user(KEPT.into())]);
-            let (raw_tx, _rx) = flume::unbounded();
 
-            let err = compact(
+            let err = summarize(
                 &provider,
-                &default_model(),
                 &mut history,
-                &EventSender::new(raw_tx, 0),
+                &mut ContextGauge::default(),
                 &AgentConfig::default(),
-                None,
                 None,
             )
             .await
@@ -486,21 +624,18 @@ mod tests {
         smol::block_on(async {
             let provider = MockProvider::new(vec![Ok(text_response(StopReason::EndTurn))]);
             let mut history = History::new(vec![Message::user("work".into())]);
-            let (raw_tx, _rx) = flume::unbounded();
             let config = AgentConfig {
                 compaction_instructions: Some(CONFIG_EXTRA.into()),
                 post_compaction_instructions: Some(POST.into()),
                 ..Default::default()
             };
 
-            compact(
+            summarize(
                 &provider,
-                &default_model(),
                 &mut history,
-                &EventSender::new(raw_tx, 0),
+                &mut ContextGauge::default(),
                 &config,
                 Some(REQUEST_EXTRA),
-                None,
             )
             .await
             .unwrap();
@@ -570,21 +705,7 @@ mod tests {
                 ..Default::default()
             };
             let mut history = History::new(vec![orphan, chat_image]);
-            let (raw_tx, _rx) = flume::unbounded();
-
-            compact_history(
-                &provider,
-                &default_model(),
-                &mut history,
-                &EventSender::new(raw_tx, 0),
-                &CancelToken::none(),
-                &AgentConfig::default(),
-                None,
-                0,
-                None,
-            )
-            .await
-            .unwrap();
+            summarize_history(&provider, &mut history, 0, None).await;
 
             let requests = provider.requests.lock().unwrap();
             let request = &requests[0];
@@ -633,7 +754,7 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(
-            is_overflow(&usage, &model, AgentConfig::default().compaction_buffer),
+            is_overflow(usage.context_tokens(), &model, &AgentConfig::default()),
             expected
         );
     }
@@ -641,13 +762,15 @@ mod tests {
     #[test_case(CompactionBuffer::Tokens(10_000), 53_999, false ; "explicit_tokens_below")]
     #[test_case(CompactionBuffer::Tokens(10_000), 54_000, true  ; "explicit_tokens_honored")]
     #[test_case(CompactionBuffer::Percent(50),    32_000, true  ; "explicit_percent_at_threshold")]
+    // A buffer under the output floor cannot leave a turn room to answer.
+    #[test_case(CompactionBuffer::Tokens(1_000),  60_000, true  ; "buffer_below_the_output_floor_is_raised")]
     fn overflow_with_explicit_buffer(buffer: CompactionBuffer, input: u32, expected: bool) {
         let model = small_context_model(64_000);
-        let usage = TokenUsage {
-            input,
-            ..Default::default()
+        let config = AgentConfig {
+            compaction_buffer: buffer,
+            ..AgentConfig::default()
         };
-        assert_eq!(is_overflow(&usage, &model, buffer), expected);
+        assert_eq!(is_overflow(input, &model, &config), expected);
     }
 
     #[test]
@@ -776,21 +899,7 @@ mod tests {
                 },
                 Message::user("prompt".into()),
             ]);
-            let (raw_tx, _rx) = flume::unbounded();
-
-            compact_history(
-                &provider,
-                &default_model(),
-                &mut history,
-                &EventSender::new(raw_tx, 0),
-                &CancelToken::none(),
-                &AgentConfig::default(),
-                None,
-                0,
-                None,
-            )
-            .await
-            .unwrap();
+            summarize_history(&provider, &mut history, 0, None).await;
 
             let requests = provider.requests.lock().unwrap();
             assert_eq!(requests.len(), 3);
@@ -826,21 +935,7 @@ mod tests {
                 Message::user("first".into()),
                 Message::user("second".into()),
             ]);
-            let (raw_tx, _rx) = flume::unbounded();
-
-            compact_history(
-                &provider,
-                &default_model(),
-                &mut history,
-                &EventSender::new(raw_tx, 0),
-                &CancelToken::none(),
-                &AgentConfig::default(),
-                None,
-                0,
-                None,
-            )
-            .await
-            .unwrap();
+            summarize_history(&provider, &mut history, 0, None).await;
 
             let requests = provider.requests.lock().unwrap();
             assert!(requests[1].len() < requests[0].len(), "{NO_COLLAPSE_MSG}");
@@ -854,22 +949,8 @@ mod tests {
         smol::block_on(async {
             let provider = MockProvider::new(vec![Ok(text_response(StopReason::EndTurn))]);
             let mut history = History::new(vec![Message::user("work".into())]);
-            let (raw_tx, _rx) = flume::unbounded();
             let session = SessionRef::generate();
-
-            compact_history(
-                &provider,
-                &default_model(),
-                &mut history,
-                &EventSender::new(raw_tx, 0),
-                &CancelToken::none(),
-                &AgentConfig::default(),
-                None,
-                0,
-                Some(&session),
-            )
-            .await
-            .unwrap();
+            summarize_history(&provider, &mut history, 0, Some(&session)).await;
 
             let sessions = provider.sessions.lock().unwrap();
             assert_eq!(sessions[0].as_deref(), Some(session.as_str()));
@@ -888,21 +969,7 @@ mod tests {
                 Message::user("first".into()),
                 Message::user(CARRIED.into()),
             ]);
-            let (raw_tx, _rx) = flume::unbounded();
-
-            compact_history(
-                &provider,
-                &default_model(),
-                &mut history,
-                &EventSender::new(raw_tx, 0),
-                &CancelToken::none(),
-                &AgentConfig::default(),
-                None,
-                1,
-                None,
-            )
-            .await
-            .unwrap();
+            summarize_history(&provider, &mut history, 1, None).await;
 
             let carried = |messages: &[Message]| {
                 messages
@@ -932,21 +999,7 @@ mod tests {
                     ..Default::default()
                 },
             ]);
-            let (raw_tx, _rx) = flume::unbounded();
-
-            compact_history(
-                &provider,
-                &default_model(),
-                &mut history,
-                &EventSender::new(raw_tx, 0),
-                &CancelToken::none(),
-                &AgentConfig::default(),
-                None,
-                0,
-                None,
-            )
-            .await
-            .unwrap();
+            summarize_history(&provider, &mut history, 0, None).await;
 
             let requests = provider.requests.lock().unwrap();
             assert!(requests[0][0].is_observation());

--- a/maki-agent/src/agent/mod.rs
+++ b/maki-agent/src/agent/mod.rs
@@ -13,6 +13,4 @@ pub use instructions::{
     Instructions, LoadedInstructions, build_system_prompt, find_subdirectory_instructions,
     is_instruction_file, load_instruction_text, load_instructions,
 };
-pub use run::{
-    Agent, AgentParams, AgentRunParams, estimate_message_tokens, resolve_compaction_model,
-};
+pub use run::{Agent, AgentParams, AgentRunParams, resolve_compaction_model};

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -7,14 +7,14 @@ use tracing::{error, info, warn};
 
 use maki_providers::provider::Provider;
 use maki_providers::{
-    ContentBlock, IMAGE_PLACEHOLDER, Message, Model, RequestOptions, Role, StopReason,
-    StreamResponse, TokenUsage,
+    ContentBlock, ContextGauge, IMAGE_PLACEHOLDER, Message, Model, RequestOptions, Role,
+    StopReason, StreamResponse,
 };
 
 use super::compaction;
 use super::history::{History, sanitize_cancelled_history};
 use super::instructions::LoadedInstructions;
-use super::streaming::{StreamError, stream_with_retry};
+use super::streaming::{StreamError, StreamRequest, stream_with_retry};
 use super::tool_dispatch::{self, RecentCalls};
 use crate::cancel::{CancelMap, CancelToken};
 use crate::mcp::McpSession;
@@ -89,6 +89,10 @@ pub struct AgentParams {
 
 pub struct AgentRunParams<'h> {
     pub history: &'h mut History,
+    /// Borrowed from the same owner as `history`, since it describes that
+    /// transcript. A gauge rebuilt per run would forget every measurement the
+    /// session made and fall back to the estimate.
+    pub gauge: &'h mut ContextGauge,
     pub system: String,
     pub event_tx: EventSender,
     pub tools: RequestTools,
@@ -98,6 +102,7 @@ pub struct Agent<'h> {
     provider: Arc<dyn Provider>,
     model: Arc<Model>,
     history: &'h mut History,
+    gauge: &'h mut ContextGauge,
     system: String,
     event_tx: EventSender,
     tools: RequestTools,
@@ -106,7 +111,6 @@ pub struct Agent<'h> {
     interrupt_source: Option<Arc<dyn InterruptSource>>,
     cancel: CancelToken,
     ledger: Arc<RunLedger>,
-    context_size: u32,
     num_turns: u32,
     recent_calls: RecentCalls,
     auto_compact: bool,
@@ -144,6 +148,7 @@ impl<'h> Agent<'h> {
             permissions: params.permissions,
             timeouts: params.timeouts,
             history: run.history,
+            gauge: run.gauge,
             system: run.system,
             event_tx: run.event_tx,
             tools: run.tools,
@@ -152,7 +157,6 @@ impl<'h> Agent<'h> {
             interrupt_source: None,
             cancel: CancelToken::none(),
             ledger: params.ledger,
-            context_size: 0,
             num_turns: 0,
             recent_calls: RecentCalls::new(),
             auto_compact: compaction::auto_compact_enabled(),
@@ -253,7 +257,11 @@ impl<'h> Agent<'h> {
             maki_otel::emit::user_prompt(&message);
         }
 
-        self.seed_context_size();
+        self.gauge.seed_if_empty(
+            self.history.as_slice(),
+            &self.system,
+            Self::request_tools(&self.tools, self.mcp.as_ref()).as_ref(),
+        );
 
         // Every frontend enters here, so busy time is measured here; a turn
         // that failed was still busy.
@@ -273,24 +281,6 @@ impl<'h> Agent<'h> {
         self.emit_done(reason)?;
 
         Ok(reason)
-    }
-
-    /// A resumed session can already fill the window, and the gauge only
-    /// learns the real size from a response, so without a seed the first
-    /// request goes out unguarded and comes back rejected. A chars/4 estimate
-    /// is a floor, good enough until the first response replaces it with the
-    /// provider's own count. Seeded here rather than in `new` because the MCP
-    /// schemas, the largest per-request addition on a heavy server set, are
-    /// only attached by the builder afterwards.
-    fn seed_context_size(&mut self) {
-        if self.context_size > 0 {
-            return;
-        }
-        self.context_size = estimate_prompt_tokens(
-            self.history.as_slice(),
-            &self.system,
-            self.request_tools().as_ref(),
-        );
     }
 
     fn push_input_context(&mut self, preamble: Vec<Message>) {
@@ -319,17 +309,20 @@ impl<'h> Agent<'h> {
         }
     }
 
-    /// `self.tools` holds base tools only; the MCP part is recomputed here
-    /// every turn so `tool_search` loads and late-connecting servers take
-    /// effect on the next request.
-    fn request_tools(&self) -> Cow<'_, Value> {
-        match &self.mcp {
+    /// `tools` holds base tools only. The MCP part is recomputed here every
+    /// turn, so `tool_search` loads and late-connecting servers take effect on
+    /// the next request.
+    ///
+    /// Takes the two fields rather than `&self`, so a caller can hold the
+    /// result and still reach `&mut self.gauge`.
+    fn request_tools<'t>(tools: &'t RequestTools, mcp: Option<&McpSession>) -> Cow<'t, Value> {
+        match mcp {
             Some(mcp) => {
-                let mut tools = self.tools.definitions().clone();
+                let mut tools = tools.definitions().clone();
                 mcp.extend_tools(&mut tools);
                 Cow::Owned(tools)
             }
-            None => Cow::Borrowed(self.tools.definitions()),
+            None => Cow::Borrowed(tools.definitions()),
         }
     }
 
@@ -337,18 +330,21 @@ impl<'h> Agent<'h> {
         if self.cancel.is_cancelled() {
             return Err(AgentError::Cancelled);
         }
-        let tools = self.request_tools();
+        let tools = Self::request_tools(&self.tools, self.mcp.as_ref());
         let response = match stream_with_retry(
-            &*self.provider,
-            &self.model,
-            self.history.as_slice(),
-            &self.system,
-            tools.as_ref(),
+            StreamRequest {
+                provider: &*self.provider,
+                model: &self.model,
+                messages: self.history.as_slice(),
+                system: &self.system,
+                tools: tools.as_ref(),
+                opts: self.opts,
+                output_budget: self.config.max_turn_output,
+                session_id: self.session_id.as_ref(),
+            },
+            Some(self.gauge),
             &self.event_tx,
             &self.cancel,
-            self.opts,
-            self.context_size,
-            self.session_id.as_ref(),
         )
         .await
         {
@@ -397,14 +393,14 @@ impl<'h> Agent<'h> {
             "API response received"
         );
 
-        self.context_size = response.usage.total_input();
+        // The gauge already took the provider's own count inside the stream.
         self.emit_turn_complete(&response)?;
 
         if has_tools {
             let history_len_before = self.history.len();
             self.process_tool_calls(response).await?;
-            self.context_size +=
-                estimate_message_tokens(&self.history.as_slice()[history_len_before..]);
+            self.gauge
+                .append(&self.history.as_slice()[history_len_before..]);
         } else {
             if response.message.first_text_content().is_some() {
                 self.history.push(response.message);
@@ -450,7 +446,7 @@ impl<'h> Agent<'h> {
         }
         self.overflow_recoveries += 1;
         warn!(
-            context_size = self.context_size,
+            context_size = self.gauge.size(),
             "prompt overflowed below the compaction threshold"
         );
         self.compact_now().await?;
@@ -494,7 +490,7 @@ impl<'h> Agent<'h> {
                 usage: response.usage,
                 model: self.model.id.clone(),
                 cost,
-                context_size: Some(self.context_size),
+                context_size: Some(self.gauge.size()),
                 context_window: self.model.context_window,
             })))
     }
@@ -512,7 +508,7 @@ impl<'h> Agent<'h> {
             usage: totals.usage,
             cost: totals.cost,
             list_cost: totals.list_cost,
-            context_size: self.context_size,
+            context_size: self.gauge.size(),
             context_window: self.model.context_window,
             num_turns: self.num_turns,
             reason,
@@ -584,25 +580,17 @@ impl<'h> Agent<'h> {
     }
 
     async fn try_auto_compact(&mut self) -> Result<(), AgentError> {
-        if !self.auto_compact
-            || !compaction::is_overflow(
-                &TokenUsage {
-                    input: self.context_size,
-                    ..Default::default()
-                },
-                &self.model,
-                self.config.compaction_buffer,
-            )
-        {
+        let context_size = self.gauge.size();
+        if !self.auto_compact || !compaction::is_overflow(context_size, &self.model, &self.config) {
             return Ok(());
         }
-        info!(context_size = self.context_size, "auto-compacting");
+        info!(context_size, "auto-compacting");
         self.compact_now().await
     }
 
     async fn compact_now(&mut self) -> Result<(), AgentError> {
         self.event_tx.send(AgentEvent::AutoCompacting {
-            context_size: self.context_size,
+            context_size: self.gauge.size(),
             context_window: self.model.context_window,
         })?;
         self.do_compact(None).await
@@ -631,7 +619,7 @@ impl<'h> Agent<'h> {
         instructions: Option<&str>,
         carry_len: usize,
     ) -> Result<(), AgentError> {
-        let context_size_before = self.context_size;
+        let context_size_before = self.gauge.size();
         let (compact_provider, compact_model) = resolve_compaction_model(
             &self.provider,
             &self.model,
@@ -657,13 +645,11 @@ impl<'h> Agent<'h> {
         let compact_list_cost = compact_model.list_cost(&compaction_usage, self.opts.fast);
         self.ledger
             .add(compaction_usage, compact_cost, compact_list_cost);
-        // The summary the model just wrote is all the next call will see, plus
-        // whatever was carried past it, which the summariser never read and so
-        // never counted.
+        // The measurement the gauge holds describes the transcript that was
+        // just summarized away, so what is left is all it may count.
+        self.gauge.reset(self.history.as_slice());
+        let context_size_after = self.gauge.size();
         let carry_from = self.history.len().saturating_sub(carry_len);
-        let context_size_after = compaction_usage.output
-            + estimate_message_tokens(&self.history.as_slice()[carry_from..]);
-        self.context_size = context_size_after;
         self.rollback_len = carry_from;
         self.carry_from = carry_from;
         self.event_tx.send(AgentEvent::CompactionDone {
@@ -715,67 +701,6 @@ impl<'h> Agent<'h> {
         Ok(true)
     }
 }
-
-const CHARS_PER_TOKEN: usize = 4;
-/// Charged flat per image, because the only thing in reach is the encoded
-/// blob, whose size tracks compression and not the tile count the provider
-/// bills. A screenshot at the sizes [`maki_providers::adapt_images_for_model`]
-/// allows lands near this; counting nothing at all made the transcripts most
-/// likely to overflow the ones the estimate understated the most.
-const TOKENS_PER_IMAGE: u32 = 1_500;
-
-/// Counts message content only. The system prompt and the tool schemas, a five
-/// figure baseline on a full tool set, stay invisible here, so never let this
-/// replace a context size the provider measured.
-pub fn estimate_message_tokens(messages: &[Message]) -> u32 {
-    if messages.is_empty() {
-        return 0;
-    }
-    let (total_bytes, images) =
-        messages
-            .iter()
-            .flat_map(|m| &m.content)
-            .fold((0usize, 0u32), |(bytes, images), block| match block {
-                ContentBlock::Text { text } => (bytes + text.len(), images),
-                ContentBlock::ToolResult { content, .. } => (bytes + content.len(), images),
-                ContentBlock::ToolUse { input, .. } => (bytes + json_len(input), images),
-                ContentBlock::Thinking { thinking, .. } => (bytes + thinking.len(), images),
-                ContentBlock::Image { .. } => (bytes, images + 1),
-                ContentBlock::RedactedThinking { .. } => (bytes, images),
-            });
-    (total_bytes.max(CHARS_PER_TOKEN) / CHARS_PER_TOKEN) as u32 + images * TOKENS_PER_IMAGE
-}
-
-/// [`estimate_message_tokens`] plus what it leaves out, the system prompt and
-/// the serialized tool schemas. A server enforcing
-/// `prompt + max_tokens <= context_window` counts those against the same
-/// budget.
-pub fn estimate_prompt_tokens(messages: &[Message], system: &str, tools: &Value) -> u32 {
-    let overhead = (system.len() + json_len(tools)) / CHARS_PER_TOKEN;
-    estimate_message_tokens(messages).saturating_add(overhead as u32)
-}
-
-/// Serialized length without the string: the estimator runs over the whole
-/// transcript plus the tool catalog before every request, and only ever wants
-/// the byte count.
-fn json_len(value: &Value) -> usize {
-    struct Counter(usize);
-    impl std::io::Write for Counter {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            self.0 += buf.len();
-            Ok(buf.len())
-        }
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-    }
-    let mut counter = Counter(0);
-    match serde_json::to_writer(&mut counter, value) {
-        Ok(()) => counter.0,
-        Err(_) => 0,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
@@ -940,6 +865,8 @@ mod tests {
         }
     }
 
+    /// The leaked gauge outlives the agent that borrows it, so no caller here
+    /// has to own one.
     fn make_agent(
         provider: impl Provider + 'static,
         history: &mut History,
@@ -975,6 +902,7 @@ mod tests {
             },
             AgentRunParams {
                 history,
+                gauge: Box::leak(Box::default()),
                 system: "system".into(),
                 event_tx: EventSender::new(raw_tx, 0),
                 tools: RequestTools::default(),
@@ -1360,9 +1288,9 @@ mod tests {
             };
             let mut history = History::new(vec![Message::user("go".into())]);
             let (mut agent, event_rx) = make_agent(MockProvider::new(responses), &mut history);
+            *agent.gauge = ContextGauge::restored(context_size);
             agent.model = Arc::new(small_context_model(200_000, 8_192));
             agent.auto_compact = enabled;
-            agent.context_size = context_size;
             agent.try_auto_compact().await.unwrap();
             drop(agent);
             assert_eq!(

--- a/maki-agent/src/agent/streaming.rs
+++ b/maki-agent/src/agent/streaming.rs
@@ -2,22 +2,26 @@ use std::time::{Duration, Instant};
 
 use maki_providers::provider::Provider;
 use maki_providers::retry::{MAX_TIMEOUT_RETRIES, RetryState};
-use maki_providers::{ContentBlock, Message, Model, ProviderEvent, RequestOptions, StreamResponse};
+use maki_providers::{
+    ContentBlock, ContextGauge, Message, Model, Overflow, ProviderEvent, RequestOptions,
+    StreamResponse, estimate_prompt_tokens,
+};
 use maki_storage::id::SessionRef;
 use serde_json::Value;
 use tracing::warn;
 
-use super::run::estimate_prompt_tokens;
 use crate::cancel::CancelToken;
 use crate::{AgentError, AgentEvent, EventSender};
 
 const FUNCTIONS_PREFIX: &str = "functions.";
-/// Floor for the clamp below, never applied above the model's own cap.
+/// Floor for the budget below, never applied above the model's own cap.
 /// Anthropic derives the thinking budget from `max_tokens` (half of it, at
-/// least 1024) and rejects a request where the two are equal, so clamping the
+/// least 1024) and rejects a request where the two are equal, so flooring the
 /// cap all the way down to 1024 would trade an overflow for a 400.
 const MIN_OUTPUT_TOKENS: u32 = 4096;
-
+/// Each round halves the ask, or lands exactly when the server quoted its own
+/// numbers, so two is enough for both. Past that the prompt is the problem.
+const MAX_BUDGET_RETRIES: u32 = 2;
 /// GPT models sometimes emit `functions.<name>`, a Codex training habit.
 /// Stripped here at the provider boundary so no raw name enters the agent;
 /// the batch plugin mirrors the rule in Lua.
@@ -91,52 +95,112 @@ impl From<StreamError> for AgentError {
     }
 }
 
-/// Servers like vLLM reject `prompt + max_tokens > window` even when the
-/// prompt alone fits. Returns the reduced cap, or `None` when the model's own
-/// cap already fits.
+/// The `max_tokens` one turn asks for.
 ///
-/// `prompt_tokens` must not be the chars/4 estimate alone. That estimate is a
-/// floor, and on code or JSON it lands well under the real count, which leaves
-/// `remaining` too generous and skips the clamp on exactly the long sessions
-/// this exists for. The caller's measured count from the last response is the
-/// better number whenever it is larger.
-fn clamped_output_tokens(model: &Model, prompt_tokens: u32) -> Option<u32> {
-    let max_output = model.max_output_tokens?;
-    let remaining = model.context_window.saturating_sub(prompt_tokens);
-    // The `min` keeps the floor from raising the cap over what the model
-    // declared, since it would reject a number it never offered.
-    (max_output > remaining).then(|| remaining.max(MIN_OUTPUT_TOKENS).min(max_output))
+/// Deliberately not "everything the window can spare": that ties `max_tokens`
+/// to a prompt estimate, and an estimate that reads low buys a rejection from
+/// every server enforcing `prompt + max_tokens <= context_window`. A turn asks
+/// for what a turn needs, so the size the server checks is one maki chose.
+///
+/// Thinking is the exception, and not a small one. A dialect spends at most
+/// half its `max_tokens` on thinking ([`Model::thinking_ceiling`]), so an
+/// effort level the user picked arrives cut down unless twice its budget fits
+/// here. On a high level that is most of the model's output cap.
+///
+/// The window clamp at the end is a backstop. Compaction reserves at least
+/// [`min_output`] ([`compaction::reserved`]), so a session that compacts on
+/// schedule only meets it when the thinking reservation is what crowds the
+/// window, and then the ceiling walks the thinking back down.
+///
+/// A model that declares no cap still gets a budget: "let the provider pick" is
+/// unbounded on the servers that most need bounding (llama.cpp hands over the
+/// rest of the window), and a size maki never set is one [`shrunk_budget`]
+/// cannot climb down from.
+///
+/// [`compaction::reserved`]: super::compaction::reserved
+fn planned_output(model: &Model, opts: RequestOptions, budget: u32, prompt: u32) -> u32 {
+    let thinking_room = opts
+        .thinking
+        .reserved_thinking(model)
+        .map_or(0, |n| n.saturating_mul(2));
+    budget
+        .max(thinking_room)
+        .min(model.max_output_tokens.unwrap_or(u32::MAX))
+        .min(model.context_window.saturating_sub(prompt))
+        .max(min_output(model))
 }
 
-#[allow(clippy::too_many_arguments)]
+/// Smallest cap a turn may be trimmed to, never above what the model declared,
+/// since it would reject a number it never offered. Compaction reserves the
+/// same floor, so a session that compacts on schedule never reaches it.
+pub(super) fn min_output(model: &Model) -> u32 {
+    MIN_OUTPUT_TOKENS.min(model.max_output_tokens.unwrap_or(MIN_OUTPUT_TOKENS))
+}
+
+/// The budget to try after a server refused the last one.
+///
+/// A server that quoted its own numbers already did the arithmetic, so the next
+/// attempt fits exactly. Without them, halving converges in a round or two.
+/// `None` means nothing above `floor` is small enough and the prompt itself has
+/// to give, which is the caller's problem.
+fn shrunk_budget(current: u32, overflow: Overflow, window: u32, floor: u32) -> Option<u32> {
+    let Overflow::Budget { prompt, limit } = overflow else {
+        return None;
+    };
+    // A quote landing at or above the budget just refused was not the
+    // arithmetic the server ran: `window` is maki's own number, and providers
+    // that resolve limits per request (catalog, opencode) override it on the
+    // way out. Halving is the honest answer then.
+    let next = match prompt.map(|p| limit.unwrap_or(window).saturating_sub(p)) {
+        Some(exact) if exact < current => exact,
+        _ => current / 2,
+    };
+    (next >= floor && next < current).then_some(next)
+}
+
+/// One request, with everything that describes it. A struct and not a dozen
+/// positional arguments, because the retry loop below re-sends it with one
+/// field changed, and a caller swapping two `&str` would not be caught.
+pub(crate) struct StreamRequest<'a> {
+    pub provider: &'a dyn Provider,
+    pub model: &'a Model,
+    pub messages: &'a [Message],
+    pub system: &'a str,
+    pub tools: &'a Value,
+    pub opts: RequestOptions,
+    /// Output tokens this kind of turn may generate. A summary needs far less
+    /// than a coding turn, so the caller decides.
+    pub output_budget: u32,
+    pub session_id: Option<&'a SessionRef>,
+}
+
+/// `gauge` is `None` for a request whose messages are not the session's, as
+/// compaction's stripped and collapsed rewrite is: neither its size nor the
+/// count it comes back with says anything about the session.
 pub(crate) async fn stream_with_retry(
-    provider: &dyn Provider,
-    model: &Model,
-    messages: &[Message],
-    system: &str,
-    tools: &Value,
+    req: StreamRequest<'_>,
+    mut gauge: Option<&mut ContextGauge>,
     event_tx: &EventSender,
     cancel: &CancelToken,
-    opts: RequestOptions,
-    measured_prompt_tokens: u32,
-    session_id: Option<&SessionRef>,
 ) -> Result<StreamResponse, StreamError> {
+    let StreamRequest {
+        provider,
+        model,
+        messages,
+        system,
+        tools,
+        opts,
+        output_budget,
+        session_id,
+    } = req;
     let opts = opts.clamped(model);
-    let prompt_tokens = estimate_prompt_tokens(messages, system, tools).max(measured_prompt_tokens);
-    let fitted = clamped_output_tokens(model, prompt_tokens).map(|max_output_tokens| {
-        warn!(
-            model = %model.id,
-            prompt_tokens,
-            context_window = model.context_window,
-            max_output_tokens,
-            "clamped max output tokens to fit the context window"
-        );
-        Model {
-            max_output_tokens: Some(max_output_tokens),
-            ..model.clone()
-        }
-    });
-    let model = fitted.as_ref().unwrap_or(model);
+    // The session's own size wins where it is larger, being a count a provider
+    // made rather than a byte estimate.
+    let measured = gauge.as_deref().map_or(0, ContextGauge::size);
+    let prompt = estimate_prompt_tokens(messages, system, tools).max(measured);
+    let floor = min_output(model);
+    let mut budget = planned_output(model, opts, output_budget, prompt);
+    let mut budget_retries = 0;
     // Rebuilding images a provider would refuse can take real time on the
     // first request of a session full of screenshots, and it all happens
     // before anything below can observe a cancel.
@@ -153,6 +217,12 @@ pub(crate) async fn stream_with_retry(
     let messages = &*adapted;
     let mut retry = RetryState::new();
     loop {
+        // The turn budget is all that moves. What the model declares stays put:
+        // the thinking a request may spend is read off the `max_tokens` this
+        // produces, so the two can never disagree, whatever a provider
+        // rewrites on the way out.
+        let fitted = model.with_turn_output(budget);
+        let model = &fitted;
         let started = Instant::now();
         let (ptx, prx) = flume::unbounded();
         let forwarder = smol::spawn({
@@ -173,6 +243,9 @@ pub(crate) async fn stream_with_retry(
             Ok(mut r) => {
                 canonicalize_tool_names(&mut r.message);
                 emit_api_request(model, &r, opts, started.elapsed());
+                if let Some(gauge) = gauge.as_deref_mut() {
+                    gauge.record(r.usage.total_input());
+                }
                 return Ok(r);
             }
             Err(AgentError::Cancelled) => return Err(StreamError::Cancelled { streamed }),
@@ -209,6 +282,37 @@ pub(crate) async fn stream_with_retry(
             }
             Err(e) => {
                 emit_api_error(model, &e, retry.attempts() + 1, started.elapsed());
+                // A budget overflow is the one rejection maki caused itself, by
+                // asking for more output than the prompt left room for. Asking
+                // for less costs nothing, so it happens here instead of falling
+                // through to the caller, whose only remedy is to summarize the
+                // session away.
+                if let Some(
+                    overflow @ Overflow::Budget {
+                        prompt: measured, ..
+                    },
+                ) = e.overflow()
+                {
+                    // The server counted the prompt maki could only estimate.
+                    if let Some(gauge) = gauge.as_deref_mut() {
+                        gauge.record(measured.unwrap_or(0));
+                    }
+                    if budget_retries < MAX_BUDGET_RETRIES
+                        && let Some(next) =
+                            shrunk_budget(budget, overflow, model.context_window, floor)
+                    {
+                        budget_retries += 1;
+                        warn!(
+                            model = %model.id,
+                            from = budget,
+                            to = next,
+                            measured_prompt = measured,
+                            "output budget did not fit the window, retrying smaller"
+                        );
+                        budget = next;
+                        continue;
+                    }
+                }
                 return Err(e.into());
             }
         }
@@ -262,7 +366,9 @@ fn error_description(error: &AgentError) -> String {
 
 #[cfg(test)]
 mod tests {
-    use maki_providers::Role;
+    use std::sync::Mutex;
+
+    use maki_providers::{Effort, Role, ThinkingConfig, TokenUsage};
     use serde_json::json;
     use test_case::test_case;
 
@@ -270,11 +376,20 @@ mod tests {
 
     const SECRET_BODY: &str = "messages.0.content: \"my private prompt\", key sk-abc";
     const WINDOW: u32 = 262_144;
-    const BIG_MAX_OUTPUT: u32 = 100_000;
+    /// The shape that started all this: the declared output cap is the whole
+    /// window, so "ask for what fits" asks for everything.
+    const HUGE_MAX_OUTPUT: u32 = WINDOW;
     const SMALL_MAX_OUTPUT: u32 = 2_048;
+    /// Half the window, as the real models declare it: `claude-sonnet-4` offers
+    /// 128k of output against a 200k window. A cap equal to the whole window
+    /// leaves no prompt small enough for `max` effort to fit beside it.
+    const DECLARED_MAX_OUTPUT: u32 = WINDOW / 2;
+    const TURN_BUDGET: u32 = 32_768;
     const SMALL_PROMPT: u32 = 1_000;
-    /// One token more than the window can spare for `BIG_MAX_OUTPUT`.
-    const CROWDING_PROMPT: u32 = WINDOW - BIG_MAX_OUTPUT + 1;
+    const EXPLICIT_THINKING: u32 = 30_000;
+    /// Less room than `TURN_BUDGET` wants.
+    const CROWDED_ROOM: u32 = 10_000;
+    const CROWDING_PROMPT: u32 = WINDOW - CROWDED_ROOM;
 
     fn model_with(max_output_tokens: Option<u32>) -> Model {
         let mut model = Model::from_spec("anthropic/claude-sonnet-4-20250514").unwrap();
@@ -283,18 +398,141 @@ mod tests {
         model
     }
 
-    #[test_case(Some(BIG_MAX_OUTPUT), SMALL_PROMPT, None; "cap_fits_inside_remaining_window")]
-    #[test_case(Some(BIG_MAX_OUTPUT), CROWDING_PROMPT, Some(WINDOW - CROWDING_PROMPT); "cap_exceeds_remaining_window")]
-    #[test_case(Some(BIG_MAX_OUTPUT), WINDOW + 1, Some(MIN_OUTPUT_TOKENS); "prompt_over_window_floors_at_minimum")]
-    #[test_case(Some(SMALL_MAX_OUTPUT), WINDOW + 1, Some(SMALL_MAX_OUTPUT); "floor_never_exceeds_the_model_cap")]
-    #[test_case(None, CROWDING_PROMPT, None; "provider_chosen_cap_is_left_alone")]
-    fn clamps_output_tokens_to_the_remaining_window(
+    fn opts_with(thinking: ThinkingConfig) -> RequestOptions {
+        RequestOptions {
+            thinking,
+            fast: false,
+        }
+    }
+
+    // The budget does not move with the prompt, so no estimate error can make
+    // the request malformed.
+    #[test_case(Some(HUGE_MAX_OUTPUT), SMALL_PROMPT, TURN_BUDGET; "budget_ignores_a_small_prompt")]
+    #[test_case(Some(HUGE_MAX_OUTPUT), WINDOW / 2, TURN_BUDGET; "budget_ignores_a_large_prompt")]
+    #[test_case(Some(SMALL_MAX_OUTPUT), SMALL_PROMPT, SMALL_MAX_OUTPUT; "the_model_cap_still_wins")]
+    // Backstop, reached only once compaction has been turned off or outrun.
+    #[test_case(Some(HUGE_MAX_OUTPUT), CROWDING_PROMPT, CROWDED_ROOM; "a_crowded_window_trims_the_budget")]
+    #[test_case(Some(HUGE_MAX_OUTPUT), WINDOW + 1, MIN_OUTPUT_TOKENS; "prompt_over_window_floors_at_minimum")]
+    #[test_case(Some(SMALL_MAX_OUTPUT), WINDOW + 1, SMALL_MAX_OUTPUT; "floor_never_exceeds_the_model_cap")]
+    // A size maki never set is one it cannot climb down from later.
+    #[test_case(None, SMALL_PROMPT, TURN_BUDGET; "an_undeclared_cap_still_gets_a_budget")]
+    fn the_output_budget_is_flat(
         max_output_tokens: Option<u32>,
         prompt_tokens: u32,
+        expected: u32,
+    ) {
+        assert_eq!(
+            planned_output(
+                &model_with(max_output_tokens),
+                opts_with(ThinkingConfig::Off),
+                TURN_BUDGET,
+                prompt_tokens
+            ),
+            expected
+        );
+    }
+
+    /// The declared model and the one a request would carry, checked on the way
+    /// out against the invariant that has to hold for every one of them:
+    /// whatever the turn or a provider does to the output cap, the thinking is
+    /// at most half the number on the wire, so the answer always has room and
+    /// no dialect is handed a budget its own `max_tokens` refuses.
+    fn fitted_with(thinking: ThinkingConfig, prompt: u32) -> (Model, Model) {
+        let declared = model_with(Some(DECLARED_MAX_OUTPUT));
+        let budget = planned_output(&declared, opts_with(thinking), TURN_BUDGET, prompt);
+        let fitted = declared.with_turn_output(budget);
+
+        let asked = fitted.output_tokens().expect("a budget is always set");
+        assert!(
+            thinking.request_thinking(&fitted).unwrap_or(0) * 2 <= asked,
+            "{thinking} thinking does not fit under a {asked} token cap"
+        );
+        (declared, fitted)
+    }
+
+    /// The regression this half of the fix exists for. A dialect can only spend
+    /// half its `max_tokens` on thinking, so a turn budget that ignored the
+    /// effort level cut `high` on a 64k-cap model from 19200 thinking tokens to
+    /// 9830. The turn asks for room instead, and the level is untouched.
+    #[test_case(ThinkingConfig::Effort(Effort::Max) ; "the_top_effort_level")]
+    #[test_case(ThinkingConfig::Budget(EXPLICIT_THINKING) ; "an_explicit_budget")]
+    fn a_turn_budget_never_rescales_the_thinking_it_makes_room_for(thinking: ThinkingConfig) {
+        let (declared, fitted) = fitted_with(thinking, SMALL_PROMPT);
+
+        assert_eq!(
+            thinking.request_thinking(&fitted),
+            thinking.reserved_thinking(&declared)
+        );
+    }
+
+    /// A window too full to hold the thinking the effort level asked for. The
+    /// reservation used to ignore the window and ask for `2 x thinking` anyway,
+    /// which Anthropic refuses with `input length and max_tokens exceed context
+    /// limit`, and maki answered a refusal it had caused itself by compacting.
+    /// On a 200k window that hit every `high` turn past 123k of prompt, well
+    /// under the 160k where compaction was due.
+    #[test_case(ThinkingConfig::Effort(Effort::Max), CROWDING_PROMPT ; "a_sliver_of_room_left")]
+    #[test_case(ThinkingConfig::Effort(Effort::Max), WINDOW + 1 ; "no_room_left_at_all")]
+    #[test_case(ThinkingConfig::Budget(EXPLICIT_THINKING), WINDOW + 1 ; "an_explicit_budget_gives_too")]
+    fn a_crowded_window_cuts_the_thinking_instead_of_the_request(
+        thinking: ThinkingConfig,
+        prompt: u32,
+    ) {
+        let (declared, fitted) = fitted_with(thinking, prompt);
+        let asked = fitted.output_tokens().expect("a budget is always set");
+        let room = WINDOW.saturating_sub(prompt);
+
+        assert!(
+            asked <= room.max(min_output(&declared)),
+            "asked for {asked} of output with {room} left in the window"
+        );
+        assert!(
+            thinking.request_thinking(&fitted) < thinking.reserved_thinking(&declared),
+            "the thinking has to give where the window cannot house it"
+        );
+    }
+
+    const SERVER_LIMIT: u32 = 200_000;
+    const SERVER_PROMPT: u32 = 180_000;
+
+    const UNQUOTED: Overflow = Overflow::Budget {
+        prompt: None,
+        limit: None,
+    };
+
+    #[test_case(
+        TURN_BUDGET,
+        Overflow::Budget { prompt: Some(SERVER_PROMPT), limit: Some(SERVER_LIMIT) },
+        Some(SERVER_LIMIT - SERVER_PROMPT)
+        ; "quoted_numbers_land_exactly"
+    )]
+    #[test_case(TURN_BUDGET, UNQUOTED, Some(TURN_BUDGET / 2) ; "otherwise_halve")]
+    // Our window is a fallback the provider overrides, so the subtraction
+    // comes out above what was just refused and says nothing.
+    #[test_case(
+        TURN_BUDGET,
+        Overflow::Budget { prompt: Some(SMALL_PROMPT), limit: None },
+        Some(TURN_BUDGET / 2)
+        ; "a_quote_that_cannot_be_the_real_arithmetic_falls_back_to_halving"
+    )]
+    // No budget is small enough, so the transcript is what has to give.
+    #[test_case(
+        TURN_BUDGET,
+        Overflow::Budget { prompt: Some(WINDOW), limit: None },
+        None
+        ; "a_full_window_cannot_be_fixed_by_shrinking"
+    )]
+    // Halving below the floor would trade the overflow for a 400 on the very
+    // same request, so the retrying stops here.
+    #[test_case(MIN_OUTPUT_TOKENS, UNQUOTED, None ; "the_floor_is_the_last_stop")]
+    #[test_case(TURN_BUDGET, Overflow::Prompt, None ; "a_prompt_overflow_is_not_ours_to_retry")]
+    fn shrinking_answers_what_the_server_said(
+        current: u32,
+        overflow: Overflow,
         expected: Option<u32>,
     ) {
         assert_eq!(
-            clamped_output_tokens(&model_with(max_output_tokens), prompt_tokens),
+            shrunk_budget(current, overflow, WINDOW, MIN_OUTPUT_TOKENS),
             expected
         );
     }
@@ -325,5 +563,136 @@ mod tests {
         let reported = error_description(&error);
         assert!(!reported.contains("private"));
         assert_eq!(reported, "API error (400)");
+    }
+
+    /// The kind of server this module exists for: it enforces
+    /// `prompt + max_tokens <= window` and counts the prompt with its own
+    /// tokenizer, which reads higher than maki's byte estimate. Any budget
+    /// derived from that estimate is too big by construction.
+    struct StrictServer {
+        window: u32,
+        requests: Mutex<Vec<u32>>,
+    }
+
+    impl Provider for StrictServer {
+        fn stream_message<'a>(
+            &'a self,
+            model: &'a Model,
+            messages: &'a [Message],
+            system: &'a str,
+            tools: &'a Value,
+            _: &'a flume::Sender<ProviderEvent>,
+            _: RequestOptions,
+            _: Option<&'a SessionRef>,
+        ) -> maki_providers::provider::BoxFuture<'a, Result<StreamResponse, AgentError>> {
+            Box::pin(async move {
+                let prompt = (estimate_prompt_tokens(messages, system, tools) as f32
+                    * UNDERCOUNT_FACTOR) as u32;
+                let asked = model.output_tokens().unwrap_or(0);
+                self.requests.lock().unwrap().push(asked);
+                if prompt + asked > self.window {
+                    return Err(AgentError::Api {
+                        status: 400,
+                        message: format!(
+                            "This model's maximum context length is {} tokens. However, you requested {} tokens ({prompt} in the messages, {asked} in the completion).",
+                            self.window,
+                            prompt + asked
+                        ),
+                    });
+                }
+                Ok(StreamResponse {
+                    message: Message::user("ok".into()),
+                    usage: TokenUsage {
+                        input: prompt,
+                        ..Default::default()
+                    },
+                    stop_reason: Some(maki_providers::StopReason::EndTurn),
+                })
+            })
+        }
+
+        fn list_models(
+            &self,
+        ) -> maki_providers::provider::BoxFuture<
+            '_,
+            Result<Vec<maki_providers::ModelInfo>, AgentError>,
+        > {
+            Box::pin(async { unimplemented!() })
+        }
+    }
+
+    const UNDERCOUNT_FACTOR: f32 = 1.25;
+    const TRANSCRIPT_BYTES: usize = 200_000;
+    const STRICT_WINDOW: u32 = 262_144;
+    /// Roomy enough for the transcript, too tight for the transcript plus a
+    /// whole turn budget.
+    const CROWDED_WINDOW: u32 = 80_000;
+
+    fn transcript() -> Vec<Message> {
+        vec![Message::user("x".repeat(TRANSCRIPT_BYTES))]
+    }
+
+    fn strict_model(window: u32) -> Model {
+        let mut model = model_with(Some(window));
+        model.context_window = window;
+        model
+    }
+
+    async fn send(
+        server: &StrictServer,
+        model: &Model,
+        gauge: &mut ContextGauge,
+    ) -> Result<StreamResponse, StreamError> {
+        let (tx, _rx) = flume::unbounded();
+        stream_with_retry(
+            StreamRequest {
+                provider: server,
+                model,
+                messages: &transcript(),
+                system: "",
+                tools: &json!([]),
+                opts: RequestOptions::default(),
+                output_budget: TURN_BUDGET,
+                session_id: None,
+            },
+            Some(gauge),
+            &EventSender::new(tx, 0),
+            &CancelToken::none(),
+        )
+        .await
+    }
+
+    #[test_case(STRICT_WINDOW, 1 ; "a_window_sized_cap_still_leaves_room_for_the_prompt")]
+    // A retry is cheap and compaction is not, so a budget that genuinely does
+    // not fit comes back smaller, with nothing summarized away to get there.
+    #[test_case(CROWDED_WINDOW, 2 ; "a_budget_that_does_not_fit_is_retried_smaller")]
+    fn a_strict_server_is_answered_without_dropping_context(window: u32, attempts: usize) {
+        smol::block_on(async {
+            let server = StrictServer {
+                window,
+                requests: Mutex::default(),
+            };
+            let mut gauge = ContextGauge::default();
+
+            let response = send(&server, &strict_model(window), &mut gauge)
+                .await
+                .expect("a flat budget leaves the window room for the prompt");
+
+            let asks = server.requests.lock().unwrap().clone();
+            assert_eq!(asks.len(), attempts, "asked for {asks:?}");
+            assert!(
+                asks[0] <= TURN_BUDGET,
+                "the first ask is a turn budget, not the window"
+            );
+            assert!(
+                asks.windows(2).all(|pair| pair[1] < pair[0]),
+                "every retry asks for less than the ask that was refused"
+            );
+            assert_eq!(
+                gauge.size(),
+                response.usage.input,
+                "the session keeps the server's count, not the estimate under it"
+            );
+        });
     }
 }

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use async_lock::Mutex;
 use maki_config::{ModelPolicy, ProjectConfig, SessionDefaults};
+use maki_providers::ContextGauge;
 use maki_providers::Message;
 use maki_providers::Timeouts;
 use maki_providers::TokenUsage;
@@ -64,9 +65,13 @@ impl SessionStore {
         }
     }
 
-    fn record_turn(&mut self, messages: &[Message], model_spec: String) {
+    /// `context_size` travels with the messages, since a resumed session seeds
+    /// its gauge from it: stored without one, the next process is back to
+    /// estimating a transcript this one had measured.
+    fn record_turn(&mut self, messages: &[Message], model_spec: String, context_size: u32) {
         self.session.replace_messages(messages.to_vec());
         self.session.set_model(model_spec);
+        self.session.meta.context_size = context_size;
         self.session.update_title_if_default();
         self.save();
     }
@@ -192,6 +197,7 @@ pub fn spawn(params: HeadlessParams) -> (HeadlessHandle, SessionEvents) {
             };
         let error_tx = event_tx.clone();
         let mut history = History::new(Vec::new());
+        let mut gauge = ContextGauge::default();
         let mut agent = Agent::new(
             AgentParams {
                 provider,
@@ -217,6 +223,7 @@ pub fn spawn(params: HeadlessParams) -> (HeadlessHandle, SessionEvents) {
                 model_policy: Arc::clone(&params.model_policy),
             },
             AgentRunParams {
+                gauge: &mut gauge,
                 history: &mut history,
                 system,
                 event_tx,
@@ -266,6 +273,10 @@ pub struct InteractiveParams {
     pub initial_wd: PathBuf,
     pub session_id: Option<SessionRef>,
     pub initial_history: Vec<Message>,
+    /// What the provider last counted for `initial_history`, zero for a
+    /// transcript nobody has sent yet. Seeds the gauge so a resumed session's
+    /// first request is budgeted against a measurement rather than a floor.
+    pub initial_context_size: u32,
     pub yolo: bool,
     pub system_prompt_override: Option<String>,
     pub append_system_prompt: Option<String>,
@@ -357,6 +368,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> (InteractiveHandle, Sessi
 
         let mut store = SessionStore::open(session_id, &working_dir, &model.spec());
         let mut history = History::restored(params.initial_history);
+        let mut gauge = ContextGauge::restored(params.initial_context_size);
         let mut run_id: u64 = 0;
 
         while let Ok(input) = input_rx.recv_async().await {
@@ -447,6 +459,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> (InteractiveHandle, Sessi
                     model_policy: Arc::clone(&params.model_policy),
                 },
                 AgentRunParams {
+                    gauge: &mut gauge,
                     history: &mut history,
                     system,
                     event_tx,
@@ -471,7 +484,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> (InteractiveHandle, Sessi
             }
 
             if let Some(store) = &mut store {
-                store.record_turn(history.as_slice(), model.spec());
+                store.record_turn(history.as_slice(), model.spec(), gauge.size());
             }
             run_id += 1;
         }
@@ -579,16 +592,22 @@ mod tests {
         assert!(loaded.messages().is_empty());
     }
 
+    const CONTEXT_SIZE: u32 = 42_000;
+
     #[test]
     fn record_turn_persists_messages_and_title() {
         let tmp = TempDir::new().unwrap();
         let mut store = store_in(&tmp);
         let messages = vec![Message::user("fix the login bug".into())];
-        store.record_turn(&messages, MODEL_SPEC.into());
+        store.record_turn(&messages, MODEL_SPEC.into(), CONTEXT_SIZE);
 
         let loaded = load(&tmp);
         assert_eq!(loaded.messages().len(), 1);
         assert_eq!(loaded.title, generate_title(&messages));
+        assert_eq!(
+            loaded.meta.context_size, CONTEXT_SIZE,
+            "a resumed session seeds its gauge from this, so it has to be stored"
+        );
     }
 
     #[test]
@@ -601,6 +620,7 @@ mod tests {
                 Message::observation("build failed".into()),
             ],
             MODEL_SPEC.into(),
+            CONTEXT_SIZE,
         );
 
         let loaded = load(&tmp);
@@ -612,7 +632,11 @@ mod tests {
     fn reopening_resumes_existing_session() {
         let tmp = TempDir::new().unwrap();
         let mut store = store_in(&tmp);
-        store.record_turn(&[Message::user("first prompt".into())], MODEL_SPEC.into());
+        store.record_turn(
+            &[Message::user("first prompt".into())],
+            MODEL_SPEC.into(),
+            CONTEXT_SIZE,
+        );
         drop(store);
 
         let mut store = store_in(&tmp);
@@ -622,7 +646,7 @@ mod tests {
             Message::user("first prompt".into()),
             Message::user("second prompt".into()),
         ];
-        store.record_turn(&messages, "other/model".into());
+        store.record_turn(&messages, "other/model".into(), CONTEXT_SIZE);
 
         let loaded = load(&tmp);
         assert_eq!(loaded.messages().len(), 2);

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -37,6 +37,14 @@ pub const MAX_SERVER_NAME_LEN: usize = 64;
 
 pub const DEFAULT_MAX_CONTINUATION_TURNS: u32 = 3;
 pub const DEFAULT_COMPACTION_BUFFER: CompactionBuffer = CompactionBuffer::Percent(20);
+/// What one turn asks to generate. A number of maki's own choosing rather than
+/// "whatever the window can spare", because the latter ties the output cap to a
+/// prompt estimate, and an estimate that reads low buys a rejection from every
+/// server enforcing `prompt + max_tokens <= context_window`.
+///
+/// An answer allowance, not a ceiling on the request: a turn asks for more
+/// where an effort level needs the room.
+pub const DEFAULT_MAX_TURN_OUTPUT: u32 = 32_768;
 
 pub const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 10;
 pub const DEFAULT_LOW_SPEED_TIMEOUT_SECS: u64 = 120;
@@ -50,6 +58,7 @@ pub const MIN_OUTPUT_BYTES: usize = 1024;
 pub const MIN_OUTPUT_LINES: usize = 10;
 pub const MIN_MAX_CONTINUATION_TURNS: u32 = 1;
 pub const MIN_COMPACTION_BUFFER: u32 = 1_000;
+pub const MIN_MAX_TURN_OUTPUT: u32 = 1_024;
 const MAX_COMPACTION_PERCENT: u8 = 99;
 const COMPACTION_BUFFER_EXPECTED: &str =
     r#"a token count (e.g. 12000) or a percent of the context window (e.g. "20%")"#;
@@ -642,6 +651,7 @@ pub struct AgentFileConfig {
     pub max_output_bytes: Option<usize>,
     pub max_output_lines: Option<usize>,
     pub max_continuation_turns: Option<u32>,
+    pub max_turn_output: Option<u32>,
     pub compaction_buffer: Option<CompactionBuffer>,
     pub compaction_instructions: Option<String>,
     pub post_compaction_instructions: Option<String>,
@@ -657,6 +667,7 @@ impl AgentFileConfig {
             max_output_bytes,
             max_output_lines,
             max_continuation_turns,
+            max_turn_output,
             compaction_buffer,
             compaction_instructions,
             post_compaction_instructions,
@@ -1255,6 +1266,9 @@ pub struct AgentConfig {
     #[config(default = DEFAULT_MAX_CONTINUATION_TURNS, min = MIN_MAX_CONTINUATION_TURNS, desc = "Max automatic continuation turns")]
     pub max_continuation_turns: u32,
 
+    #[config(default = DEFAULT_MAX_TURN_OUTPUT, min = MIN_MAX_TURN_OUTPUT, desc = "Output tokens one turn asks for, raised where an effort level needs the room and capped by the model's own limit")]
+    pub max_turn_output: u32,
+
     #[config(default = DEFAULT_COMPACTION_BUFFER, ty = "u32 | string", default_doc = "20%", desc = "Context reserved for compaction: token count or percent of the context window (e.g. \"20%\")")]
     pub compaction_buffer: CompactionBuffer,
 
@@ -1304,6 +1318,7 @@ impl AgentConfig {
             max_continuation_turns: file
                 .max_continuation_turns
                 .unwrap_or(DEFAULT_MAX_CONTINUATION_TURNS),
+            max_turn_output: file.max_turn_output.unwrap_or(DEFAULT_MAX_TURN_OUTPUT),
             compaction_buffer: file.compaction_buffer.unwrap_or(DEFAULT_COMPACTION_BUFFER),
             compaction_instructions: file.compaction_instructions,
             post_compaction_instructions: file.post_compaction_instructions,

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -26,7 +26,8 @@ use maki_lua_macro::{lua_class, lua_fn, lua_table};
 use maki_providers::model::ModelTier;
 use maki_providers::provider;
 use maki_providers::{
-    ContentBlock, Model, ModelError, RequestOptions, Role, ThinkingConfig, TokenUsage, add_cost,
+    ContentBlock, ContextGauge, Model, ModelError, RequestOptions, Role, ThinkingConfig,
+    TokenUsage, add_cost,
 };
 use maki_storage::id::MakiId;
 use maki_storage::sessions::StoredThinking;
@@ -636,6 +637,7 @@ async fn session(
             .filter(|_| mcp_enabled)
             .map(McpSession::fresh),
         history: History::new(Vec::new()),
+        gauge: ContextGauge::default(),
         sub_event_tx,
         stream_guard: Some(stream_guard),
         child_cancel,
@@ -754,6 +756,9 @@ struct SessionState {
     /// subagent and its parent.
     mcp: Option<McpSession>,
     history: History,
+    /// Travels with `history`: a subagent session spans many runs, and a gauge
+    /// rebuilt per run would forget every measurement it made.
+    gauge: ContextGauge,
     sub_event_tx: EventSender,
     /// Dropped on close, which ends the relay task. Tool contexts keep
     /// [`EventSender`] clones alive past the run, so the relay cannot key off
@@ -867,6 +872,7 @@ async fn prompt(
         s.params.clone(),
         AgentRunParams {
             history: &mut s.history,
+            gauge: &mut s.gauge,
             system: s.system.clone(),
             event_tx: s.sub_event_tx.clone(),
             tools: s.tools.clone(),

--- a/maki-providers/src/error.rs
+++ b/maki-providers/src/error.rs
@@ -9,6 +9,78 @@ use crate::providers::opencode::{self, NonLoginError};
 /// Request fields that cap the *output*. A 400 naming one of them is about the
 /// cap we sent, never about the prompt being too big.
 const OUTPUT_CAP_FIELDS: [&str; 3] = ["max_tokens", "max_completion_tokens", "max_output_tokens"];
+/// Markers of the OpenAI/vLLM shape, which quotes the two halves separately:
+/// `you requested 10000 tokens (6000 in the messages, 4000 in the completion)`.
+const MESSAGES_HALF: &str = " in the messages";
+const COMPLETION_HALF: &str = " in the completion";
+const OPENAI_LIMIT: &str = "maximum context length is ";
+
+/// Why a provider refused a request for size.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Overflow {
+    /// The transcript alone does not fit. Dropping context is the only way
+    /// through.
+    Prompt,
+    /// The transcript plus the output budget does not fit, though the
+    /// transcript by itself may well. Asking for less output costs nothing, so
+    /// this must never be answered by summarizing the transcript away.
+    ///
+    /// The fields are whatever the server quoted. A server that counts the
+    /// halves out loud also hands over an exact measurement of a prompt maki
+    /// could only estimate.
+    Budget {
+        prompt: Option<u32>,
+        limit: Option<u32>,
+    },
+}
+
+fn trailing_number(text: &str) -> Option<u32> {
+    let text = text.trim_end();
+    let start = text.len() - text.bytes().rev().take_while(u8::is_ascii_digit).count();
+    text[start..].parse().ok()
+}
+
+fn leading_number(text: &str) -> Option<u32> {
+    let text = text.trim_start();
+    let end = text.bytes().take_while(u8::is_ascii_digit).count();
+    text[..end].parse().ok()
+}
+
+/// Digits just before `marker`, e.g. the `6000` of `6000 in the messages`.
+fn number_before(text: &str, marker: &str) -> Option<u32> {
+    trailing_number(text.split_once(marker)?.0)
+}
+
+/// Digits just after `marker`, e.g. the `8192` of
+/// `maximum context length is 8192 tokens`.
+fn number_after(text: &str, marker: &str) -> Option<u32> {
+    leading_number(text.split_once(marker)?.1)
+}
+
+/// Anthropic reports the condition as arithmetic:
+/// ``input length and `max_tokens` exceed context limit: 199773 + 8192 > 200000``.
+/// All three numbers have to parse, or any prose with a `+` and a `>` would
+/// match.
+fn sum_over_limit(text: &str) -> Option<Overflow> {
+    let (head, limit) = text.split_once(" > ")?;
+    let (prompt, output) = head.rsplit_once(" + ")?;
+    leading_number(output)?;
+    Some(Overflow::Budget {
+        prompt: Some(trailing_number(prompt)?),
+        limit: Some(leading_number(limit)?),
+    })
+}
+
+fn budget_overflow(m: &str) -> Option<Overflow> {
+    sum_over_limit(m).or_else(|| {
+        // A zero-token completion half means the prompt alone is the problem,
+        // and no budget is small enough to fix that.
+        (number_before(m, COMPLETION_HALF)? > 0).then(|| Overflow::Budget {
+            prompt: number_before(m, MESSAGES_HALF),
+            limit: number_after(m, OPENAI_LIMIT),
+        })
+    })
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum AgentError {
@@ -54,11 +126,20 @@ impl AgentError {
         }
     }
 
-    /// Returns true if the error indicates a context window overflow.
+    /// Refused for size, either cause.
+    pub fn is_context_overflow(&self) -> bool {
+        self.overflow().is_some()
+    }
+
+    /// Why a provider refused the request for size, and what it said about the
+    /// numbers. The two causes have opposite remedies: one is fixed by asking
+    /// for less output, the other only by dropping context.
     ///
     /// Provider error formats:
     /// - Anthropic:  413 "prompt is too long"  <https://docs.anthropic.com/en/docs/errors>
+    /// - Anthropic:  400 "input length and `max_tokens` exceed context limit: A + B > C"
     /// - OpenAI:     400 "maximum context length is X tokens"  <https://platform.openai.com/docs/guides/error-codes>
+    /// - vLLM:       400 "... you requested N tokens (A in the messages, B in the completion)"
     /// - Gemini:     400 "input token count exceeds" / "too many tokens"  <https://ai.google.dev/gemini-api/docs/troubleshooting>
     /// - Ollama:     400 "context length exceeded"  <https://docs.ollama.com/api/errors>
     /// - llama.cpp:  400 "exceeds the available context size"  <https://github.com/ggml-org/llama.cpp/blob/master/tools/server/server-context.cpp>
@@ -67,37 +148,42 @@ impl AgentError {
     /// - Mistral:    400 "too large for model with X maximum context length"  <https://docs.mistral.ai/resources/known-limitations>
     /// - OpenRouter: 400 "endpoint's maximum context length is X tokens"  <https://openrouter.ai/docs/api/reference/errors-and-debugging.mdx>
     /// - Synthetic:  400 pass-through from upstream models (OpenAI-compatible)  <https://synthetic.new>
-    pub fn is_context_overflow(&self) -> bool {
-        match self {
-            Self::Api { status: 413, .. } => true,
-            Self::Api {
-                status: 400,
-                message,
-                ..
-            } => {
-                let m = message.to_lowercase();
-                // `Invalid 'max_tokens': integer above maximum value` reads as
-                // "token" plus "maximum" and would sail through the sniff
-                // below, but the caller answers an overflow by summarizing the
-                // whole session away, and no amount of that fixes a cap we
-                // guessed too high. Our own 100k default for unknown
-                // OpenAI-kind models is exactly how you hit this.
-                if OUTPUT_CAP_FIELDS.iter().any(|field| m.contains(field)) {
-                    return false;
-                }
-                let is_scope = m.contains("context")
-                    || m.contains("token")
-                    || m.contains("prompt")
-                    || m.contains("input");
-                let is_overflow = m.contains("exceeds")
-                    || m.contains("exceeded")
-                    || m.contains("too long")
-                    || m.contains("too many")
-                    || m.contains("maximum");
-                is_scope && is_overflow
-            }
-            _ => false,
+    pub fn overflow(&self) -> Option<Overflow> {
+        let Self::Api { status, message } = self else {
+            return None;
+        };
+        if !matches!(status, 400 | 413) {
+            return None;
         }
+        let m = message.to_lowercase();
+        // Before the output-cap guard below: servers that enforce
+        // `prompt + max_tokens <= window` name `max_tokens` while reporting a
+        // budget overflow, and reading that as "our cap was malformed" turns a
+        // one-field fix into an unrecoverable error.
+        if let Some(budget) = budget_overflow(&m) {
+            return Some(budget);
+        }
+        if *status == 413 {
+            return Some(Overflow::Prompt);
+        }
+        // `Invalid 'max_tokens': integer above maximum value` reads as "token"
+        // plus "maximum" and would sail through the sniff below. The caller
+        // answers a prompt overflow by summarizing the session away, and no
+        // amount of that fixes a cap we guessed too high. Our own 100k default
+        // for unknown OpenAI-kind models is how you hit this.
+        if OUTPUT_CAP_FIELDS.iter().any(|field| m.contains(field)) {
+            return None;
+        }
+        let is_scope = m.contains("context")
+            || m.contains("token")
+            || m.contains("prompt")
+            || m.contains("input");
+        let is_overflow = m.contains("exceeds")
+            || m.contains("exceeded")
+            || m.contains("too long")
+            || m.contains("too many")
+            || m.contains("maximum");
+        (is_scope && is_overflow).then_some(Overflow::Prompt)
     }
 
     pub fn is_auth_error(&self) -> bool {
@@ -355,6 +441,8 @@ mod tests {
     #[test_case(400, "Input is too long for requested model.", true                                                          ; "bedrock")]
     #[test_case(400, "Input is too long for the model", true                                              ; "too_long_input")]
     #[test_case(400, "Rate limit exceeded", false                                                         ; "not_context")]
+    // Arithmetic in unrelated prose must not read as a quoted budget overflow.
+    #[test_case(400, "Rate limit exceeded, 5 + 3 requests", false                                         ; "arithmetic_without_a_limit")]
     #[test_case(400, "Invalid API key", false                                                             ; "auth_error")]
     #[test_case(500, "Internal server error", false                                                       ; "server_error")]
     #[test_case(400, "The output is too long", false                                                      ; "output_not_context")]
@@ -371,5 +459,29 @@ mod tests {
         let err = api_msg(400, "request exceeds the available context size");
         assert!(err.is_context_overflow());
         assert!(!err.is_retryable());
+    }
+
+    const ANTHROPIC_BUDGET: &str = "input length and `max_tokens` exceed context limit: 199773 + 8192 > 200000, decrease input length or max_tokens and try again";
+    const VLLM_BUDGET: &str = "This model's maximum context length is 1048576 tokens. However, you requested 1051000 tokens (100000 in the messages, 951000 in the completion). Please reduce the length of the messages or completion.";
+    const VLLM_PROMPT_ONLY: &str = "This model's maximum context length is 8192 tokens. However, you requested 9000 tokens (9000 in the messages, 0 in the completion).";
+
+    /// These servers name `max_tokens` while reporting a budget overflow, which
+    /// the output-cap guard used to read as a malformed cap of our own and
+    /// report as unrecoverable.
+    #[test_case(
+        ANTHROPIC_BUDGET,
+        Overflow::Budget { prompt: Some(199_773), limit: Some(200_000) }
+        ; "anthropic_reports_the_sum"
+    )]
+    #[test_case(
+        VLLM_BUDGET,
+        Overflow::Budget { prompt: Some(100_000), limit: Some(1_048_576) }
+        ; "vllm_reports_the_halves"
+    )]
+    // No budget is small enough to fit a prompt that already overflows alone.
+    #[test_case(VLLM_PROMPT_ONLY, Overflow::Prompt ; "an_empty_completion_half_is_a_prompt_overflow")]
+    #[test_case("prompt is too long: 250000 tokens > 200000 maximum", Overflow::Prompt ; "anthropic_prompt_alone")]
+    fn overflow_kind_is_read_off_the_message(message: &str, expected: Overflow) {
+        assert_eq!(api_msg(400, message).overflow(), Some(expected));
     }
 }

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -7,9 +7,10 @@ pub mod pricing;
 pub mod provider;
 pub(crate) mod providers;
 pub mod retry;
+pub mod tokens;
 pub(crate) mod types;
 
-pub use error::AgentError;
+pub use error::{AgentError, Overflow};
 pub use maki_storage::sessions::add_cost;
 pub use model::{
     FastPricing, Model, ModelEntry, ModelError, ModelFamily, ModelInfo, ModelPricing, ModelTier,
@@ -26,6 +27,7 @@ pub use providers::copilot::auth as copilot_auth;
 pub use providers::dynamic;
 pub use providers::openai::auth as openai_auth;
 pub use providers::xai::auth as xai_auth;
+pub use tokens::{ContextGauge, estimate_message_tokens, estimate_prompt_tokens};
 pub use types::{
     ContentBlock, EMPTY_RESPONSE_MARKER, Effort, EffortDialect, IMAGE_EVICTED_NOTE,
     IMAGE_OMITTED_NOTE, IMAGE_PLACEHOLDER, IMAGE_UNUSABLE_NOTE, ImageMediaType, ImageSource,

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -342,8 +342,13 @@ pub struct Model {
     /// Discovery reported an explicit all-zero price. Distinct from a zero
     /// `pricing`, which also covers "no price is known".
     pub discovered_free: bool,
-    /// `None` when unknown, see [`ProviderKind::fallback_max_output`].
+    /// What the model declares it can generate, `None` when unknown (see
+    /// [`ProviderKind::fallback_max_output`]). Stays the same across requests,
+    /// because [`Self::max_thinking_budget`] scales effort levels off it.
     pub max_output_tokens: Option<u32>,
+    /// What this one request may generate, when a caller trimmed the cap to a
+    /// turn budget. `None` leaves the declared cap standing.
+    pub turn_output_tokens: Option<u32>,
     pub context_window: u32,
     pub thinking_fields: Option<Box<ThinkingFields>>,
 }
@@ -394,6 +399,7 @@ impl Model {
             pricing,
             discovered_free: discovered_pricing.is_some_and(ModelPricing::is_zero),
             max_output_tokens,
+            turn_output_tokens: None,
             context_window,
             thinking_fields: None,
         }
@@ -417,6 +423,7 @@ impl Model {
             pricing: meta.pricing.unwrap_or_default(),
             discovered_free: false,
             max_output_tokens: Some(max_output_tokens),
+            turn_output_tokens: None,
             context_window,
             thinking_fields: None,
         }
@@ -468,10 +475,30 @@ impl Model {
             .unwrap_or_else(|| self.family.supports_tool_examples())
     }
 
-    /// Half the output window, so the answer always has room after the
-    /// thinking. `None` when the window is unknown: callers must then let
+    /// The `max_tokens` this request should carry.
+    ///
+    /// The turn budget is clamped on read rather than where it is set, because
+    /// providers that resolve limits per request (catalog, opencode) rewrite
+    /// `max_output_tokens` on the way out, long after the budget was sized.
+    /// Doing it here means such a provider only has to report the cap it knows,
+    /// and cannot send a budget its endpoint never offered by forgetting to
+    /// re-apply the trim.
+    pub fn output_tokens(&self) -> Option<u32> {
+        [self.turn_output_tokens, self.max_output_tokens]
+            .into_iter()
+            .flatten()
+            .min()
+    }
+
+    /// Half the *declared* output window, which is what an effort level is a
+    /// percentage of. `None` when the window is unknown: callers must then let
     /// budgets through unclamped. Providers cap further only where the API
     /// documents a hard limit (currently just Google).
+    ///
+    /// Blind to the turn budget on purpose. A turn budget is what one request
+    /// may spend, not what the model can do, so resolving `high` against it
+    /// would redefine `high` rather than bound it. [`Self::thinking_ceiling`]
+    /// does the bounding.
     pub fn max_thinking_budget(&self) -> Option<u32> {
         self.max_output_tokens
             .map(|n| (n / 2).max(MIN_THINKING_BUDGET))
@@ -498,6 +525,23 @@ impl Model {
                 tokens: Some(level.budget(max)),
             }))
             .collect()
+    }
+
+    /// This model carrying one request's output budget, leaving the declared
+    /// cap to say what the model can do.
+    pub fn with_turn_output(&self, budget: u32) -> Self {
+        Self {
+            turn_output_tokens: Some(budget),
+            ..self.clone()
+        }
+    }
+
+    /// Ceiling for the thinking one *request* may ask for: half the
+    /// `max_tokens` it carries, so the answer always has room after the
+    /// thinking, and no dialect is handed a budget its own `max_tokens` refuses
+    /// (Anthropic 400s when the two meet).
+    pub fn thinking_ceiling(&self) -> Option<u32> {
+        self.output_tokens().map(|n| n / 2)
     }
 
     /// A model supports fast mode exactly when it carries fast-tier pricing, so
@@ -933,6 +977,31 @@ mod tests {
         let error = Model::from_spec_with_policy(spec, &policy).unwrap_err();
 
         assert!(matches!(error, ModelError::NotAllowed(disallowed) if disallowed == spec));
+    }
+
+    const SMALL_CAP: u32 = 8_192;
+    const TURN_BUDGET: u32 = 32_768;
+
+    /// Providers that resolve limits per request rewrite `max_output_tokens`
+    /// after the agent sized the turn, so a budget above the cap they report
+    /// must not survive to the wire.
+    #[test_case(Some(TURN_BUDGET), Some(SMALL_CAP), Some(SMALL_CAP) ; "a_lowered_cap_clamps_the_budget")]
+    #[test_case(Some(SMALL_CAP), Some(TURN_BUDGET), Some(SMALL_CAP) ; "a_trimmed_turn_is_what_the_request_carries")]
+    #[test_case(None, Some(SMALL_CAP), Some(SMALL_CAP) ; "an_untrimmed_turn_leaves_the_cap_standing")]
+    #[test_case(Some(TURN_BUDGET), None, Some(TURN_BUDGET) ; "an_undeclared_cap_keeps_the_budget")]
+    #[test_case(None, None, None ; "nothing_to_send")]
+    fn output_tokens_never_exceeds_the_declared_cap(
+        turn_output_tokens: Option<u32>,
+        max_output_tokens: Option<u32>,
+        expected: Option<u32>,
+    ) {
+        let model = Model {
+            turn_output_tokens,
+            max_output_tokens,
+            ..Model::from_spec("openai/gpt-5.6-sol").unwrap()
+        };
+
+        assert_eq!(model.output_tokens(), expected);
     }
 
     #[test]
@@ -1456,6 +1525,7 @@ mod tests {
             pricing: ModelPricing::default(),
             discovered_free: false,
             max_output_tokens,
+            turn_output_tokens: None,
             context_window: 200_000,
             thinking_fields: None,
         }

--- a/maki-providers/src/pricing.rs
+++ b/maki-providers/src/pricing.rs
@@ -239,6 +239,7 @@ mod tests {
             },
             discovered_free: false,
             max_output_tokens: None,
+            turn_output_tokens: None,
             context_window: 0,
             thinking_fields: None,
         }

--- a/maki-providers/src/providers/anthropic/shared.rs
+++ b/maki-providers/src/providers/anthropic/shared.rs
@@ -229,7 +229,7 @@ pub(crate) fn build_request_body_with_system(
     let wire_tools = build_wire_tools(tools);
 
     let mut body = json!({
-        "max_tokens": model.max_output_tokens.unwrap_or(FALLBACK_MAX_TOKENS),
+        "max_tokens": model.output_tokens().unwrap_or(FALLBACK_MAX_TOKENS),
         "system": system_blocks,
         "messages": wire_messages,
         "tools": wire_tools,

--- a/maki-providers/src/providers/catalog.rs
+++ b/maki-providers/src/providers/catalog.rs
@@ -852,6 +852,9 @@ impl Provider for CatalogProvider {
                 })?;
             let stream_model = Model {
                 id: model.id.clone(),
+                // The turn budget the agent set rides along in `..model`, and
+                // [`Model::output_tokens`] clamps it to this cap on read, so
+                // reporting what the endpoint accepts is all this has to do.
                 max_output_tokens: Some(meta.max_output()),
                 context_window: meta.context_window(),
                 ..model.clone()
@@ -1135,6 +1138,7 @@ mod tests {
             pricing: ModelPricing::default(),
             discovered_free: false,
             max_output_tokens: None,
+            turn_output_tokens: None,
             context_window: 0,
             thinking_fields: None,
         };

--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -648,7 +648,7 @@ impl Copilot {
         let auth = self.auth().await?;
         let mut body = json!({
             "model": model.id,
-            "max_tokens": model.max_output_tokens.unwrap_or(shared::FALLBACK_MAX_TOKENS),
+            "max_tokens": model.output_tokens().unwrap_or(shared::FALLBACK_MAX_TOKENS),
             "system": [{"type": "text", "text": system}],
             "messages": anthropic_messages(messages),
             "tools": tools,

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -154,6 +154,7 @@ fn model_from_def(def: &ProviderDef, kind: ProviderKind, slug: &str, model_id: &
         pricing,
         discovered_free: false,
         max_output_tokens,
+        turn_output_tokens: None,
         context_window,
         thinking_fields: None,
     }

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -104,6 +104,7 @@ impl ScriptModel {
             pricing: self.pricing.clone().unwrap_or_default(),
             discovered_free: false,
             max_output_tokens: Some(self.max_output_tokens),
+            turn_output_tokens: None,
             context_window: self.context_window,
             thinking_fields: self.thinking_fields.clone().map(Box::new),
         }

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -202,9 +202,9 @@ impl Google {
             body["systemInstruction"] = json!({"parts": [{"text": system}]});
         }
 
-        thinking.apply_google_thinking(&mut body, max_thinking(model));
+        thinking.apply_google_thinking(&mut body, model, max_thinking(model));
 
-        if let Some(max_output) = model.max_output_tokens {
+        if let Some(max_output) = model.output_tokens() {
             body["generationConfig"]["maxOutputTokens"] = json!(max_output);
         }
 
@@ -718,6 +718,7 @@ mod tests {
             pricing: ModelPricing::default(),
             discovered_free: false,
             max_output_tokens: Some(8192),
+            turn_output_tokens: None,
             context_window: 1_048_576,
             thinking_fields: None,
         }

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -128,7 +128,7 @@ impl OpenAiCompatProvider {
             "messages": wire_messages,
             "stream": true,
         });
-        if let Some(max_output) = model.max_output_tokens {
+        if let Some(max_output) = model.output_tokens() {
             body[self.config.max_tokens_field] = json!(max_output);
         }
         if self.config.include_stream_usage {

--- a/maki-providers/src/providers/opencode.rs
+++ b/maki-providers/src/providers/opencode.rs
@@ -148,6 +148,8 @@ impl Provider for Opencode {
 
             let stream_model = Model {
                 id: actual_id.to_string(),
+                // `..model` carries the agent's turn budget, which
+                // [`Model::output_tokens`] clamps to this cap on read.
                 max_output_tokens: Some(meta.max_output()),
                 context_window: meta.context_window(),
                 ..model.clone()

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -335,6 +335,7 @@ mod tests {
             pricing: ModelPricing::default(),
             discovered_free: false,
             max_output_tokens: Some(8192),
+            turn_output_tokens: None,
             context_window: 200_000,
             thinking_fields: None,
         };

--- a/maki-providers/src/providers/tensorx.rs
+++ b/maki-providers/src/providers/tensorx.rs
@@ -137,90 +137,7 @@ impl Provider for TensorX {
 
             let mut models: Vec<ModelInfo> = body["data"]
                 .as_array()
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|entry| {
-                            let id = entry["model_name"].as_str()?;
-                            let info = entry.get("model_info")?;
-
-                            // Only include models with mode "chat" or mode null
-                            let mode_ok = info
-                                .get("mode")
-                                .and_then(|v| v.as_str())
-                                .is_none_or(|m| m == "chat");
-                            if !mode_ok {
-                                return None;
-                            }
-
-                            // Context window: prefer max_tokens, fall back to max_input_tokens
-                            let context_window = info["max_tokens"]
-                                .as_u64()
-                                .or_else(|| info["max_input_tokens"].as_u64())
-                                .and_then(|v| u32::try_from(v).ok());
-
-                            // FIXME: API rejects requests if we request the maximum number of
-                            // output tokens. It checks input+max_output<=context_window
-                            // let max_output_tokens = info["max_output_tokens"]
-                            //     .as_u64()
-                            //     .and_then(|v| u32::try_from(v).ok());
-                            let max_output_tokens = None;
-
-                            // Convert per-token costs to per-million costs
-                            let input_cost = info["input_cost_per_token"].as_f64();
-                            let output_cost = info["output_cost_per_token"].as_f64();
-                            let pricing = if input_cost.is_some() || output_cost.is_some() {
-                                let per_million = 1_000_000.0;
-                                Some(ModelPricing {
-                                    input: input_cost.unwrap_or(0.0) * per_million,
-                                    output: output_cost.unwrap_or(0.0) * per_million,
-                                    cache_write: info["cache_creation_input_token_cost"]
-                                        .as_f64()
-                                        .unwrap_or(0.0)
-                                        * per_million,
-                                    cache_read: info["cache_read_input_token_cost"]
-                                        .as_f64()
-                                        .unwrap_or(0.0)
-                                        * per_million,
-                                    fast: None,
-                                })
-                            } else {
-                                None
-                            };
-
-                            let supports_vision = info
-                                .get("supports_vision")
-                                .and_then(Value::as_bool)
-                                .unwrap_or(false);
-
-                            let supports_thinking =
-                                info.get("supports_reasoning").and_then(Value::as_bool);
-
-                            let supported_params = info
-                                .get("supported_openai_params")
-                                .and_then(Value::as_array)
-                                .map(|params| TensorXModelInfo {
-                                    has_thinking: params
-                                        .iter()
-                                        .any(|v| v.as_str() == Some("thinking")),
-                                    has_reasoning_effort: params
-                                        .iter()
-                                        .any(|v| v.as_str() == Some("reasoning_effort")),
-                                });
-
-                            Some(ModelInfo {
-                                id: id.to_string(),
-                                context_window,
-                                max_output_tokens,
-                                pricing,
-                                supports_thinking,
-                                supports_vision: Some(supports_vision),
-                                tier: None,
-                                provider_info: supported_params
-                                    .map(|p| Arc::new(p) as Arc<dyn std::any::Any + Send + Sync>),
-                            })
-                        })
-                        .collect()
-                })
+                .map(|arr| arr.iter().filter_map(model_info).collect())
                 .unwrap_or_default();
             models.sort_by(|a, b| a.id.cmp(&b.id));
             Ok(models)
@@ -234,5 +151,122 @@ impl Provider for TensorX {
                 .as_ref()
                 .is_some_and(|p| p.rotate_bearer(&self.auth)))
         })
+    }
+}
+
+/// One entry of `/model/info`. `None` for anything that is not a chat model.
+fn model_info(entry: &Value) -> Option<ModelInfo> {
+    let id = entry["model_name"].as_str()?;
+    let info = entry.get("model_info")?;
+
+    let mode_ok = info
+        .get("mode")
+        .and_then(|v| v.as_str())
+        .is_none_or(|m| m == "chat");
+    if !mode_ok {
+        return None;
+    }
+
+    let context_window = info["max_tokens"]
+        .as_u64()
+        .or_else(|| info["max_input_tokens"].as_u64())
+        .and_then(|v| u32::try_from(v).ok());
+
+    // This endpoint enforces `input + max_output <= context_window`, which used
+    // to make reporting the real cap fatal: the agent asked for whatever the
+    // window had left, so any undercount of the prompt put the sum over. The
+    // ask is a flat turn budget now, clamped down to this number, so the cap is
+    // safe to report again.
+    let max_output_tokens = info["max_output_tokens"]
+        .as_u64()
+        .and_then(|v| u32::try_from(v).ok());
+
+    let input_cost = info["input_cost_per_token"].as_f64();
+    let output_cost = info["output_cost_per_token"].as_f64();
+    let pricing = if input_cost.is_some() || output_cost.is_some() {
+        let per_million = 1_000_000.0;
+        Some(ModelPricing {
+            input: input_cost.unwrap_or(0.0) * per_million,
+            output: output_cost.unwrap_or(0.0) * per_million,
+            cache_write: info["cache_creation_input_token_cost"]
+                .as_f64()
+                .unwrap_or(0.0)
+                * per_million,
+            cache_read: info["cache_read_input_token_cost"].as_f64().unwrap_or(0.0) * per_million,
+            fast: None,
+        })
+    } else {
+        None
+    };
+
+    let supports_vision = info
+        .get("supports_vision")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let supports_thinking = info.get("supports_reasoning").and_then(Value::as_bool);
+
+    let supported_params = info
+        .get("supported_openai_params")
+        .and_then(Value::as_array)
+        .map(|params| TensorXModelInfo {
+            has_thinking: params.iter().any(|v| v.as_str() == Some("thinking")),
+            has_reasoning_effort: params
+                .iter()
+                .any(|v| v.as_str() == Some("reasoning_effort")),
+        });
+
+    Some(ModelInfo {
+        id: id.to_string(),
+        context_window,
+        max_output_tokens,
+        pricing,
+        supports_thinking,
+        supports_vision: Some(supports_vision),
+        tier: None,
+        provider_info: supported_params
+            .map(|p| Arc::new(p) as Arc<dyn std::any::Any + Send + Sync>),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use test_case::test_case;
+
+    use super::*;
+
+    const WINDOW: u32 = 1_048_576;
+    const INPUT_WINDOW: u32 = 131_072;
+    const OUTPUT_CAP: u32 = 262_144;
+
+    fn entry(info: Value) -> Value {
+        json!({ "model_name": "kimi-k3", "model_info": info })
+    }
+
+    /// The output cap was hard-coded to `None` while reporting it was fatal,
+    /// which left the model picker and the thinking math with no number at all.
+    #[test_case(
+        json!({ "mode": "chat", "max_tokens": WINDOW, "max_input_tokens": INPUT_WINDOW, "max_output_tokens": OUTPUT_CAP }),
+        (Some(WINDOW), Some(OUTPUT_CAP))
+        ; "max_tokens_wins_over_max_input_tokens"
+    )]
+    #[test_case(
+        json!({ "max_input_tokens": INPUT_WINDOW }),
+        (Some(INPUT_WINDOW), None)
+        ; "an_unstated_window_falls_back_to_the_input_window"
+    )]
+    #[test_case(json!({}), (None, None) ; "nothing_stated_leaves_the_choice_to_the_provider")]
+    fn the_window_and_the_cap_are_read_off_the_entry(
+        info: Value,
+        expected: (Option<u32>, Option<u32>),
+    ) {
+        let model = model_info(&entry(info)).expect("a chat model is listed");
+        assert_eq!((model.context_window, model.max_output_tokens), expected);
+    }
+
+    #[test]
+    fn models_that_do_not_chat_are_skipped() {
+        assert!(model_info(&entry(json!({ "mode": "embedding" }))).is_none());
     }
 }

--- a/maki-providers/src/providers/xai/platform.rs
+++ b/maki-providers/src/providers/xai/platform.rs
@@ -308,6 +308,7 @@ mod tests {
             pricing: ModelPricing::ZERO,
             discovered_free: false,
             max_output_tokens: Some(131_072),
+            turn_output_tokens: None,
             context_window: 500_000,
             thinking_fields: None,
         }

--- a/maki-providers/src/tokens.rs
+++ b/maki-providers/src/tokens.rs
@@ -1,0 +1,228 @@
+//! Prompt size accounting.
+//!
+//! An estimate maki computes from message bytes, and the count the provider
+//! returns with a response. [`ContextGauge`] carries one session's running
+//! total, so a measurement is never re-derived from an estimate.
+
+use serde_json::Value;
+
+use crate::types::{ContentBlock, Message};
+
+const CHARS_PER_TOKEN: usize = 4;
+/// Flat per image, because all we have is the encoded blob, and its size
+/// tracks compression rather than the tile count the provider bills. A
+/// screenshot at the sizes [`crate::adapt_images_for_model`] allows lands near
+/// this. Counting nothing understated exactly the transcripts most likely to
+/// overflow.
+const TOKENS_PER_IMAGE: u32 = 1_500;
+
+/// Counts message content only. The system prompt and the tool schemas, a five
+/// figure baseline on a full tool set, are not in here, so this must never
+/// replace a context size the provider measured.
+pub fn estimate_message_tokens(messages: &[Message]) -> u32 {
+    if messages.is_empty() {
+        return 0;
+    }
+    let (total_bytes, images) =
+        messages
+            .iter()
+            .flat_map(|m| &m.content)
+            .fold((0usize, 0u32), |(bytes, images), block| match block {
+                ContentBlock::Text { text } => (bytes + text.len(), images),
+                ContentBlock::ToolResult { content, .. } => (bytes + content.len(), images),
+                ContentBlock::ToolUse { input, .. } => (bytes + json_len(input), images),
+                ContentBlock::Thinking { thinking, .. } => (bytes + thinking.len(), images),
+                ContentBlock::Image { .. } => (bytes, images + 1),
+                ContentBlock::RedactedThinking { .. } => (bytes, images),
+            });
+    (total_bytes.max(CHARS_PER_TOKEN) / CHARS_PER_TOKEN) as u32 + images * TOKENS_PER_IMAGE
+}
+
+/// [`estimate_message_tokens`] plus the system prompt and the serialized tool
+/// schemas, which a server checking `prompt + max_tokens <= context_window`
+/// counts too.
+pub fn estimate_prompt_tokens(messages: &[Message], system: &str, tools: &Value) -> u32 {
+    let overhead = (system.len() + json_len(tools)) / CHARS_PER_TOKEN;
+    estimate_message_tokens(messages).saturating_add(overhead as u32)
+}
+
+/// Serialized length without building the string, since this runs over the
+/// whole transcript and the tool catalog before every request.
+fn json_len(value: &Value) -> usize {
+    struct Counter(usize);
+    impl std::io::Write for Counter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0 += buf.len();
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    let mut counter = Counter(0);
+    match serde_json::to_writer(&mut counter, value) {
+        Ok(()) => counter.0,
+        Err(_) => 0,
+    }
+}
+
+/// The running prompt size of one session: the provider's own count for the
+/// last prompt it was sent, plus a byte estimate of everything appended since.
+///
+/// The two are held apart because only one of them can be wrong, and every
+/// response shrinks the guessed part back to nothing.
+///
+/// Lives as long as the transcript, which is longer than one agent run. A gauge
+/// rebuilt per user turn throws away every measurement the session ever made
+/// and is back to guessing.
+#[derive(Debug, Clone, Default)]
+pub struct ContextGauge {
+    measured: u32,
+    /// Byte estimate of the messages appended since that count.
+    appended: u32,
+}
+
+impl ContextGauge {
+    /// A session read back from disk was measured before it was stored, so it
+    /// starts from that count rather than from an estimate of its transcript.
+    pub fn restored(measured: u32) -> Self {
+        Self {
+            measured,
+            appended: 0,
+        }
+    }
+
+    pub fn size(&self) -> u32 {
+        self.measured.saturating_add(self.appended)
+    }
+
+    /// Ground truth for a prompt that was just sent, from a response or from a
+    /// rejection that quoted its own count. It covers every message that
+    /// request carried, so it replaces the total instead of adding to it.
+    ///
+    /// A zero measurement means the provider reported no usage (Z.AI streams
+    /// without it), not an empty prompt, so it overwrites nothing.
+    pub fn record(&mut self, measured: u32) {
+        if measured == 0 {
+            return;
+        }
+        self.measured = measured;
+        self.appended = 0;
+    }
+
+    /// Messages appended since the last measurement, estimated until the next
+    /// response measures them along with the rest.
+    pub fn append(&mut self, messages: &[Message]) {
+        self.appended = self
+            .appended
+            .saturating_add(estimate_message_tokens(messages));
+    }
+
+    /// Starts over from a transcript nobody has sent yet, as compaction leaves
+    /// behind. Whatever was measured describes messages that no longer exist.
+    pub fn reset(&mut self, messages: &[Message]) {
+        *self = Self::default();
+        self.append(messages);
+    }
+
+    /// A resumed session can already fill the window, and the gauge only learns
+    /// the real size from a response, so without this its first request goes
+    /// out unguarded.
+    pub fn seed_if_empty(&mut self, messages: &[Message], system: &str, tools: &Value) {
+        if self.size() == 0 {
+            self.appended = estimate_prompt_tokens(messages, system, tools);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::types::{ImageMediaType, ImageSource, Role};
+
+    const MEASURED: u32 = 10_000;
+    const TEXT_BYTES: usize = 4_000;
+    const TEXT_TOKENS: u32 = (TEXT_BYTES / CHARS_PER_TOKEN) as u32;
+
+    fn text_message(len: usize) -> Message {
+        Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text {
+                text: "x".repeat(len),
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_measurement_replaces_the_estimate_and_later_appends_stack_on_it() {
+        let mut gauge = ContextGauge::default();
+        gauge.append(&[text_message(TEXT_BYTES)]);
+        assert_eq!(gauge.size(), TEXT_TOKENS);
+
+        gauge.record(MEASURED);
+        assert_eq!(
+            gauge.size(),
+            MEASURED,
+            "the estimate the measurement covers is not counted twice"
+        );
+
+        gauge.record(0);
+        assert_eq!(
+            gauge.size(),
+            MEASURED,
+            "a provider that reports no usage overwrites nothing"
+        );
+
+        gauge.append(&[text_message(TEXT_BYTES)]);
+        assert_eq!(gauge.size(), MEASURED + TEXT_TOKENS);
+    }
+
+    /// The transcript compaction summarized away is gone, so the measurement
+    /// describing it cannot keep sizing the session.
+    #[test]
+    fn a_reset_drops_the_measurement_with_the_transcript() {
+        let mut gauge = ContextGauge::restored(MEASURED);
+        gauge.reset(&[text_message(TEXT_BYTES)]);
+        assert_eq!(gauge.size(), TEXT_TOKENS);
+    }
+
+    #[test]
+    fn seeding_only_fills_an_empty_gauge() {
+        let messages = [text_message(TEXT_BYTES)];
+        let mut gauge = ContextGauge::default();
+        gauge.seed_if_empty(&messages, "", &json!([]));
+        assert_eq!(gauge.size(), TEXT_TOKENS);
+
+        gauge.seed_if_empty(&[text_message(TEXT_BYTES * 10)], "", &json!([]));
+        assert_eq!(gauge.size(), TEXT_TOKENS, "a seeded gauge is not reseeded");
+    }
+
+    #[test]
+    fn the_prompt_estimate_covers_the_system_prompt_and_the_tool_schemas() {
+        let messages = [text_message(TEXT_BYTES)];
+        let system = "s".repeat(TEXT_BYTES);
+        assert!(
+            estimate_prompt_tokens(&messages, &system, &json!([{"name": "read"}]))
+                > estimate_message_tokens(&messages) + TEXT_TOKENS
+        );
+    }
+
+    #[test]
+    fn images_are_charged_even_though_their_bytes_are_not() {
+        let with_image = [Message {
+            role: Role::User,
+            content: vec![ContentBlock::Image {
+                source: ImageSource::new(ImageMediaType::Png, "".into()),
+            }],
+            ..Default::default()
+        }];
+        let empty_text = [text_message(0)];
+        assert_eq!(
+            estimate_message_tokens(&with_image) - estimate_message_tokens(&empty_text),
+            TOKENS_PER_IMAGE
+        );
+    }
+}

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -691,6 +691,40 @@ impl ThinkingConfig {
         !matches!(self, Self::Off)
     }
 
+    /// Thinking tokens this config asks for on `model` before any request-level
+    /// trim, or `None` when the provider decides (`Off`, `Adaptive`, or an
+    /// unknown output window). This is the number a caller sizing `max_tokens`
+    /// has to leave room for.
+    pub fn reserved_thinking(self, model: &Model) -> Option<u32> {
+        match self.budget(model.max_thinking_budget()) {
+            Budgeted::Tokens(n) => Some(n),
+            Budgeted::Off | Budgeted::Adaptive => None,
+        }
+    }
+
+    /// What [`Self::reserved_thinking`] comes out as once the `max_tokens` on
+    /// the wire has had its say.
+    pub fn request_thinking(self, model: &Model) -> Option<u32> {
+        let asked = self.reserved_thinking(model)?;
+        Some(model.thinking_ceiling().map_or(asked, |c| asked.min(c)))
+    }
+
+    /// The budget one request carries: the level the user picked resolved
+    /// against what the model declares (`declared`), then cut to what the
+    /// `max_tokens` on the wire can house.
+    ///
+    /// Resolve then cut, never resolve against the cut. An effort level is a
+    /// percentage, so handing it a trimmed ceiling redefines what the user
+    /// picked, and an explicit budget read back through [`Effort::from_budget`]
+    /// comes out as a *higher* level than it went in as. Cutting afterwards
+    /// lowers the thinking exactly as far as the window forces and no further.
+    fn request_budget(self, model: &Model, declared: Option<u32>) -> Budgeted {
+        match (self.budget(declared), model.thinking_ceiling()) {
+            (Budgeted::Tokens(asked), Some(ceiling)) => Budgeted::Tokens(asked.min(ceiling)),
+            (budgeted, _) => budgeted,
+        }
+    }
+
     /// The effort string to send, snapped to the dialect's supported levels
     /// here and nowhere else (never chain snaps). `None` means send nothing:
     /// `Off` without an explicit off string, or `Adaptive` on APIs with their
@@ -744,7 +778,7 @@ impl ThinkingConfig {
             }
             return;
         }
-        match self.budget(model.max_thinking_budget()) {
+        match self.request_budget(model, model.max_thinking_budget()) {
             Budgeted::Off => {}
             Budgeted::Adaptive => body["thinking"] = json!({"type": "adaptive"}),
             Budgeted::Tokens(n) => {
@@ -773,8 +807,10 @@ impl ThinkingConfig {
         }
     }
 
-    pub fn apply_google_thinking(self, body: &mut Value, max: u32) {
-        match self.budget(Some(max)) {
+    /// `max` is Google's own documented ceiling on thinking, which is a
+    /// capability and so part of resolving the level, not a trim.
+    pub fn apply_google_thinking(self, body: &mut Value, model: &Model, max: u32) {
+        match self.request_budget(model, Some(max)) {
             Budgeted::Off => {}
             Budgeted::Adaptive => {
                 body["generationConfig"]["thinkingConfig"] = json!({"includeThoughts": true});
@@ -792,14 +828,14 @@ impl ThinkingConfig {
             && let Some(object) = body.as_object_mut()
         {
             merge_body(object, fragment);
-            if keep_budget && let Budgeted::Tokens(budget) = self.budget(max) {
+            if keep_budget && let Budgeted::Tokens(budget) = self.request_budget(model, max) {
                 body[LOCAL_BUDGET_FIELD] = json!(budget);
             }
             return;
         }
         // No fragment means the model has no way to spell this mode, so the
         // budget field takes over: a request must never end up saying nothing.
-        let budget = match self.budget(max) {
+        let budget = match self.request_budget(model, max) {
             Budgeted::Off => 0,
             Budgeted::Adaptive => -1,
             Budgeted::Tokens(n) => i64::from(n),
@@ -1291,6 +1327,32 @@ mod tests {
         assert_eq!(body, expected);
     }
 
+    const TRIMMED_TURN: u32 = 8_192;
+    const REWRITTEN_CAP: u32 = 131_072;
+
+    /// Providers that resolve limits per request rewrite `max_output_tokens`
+    /// after the agent sized the turn (catalog, opencode). Cutting the budget
+    /// to what the `max_tokens` on the wire can house means no rewrite leaves a
+    /// request asking to think for longer than it may answer, which Anthropic
+    /// refuses outright and every other dialect answers with nothing but
+    /// thinking.
+    #[test_case(ThinkingConfig::Effort(Max) ; "the_top_effort_level")]
+    #[test_case(ThinkingConfig::Effort(Minimal) ; "the_lowest")]
+    #[test_case(ThinkingConfig::Budget(LARGE_BUDGET) ; "an_explicit_budget")]
+    fn a_provider_that_rewrites_the_output_cap_cannot_unbound_the_thinking(config: ThinkingConfig) {
+        let model = crate::model::Model {
+            turn_output_tokens: Some(TRIMMED_TURN),
+            max_output_tokens: Some(REWRITTEN_CAP),
+            ..thinking_model("claude-sonnet-4-20250514")
+        };
+        let budget = config.request_thinking(&model).expect("a budget is sent");
+
+        assert!(
+            budget * 2 <= TRIMMED_TURN,
+            "{budget} thinking tokens under a {TRIMMED_TURN} token cap"
+        );
+    }
+
     #[test_case(&dialect::STANDARD, ThinkingConfig::Off,             None            ; "standard_off_noop")]
     #[test_case(&dialect::STANDARD, ThinkingConfig::Adaptive,        Some("medium")  ; "standard_adaptive")]
     #[test_case(&dialect::STANDARD, ThinkingConfig::Effort(Minimal), Some("minimal") ; "standard_minimal_passthrough")]
@@ -1372,13 +1434,30 @@ mod tests {
         assert_eq!(child.clamp_to(parent), expected);
     }
 
-    #[test_case(ThinkingConfig::Off,          json!({})                                                                  ; "off")]
-    #[test_case(ThinkingConfig::Adaptive,     json!({"generationConfig": {"thinkingConfig": {"includeThoughts": true}}}) ; "adaptive")]
-    #[test_case(ThinkingConfig::Budget(4096), json!({"generationConfig": {"thinkingConfig": {"thinkingBudget": 4096}}}) ; "budget")]
-    #[test_case(ThinkingConfig::Budget(10000), json!({"generationConfig": {"thinkingConfig": {"thinkingBudget": 8192}}}) ; "budget_clamped")]
-    fn thinking_apply_google_thinking(config: ThinkingConfig, expected: Value) {
+    /// Google's own documented ceiling on thinking, which is a capability and
+    /// so part of resolving the level.
+    const GOOGLE_CAP: u32 = 8192;
+    /// Roomy enough that the request ceiling is not what binds.
+    const ROOMY_OUTPUT: Option<u32> = Some(65_536);
+
+    #[test_case(ThinkingConfig::Off, ROOMY_OUTPUT, json!({})                                                                  ; "off")]
+    #[test_case(ThinkingConfig::Adaptive, ROOMY_OUTPUT, json!({"generationConfig": {"thinkingConfig": {"includeThoughts": true}}}) ; "adaptive")]
+    #[test_case(ThinkingConfig::Budget(4096), ROOMY_OUTPUT, json!({"generationConfig": {"thinkingConfig": {"thinkingBudget": 4096}}}) ; "budget")]
+    #[test_case(ThinkingConfig::Budget(10000), ROOMY_OUTPUT, json!({"generationConfig": {"thinkingConfig": {"thinkingBudget": 8192}}}) ; "budget_clamped_to_googles_cap")]
+    // Half the `maxOutputTokens` the same request carries, or the answer has
+    // nowhere to land.
+    #[test_case(ThinkingConfig::Budget(10000), Some(GOOGLE_CAP), json!({"generationConfig": {"thinkingConfig": {"thinkingBudget": 4096}}}) ; "budget_cut_to_what_the_request_can_house")]
+    fn thinking_apply_google_thinking(
+        config: ThinkingConfig,
+        max_output_tokens: Option<u32>,
+        expected: Value,
+    ) {
         let mut body = json!({});
-        config.apply_google_thinking(&mut body, 8192);
+        let model = crate::model::Model {
+            max_output_tokens,
+            ..thinking_model("gemini-2.5-pro")
+        };
+        config.apply_google_thinking(&mut body, &model, GOOGLE_CAP);
         assert_eq!(body, expected);
     }
 
@@ -1476,6 +1555,7 @@ mod tests {
             pricing: crate::model::ModelPricing::default(),
             discovered_free: false,
             max_output_tokens: Some(8192),
+            turn_output_tokens: None,
             context_window: 200_000,
             thinking_fields: None,
         }

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -15,7 +15,7 @@ use maki_agent::{
 };
 use maki_config::ModelPolicy;
 use maki_lua::EventHandle;
-use maki_providers::{AgentError, Message, Model};
+use maki_providers::{AgentError, ContextGauge, Message, Model};
 use maki_storage::id::SessionRef;
 use tracing::error;
 
@@ -32,6 +32,9 @@ pub(super) struct AgentLoop {
     tools: RequestTools,
     mcp: Option<McpSession>,
     history: History,
+    /// Owned beside `history` because it describes that transcript and outlives
+    /// every run over it, so the provider's own counts pile up between turns.
+    gauge: ContextGauge,
     btw_system: Arc<ArcSwap<String>>,
     cancel_map: Arc<RunCancelMap>,
     init_cancel: CancelToken,
@@ -56,6 +59,7 @@ impl AgentLoop {
         config: AgentConfig,
         tool_output_lines: ToolOutputLines,
         initial_history: Vec<Message>,
+        initial_context_size: u32,
         shared_history: SharedMessages,
         btw_system: Arc<ArcSwap<String>>,
         mcp_handle: Option<McpHandle>,
@@ -82,6 +86,7 @@ impl AgentLoop {
             tools: RequestTools::default(),
             mcp,
             history: History::restored(initial_history).with_mirror(shared_history),
+            gauge: ContextGauge::restored(initial_context_size),
             btw_system,
             cancel_map,
             init_cancel,
@@ -192,6 +197,7 @@ impl AgentLoop {
             &*provider,
             &model,
             &mut self.history,
+            &mut self.gauge,
             event_tx,
             &self.config,
             instructions,
@@ -278,6 +284,7 @@ impl AgentLoop {
             },
             AgentRunParams {
                 history: &mut self.history,
+                gauge: &mut self.gauge,
                 system,
                 event_tx,
                 tools: self.tools.clone(),

--- a/maki-ui/src/agent/mod.rs
+++ b/maki-ui/src/agent/mod.rs
@@ -67,6 +67,7 @@ impl AgentHandles {
     pub(crate) fn spawn(
         model_slot: &Arc<ArcSwap<ModelSlot>>,
         initial_history: Vec<Message>,
+        initial_context_size: u32,
         config: AgentConfig,
         tool_output_lines: ToolOutputLines,
         permissions: &Arc<PermissionManager>,
@@ -81,6 +82,7 @@ impl AgentHandles {
             flume::unbounded(),
             model_slot,
             initial_history,
+            initial_context_size,
             config,
             tool_output_lines,
             permissions,
@@ -154,6 +156,9 @@ impl AgentHandles {
             (self.agent_tx.clone(), self.agent_rx.clone()),
             model_slot,
             history,
+            // A respawn carries the app's last reported count across, so the
+            // next request is not left guessing at its own prompt.
+            app.state.context_size,
             config,
             tool_output_lines,
             permissions,
@@ -216,6 +221,7 @@ fn spawn_agent_internal(
     (agent_tx, agent_rx): (flume::Sender<Envelope>, flume::Receiver<Envelope>),
     model_slot: &Arc<ArcSwap<ModelSlot>>,
     initial_history: Vec<Message>,
+    initial_context_size: u32,
     config: AgentConfig,
     tool_output_lines: ToolOutputLines,
     permissions: &Arc<PermissionManager>,
@@ -253,6 +259,7 @@ fn spawn_agent_internal(
         config,
         tool_output_lines,
         initial_history,
+        initial_context_size,
         Arc::clone(&shared_history),
         Arc::clone(&btw_system),
         mcp_handle.clone(),
@@ -356,6 +363,7 @@ mod tests {
         let handles = AgentHandles::spawn(
             &model_slot,
             initial_history,
+            0,
             AgentConfig::default(),
             ToolOutputLines::default(),
             &permissions,

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -1247,15 +1247,23 @@ impl App {
                 .session_mut()
                 .add_model_usage(&tc.model, tc.usage.billed(tc.cost));
             let ctx_size = tc.context_size.unwrap_or_else(|| tc.usage.context_tokens());
-            self.chats[chat_idx].context_size = ctx_size;
-            if chat_idx == 0 {
-                self.state.context_size = ctx_size;
-            }
+            self.set_context_size(chat_idx, ctx_size);
             self.chats[chat_idx].set_pending_turn_usage(tc.usage.format(tc.cost));
             if let Some(tool_id) = &subagent_id {
                 let formatted = tc.usage.format_sum_cost(self.chats[chat_idx].cost);
                 self.chats[0].set_tool_turn_usage(tool_id, formatted);
             }
+        }
+
+        // Compaction is the one thing that lowers the context size with no turn
+        // behind it. The number is stored in the session meta and seeds the
+        // next run's gauge, so left stale a session compacted just before exit
+        // gets compacted again on resume.
+        if let AgentEvent::CompactionDone {
+            context_size_after, ..
+        } = envelope.event
+        {
+            self.set_context_size(chat_idx, context_size_after);
         }
 
         let plan_path = if self.state.mode == Mode::Plan {
@@ -1329,6 +1337,15 @@ impl App {
             }
         }
         vec![]
+    }
+
+    /// Chat 0 is the session itself, and its size is the one stored in the
+    /// session meta.
+    fn set_context_size(&mut self, chat_idx: usize, size: u32) {
+        self.chats[chat_idx].context_size = size;
+        if chat_idx == 0 {
+            self.state.context_size = size;
+        }
     }
 
     fn resolve_or_create_chat(&mut self, subagent: &SubagentInfo) -> usize {

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -6,9 +6,8 @@ use crate::app::tasks::TaskOutcome;
 use crate::chat::{Chat, DONE_TEXT, history_to_display};
 use crate::components::rewind_picker::RewindEntry;
 use crate::components::{Action, LoadedSession};
-use maki_agent::agent::estimate_message_tokens;
 use maki_lua::SessionEndReason;
-use maki_providers::{Model, RequestOptions, TokenUsage};
+use maki_providers::{Model, RequestOptions, TokenUsage, estimate_message_tokens};
 use maki_storage::id::MakiId;
 use maki_storage::sessions::{SessionMeta, StoredSubagent};
 

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -3083,6 +3083,26 @@ fn rewind_recomputes_context_size(measured: u32, floor: u32) {
     assert_eq!(app.chats[0].context_size, size);
 }
 
+/// Left at the pre-compaction value, a session compacted just before exit
+/// compacts itself again on resume.
+#[test]
+fn compaction_lowers_the_stored_context_size() {
+    const AFTER: u32 = SMALL_HISTORY;
+    let mut app = test_app();
+    app.run_id = 1;
+    app.state.context_size = MEASURED_CONTEXT;
+    app.chats[0].context_size = MEASURED_CONTEXT;
+
+    app.update(agent_msg(AgentEvent::CompactionDone {
+        context_size_before: MEASURED_CONTEXT,
+        context_size_after: AFTER,
+        context_window: 0,
+    }));
+
+    assert_eq!(app.state.context_size, AFTER);
+    assert_eq!(app.chats[0].context_size, AFTER);
+}
+
 #[test]
 fn rewind_to_first_turn_clears_everything() {
     let mut app = build_rewind_app();

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -421,6 +421,7 @@ pub(crate) fn test_model() -> maki_providers::Model {
         pricing: test_pricing(),
         discovered_free: false,
         max_output_tokens: Some(8192),
+        turn_output_tokens: None,
         context_window: TEST_CONTEXT_WINDOW,
         thinking_fields: None,
     }

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -394,6 +394,7 @@ impl SpawnCtx {
         let handles = AgentHandles::spawn(
             &self.model_slot,
             session.messages().to_vec(),
+            session.meta.context_size,
             self.config.clone(),
             self.ui_config.tool_output_lines,
             &permissions,

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -122,6 +122,7 @@ How many lines of output to show per tool in the UI. All values are `usize` with
 | `max_output_bytes` | usize | `51200` | 1024 | Max tool output size (bytes) |
 | `max_output_lines` | usize | `2000` | 10 | Max tool output lines |
 | `max_continuation_turns` | u32 | `3` | 1 | Max automatic continuation turns |
+| `max_turn_output` | u32 | `32768` | 1024 | Output tokens one turn asks for, raised where an effort level needs the room and capped by the model's own limit |
 | `compaction_buffer` | u32 \| string | `20%` | - | Context reserved for compaction: token count or percent of the context window (e.g. "20%") |
 | `compaction_instructions` | String | `none` | - | Extra instructions appended to the compaction summary prompt |
 | `post_compaction_instructions` | String | `none` | - | Extra instructions the agent receives after any compaction (e.g. re-read plan.md) |

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -546,7 +546,7 @@ pub fn run(params: SdkParams) -> Result<()> {
 
     let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());
     let working_dir = cwd.to_string_lossy().into_owned();
-    let (session_id, initial_history) = resolve_session(&cli, &working_dir)?;
+    let (session_id, initial_history, initial_context_size) = resolve_session(&cli, &working_dir)?;
     crate::setup::report_session_start(
         if initial_history.is_empty() {
             maki_otel::emit::START_FRESH
@@ -574,6 +574,7 @@ pub fn run(params: SdkParams) -> Result<()> {
         initial_wd: cwd.clone(),
         session_id,
         initial_history,
+        initial_context_size,
         yolo: permission_mode == PermissionMode::BypassPermissions,
         system_prompt_override: cli.system_prompt.clone().filter(|s| !s.is_empty()),
         append_system_prompt: cli.append_system_prompt.clone().filter(|s| !s.is_empty()),
@@ -761,25 +762,30 @@ pub fn run(params: SdkParams) -> Result<()> {
 
 type StoredSession = Session<Message, TokenUsage, ToolOutput>;
 
-fn resolve_session(cli: &Cli, cwd: &str) -> Result<(Option<SessionRef>, Vec<Message>)> {
-    let (resumed_id, history) = if let Some(id) = &cli.session {
+/// Also returns the provider's last prompt count for the restored history, so
+/// the resumed session's first request is budgeted from a measurement.
+fn resolve_session(cli: &Cli, cwd: &str) -> Result<(Option<SessionRef>, Vec<Message>, u32)> {
+    let (resumed_id, session) = if let Some(id) = &cli.session {
         let storage = StateDir::resolve().context("resolve state dir")?;
         let session_ref: SessionRef = id
             .parse()
             .map_err(|e| eyre!("invalid session id {id}: {e}"))?;
         let session = StoredSession::load(session_ref.id(), &storage)
             .map_err(|e| eyre!("load session {id}: {e}"))?;
-        let resumed = (!cli.fork_session).then_some(session_ref);
-        (resumed, session.take_messages())
+        ((!cli.fork_session).then_some(session_ref), Some(session))
     } else if cli.continue_session {
         let storage = StateDir::resolve().context("resolve state dir")?;
         match StoredSession::latest(cwd, &storage) {
-            Ok(Some(session)) => (Some(SessionRef::from(session.id)), session.take_messages()),
-            _ => (None, Vec::new()),
+            Ok(Some(session)) => (Some(SessionRef::from(session.id)), Some(session)),
+            _ => (None, None),
         }
     } else {
-        (None, Vec::new())
+        (None, None)
     };
+    let context_size = session.as_ref().map_or(0, |s| s.meta.context_size);
+    let history = session
+        .map(StoredSession::take_messages)
+        .unwrap_or_default();
 
     let cli_session_id = cli.session_id.as_deref().map(|s| {
         s.parse::<SessionRef>()
@@ -791,7 +797,7 @@ fn resolve_session(cli: &Cli, cwd: &str) -> Result<(Option<SessionRef>, Vec<Mess
         None => None,
     };
 
-    Ok((cli_session_id.or(resumed_id), history))
+    Ok((cli_session_id.or(resumed_id), history, context_size))
 }
 
 fn parse_or_warn<T: serde::de::DeserializeOwned>(payload: Value, what: &str) -> Option<T> {


### PR DESCRIPTION
Every request asked for whatever the window had left after a chars/4 guess at the prompt, so on a server that checks `prompt + max_tokens <= context_window` any undercount made the request malformed, and maki read the rejection as a full transcript and compacted, throwing away context to fix a number in a header.

A turn now asks for a flat `agent.max_turn_output`, 32k clamped to the model cap and raised where an effort level needs the room, so no estimate error can put the sum over, and `tensorx` can report its real output cap again instead of hiding it behind a `FIXME`.

`max_output_tokens` stays what the model declared so effort levels keep resolving against it, while `turn_output_tokens` carries the trim and is clamped inside `Model::output_tokens`, so providers that rewrite limits per request only have to report their own cap.

`ContextGauge` now holds the provider's own count beside an estimate of what came after it and lives next to the transcript instead of being rebuilt every run, so the compaction threshold stops drifting on long sessions.

`AgentError::overflow` tells a prompt that does not fit from a budget that does not fit, and the second is retried smaller off the counts the server quotes, so compaction is the last resort rather than the first.