### PR TITLE
fix(highlight): stop a JavaScript line from pinning a core forever

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5290,8 +5290,7 @@ dependencies = [
 [[package]]
 name = "syntect"
 version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+source = "git+https://github.com/tontinton/syntect?rev=01df275f6f25da670e5ba5b7128cb89d03795119#01df275f6f25da670e5ba5b7128cb89d03795119"
 dependencies = [
  "bincode",
  "fancy-regex 0.16.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,5 +219,11 @@ debug = false
 # multiline paste submits at the first newline (#336). Pinned to the head of
 # crossterm-rs/crossterm#1030, which lives in refs/pull/1030/head on the upstream repo.
 # Remove once the PR ships in a crossterm release.
+#
+# syntect 5.3.0 spins forever on a JavaScript line like `x /*`: two rules match
+# empty at the same byte and `set` each other back, which is neither the push nor
+# the pop its loop guard watches, so one such line pins a core at 100% for good.
+# Pinned to a v5.3.0 backport of trishume/syntect#706, remove once that ships.
 [patch.crates-io]
 crossterm = { git = "https://github.com/crossterm-rs/crossterm", rev = "3ca54292d2b1f1c58e200a06122ddaf5dd6b5c77" }
+syntect = { git = "https://github.com/tontinton/syntect", rev = "01df275f6f25da670e5ba5b7128cb89d03795119" }

--- a/flake.nix
+++ b/flake.nix
@@ -91,6 +91,8 @@
           "sha256-P4PgqfYykkZrWGg5G3WQo070lORLEhmXQUQPx3+Yslo=";
         "git+https://github.com/crossterm-rs/crossterm?rev=3ca54292d2b1f1c58e200a06122ddaf5dd6b5c77#3ca54292d2b1f1c58e200a06122ddaf5dd6b5c77" =
           "sha256-A5lgiEEi7mktf7m2GljdAxst7Fdl7Uqko29Xq6o90Ow=";
+        "git+https://github.com/tontinton/syntect?rev=01df275f6f25da670e5ba5b7128cb89d03795119#01df275f6f25da670e5ba5b7128cb89d03795119" =
+          "sha256-ZszhXL+Bd0zZGOfOodvP4z6dLD3jJr3pO07riwFUC70=";
       };
 
       missingGitDepHashes = builtins.filter (s: !(builtins.hasAttr s gitDepHashes)) gitDepSources;


### PR DESCRIPTION
Opening a session sent a core to 100% and kept it there until maki was killed, and nothing in the transcript looked unusual.

The thread named `highlight` was stuck inside a single `ParseState::parse_line` call on a 20 line JavaScript snippet, and the minimal case turned out to be `x /*`: two rules in the JavaScript syntax `bat` ships both match empty at the byte after the identifier and `set` each other's context back, forever, because syntect's loop guard only watches a push followed by a pop, and a `set` is neither.

Flat memory the whole time, so it is a real cycle rather than backtracking, and the queue in `maki-highlight/src/pool.rs` is a single thread with no deadline, so that one line also starved every highlight job that came after it.

Pins syntect to a `v5.3.0` backport of trishume/syntect#706, which remembers the `(byte, context stack)` a non-consuming `set` was taken from and advances a character on the second visit, exactly what the push/pop guard already does; both syntest baselines are unchanged upstream.